### PR TITLE
feat/replace-mbdetls-by-openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Chuchu is in active development. I am daily driving it and improving any issues 
 - Kotlin + Jetpack Compose for the Android app
 - Zig for native build orchestration and JNI/native bridge code
 - Ghostty VT for terminal emulation
-- `libssh2` + `mbedtls` for the current native SSH path
+- `libssh2` + `openssl` for the current native SSH path
 - Room for local data storage
 
 ## Project Layout
@@ -98,5 +98,4 @@ chuchu is one of my favorite characters from the amharic book [Yesinbit Kelemat]
 <p align="center">
   <img src="./assets/chuchu_demo.gif" alt="Chuchu demo" width="400" />
 </p>
-
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -351,13 +351,6 @@ fun TerminalScreen(
                             if (pwdText != null) {
                                 ChuText(text = pwdText, style = typography.labelSmall, color = colors.textPrimary.copy(alpha = 0.7f))
                             }
-                            ChuButton(
-                                onClick = { showSettings = true },
-                                variant = ChuButtonVariant.Ghost,
-                                contentPadding = PaddingValues(4.dp),
-                            ) {
-                                ChuText("⚙", style = typography.label, color = colors.textMuted)
-                            }
                         }
 
                         if (hasSelectionActive) {
@@ -445,7 +438,7 @@ fun TerminalScreen(
                         items = accessoryLayout,
                         modifierState = modifierState,
                         onAction = ::dispatchAccessoryAction,
-                        nativeVersion = sessionState.nativeVersion,
+                        onSettings = { showSettings = true },
                         modifier = Modifier.padding(bottom = 2.dp),
                     )
                 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -25,7 +23,7 @@ fun KeyboardAccessoryBar(
     items: List<AccessoryKeyItem>,
     modifierState: ModifierState,
     onAction: (AccessoryAction) -> Unit,
-    nativeVersion: String? = null,
+    onSettings: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val buttonHeight = 30.dp
@@ -62,15 +60,16 @@ fun KeyboardAccessoryBar(
             }
         }
 
-        if (nativeVersion != null) {
-            Spacer(modifier = Modifier.size(4.dp))
-            ChuText(
-                text = nativeVersion,
-                style = typography.labelSmall,
-                color = ChuColors.current.textMuted,
-            )
+        if (onSettings != null) {
+            ChuButton(
+                onClick = onSettings,
+                variant = ChuButtonVariant.Outlined,
+                modifier = Modifier.height(buttonHeight),
+                contentPadding = buttonPadding,
+            ) {
+                ChuText("⚙", style = typography.label)
+            }
         }
-
     }
 }
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -60,6 +60,7 @@ fun TerminalCanvas(
     val density = LocalDensity.current
     val fontSizePx = with(density) { fontSizeSp.sp.toPx() }
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+    var lastResizedGrid by remember { mutableStateOf(Pair(0, 0)) }
     var selection by remember { mutableStateOf<TerminalSelection?>(null) }
     var selectionAnchorOffset by remember { mutableStateOf(Offset.Zero) }
     val doubleTapState = remember { DoubleTapState() }
@@ -138,7 +139,11 @@ fun TerminalCanvas(
         if (canvasSize.width <= 0 || canvasSize.height <= 0) return@LaunchedEffect
         val cols = max(1, floor(canvasSize.width / cellWidthPx).toInt())
         val rows = max(1, floor(canvasSize.height / cellHeightPx).toInt())
-        onResize(cols, rows, cellWidthInt, cellHeightInt, canvasSize.width, canvasSize.height)
+        val grid = Pair(cols, rows)
+        if (grid != lastResizedGrid) {
+            lastResizedGrid = grid
+            onResize(cols, rows, cellWidthInt, cellHeightInt, canvasSize.width, canvasSize.height)
+        }
     }
 
     Canvas(

--- a/devshell.nix
+++ b/devshell.nix
@@ -14,6 +14,10 @@ with pkgs;
         value = "${android-sdk}/share/android-sdk";
       }
       {
+        name = "ANDROID_NDK_HOME";
+        value = "${android-sdk}/share/android-sdk";
+      }
+      {
         name = "ANDROID_SDK_ROOT";
         value = "${android-sdk}/share/android-sdk";
       }

--- a/devshell.nix
+++ b/devshell.nix
@@ -15,7 +15,7 @@ with pkgs;
       }
       {
         name = "ANDROID_NDK_HOME";
-        value = "${android-sdk}/share/android-sdk";
+        value = "${android-sdk}/share/android-sdk/ndk/29.0.13113456";
       }
       {
         name = "ANDROID_SDK_ROOT";

--- a/zig-src/build.zig
+++ b/zig-src/build.zig
@@ -88,7 +88,7 @@ fn buildNativeLibrary(
     const include_dir = b.pathJoin(&.{ ndk_sysroot, "usr", "include" });
     const target_include_dir = b.pathJoin(&.{ include_dir, android_target });
 
-    // Build libssh2 (which also builds mbedtls as a sub-dependency)
+    // Build libssh2 (configured to use openssl-zig)
     const libssh2_dep = b.dependency("libssh2", .{
         .target = target,
         .optimize = optimize,

--- a/zig-src/build.zig
+++ b/zig-src/build.zig
@@ -167,6 +167,25 @@ pub fn build(b: *std.Build) void {
         jni_step.dependOn(&copy_to_jni_libs.step);
     }
 
+    // Test: try building openssl for aarch64 android
+    const openssl_test_step = b.step("test-openssl", "Test building OpenSSL for Android aarch64");
+    {
+        const test_target = b.resolveTargetQuery(.{
+            .cpu_arch = .aarch64,
+            .os_tag = .linux,
+            .abi = .android,
+            .android_api_level = 24,
+        });
+        const openssl_dep = b.dependency("openssl", .{
+            .target = test_target,
+            .optimize = .ReleaseSmall,
+        });
+        const crypto = openssl_dep.artifact("crypto");
+        const ssl = openssl_dep.artifact("ssl");
+        openssl_test_step.dependOn(&crypto.step);
+        openssl_test_step.dependOn(&ssl.step);
+    }
+
     const fmt_check = b.addFmt(.{ .paths = &.{ "src", "build.zig", "build.zig.zon" } });
     const fmt_step = b.step("fmt", "Format Zig files");
     fmt_step.dependOn(&fmt_check.step);

--- a/zig-src/build.zig.zon
+++ b/zig-src/build.zig.zon
@@ -16,6 +16,9 @@
         .libssh2 = .{
             .path = "src/vendor/libssh2",
         },
+        .openssl = .{
+            .path = "../../openssl-zig",
+        },
     },
     .fingerprint = 0xddba11030bd5a50,
     .paths = .{

--- a/zig-src/build.zig.zon
+++ b/zig-src/build.zig.zon
@@ -10,14 +10,12 @@
             .url = "git+https://github.com/jossephus/zignal#arm32-fix",
             .hash = "zignal-0.5.0-dev-OrZ3s9DMEgAWYOOzH4U7LWIZi_jDq8zctxAckan3N0U0",
         },
-        .mbedtls = .{
-            .path = "src/vendor/mbedtls",
-        },
         .libssh2 = .{
             .path = "src/vendor/libssh2",
         },
         .openssl = .{
-            .path = "../../openssl-zig",
+            .url = "git+https://github.com/jossephus/openssl-zig#bc228fc66b51610129b65a6f4590e26b409048cb",
+            .hash = "openssl-3.6.0-wZcA76Qb8gHOC9xYtu7mOgCh_5Fdf-ysBWyDaR9vvwgL",
         },
     },
     .fingerprint = 0xddba11030bd5a50,

--- a/zig-src/src/vendor/libssh2/build.zig
+++ b/zig-src/src/vendor/libssh2/build.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 const libssh2_src: []const []const u8 = &.{
     "src/agent.c",
     "src/bcrypt_pbkdf.c",
-    "src/blowfish.c",
     "src/chacha.c",
     "src/channel.c",
     "src/cipher-chachapoly.c",
@@ -83,6 +82,7 @@ pub fn build(b: *std.Build) void {
     lib.root_module.addIncludePath(upstream.path("include"));
     lib.addIncludePath(openssl_dep.path("include"));
     lib.addIncludePath(openssl_dep.path("include_gen"));
+    lib.root_module.addCMacro("OPENSSL_NO_BF", "1");
     lib.root_module.addCMacro("HAVE_CONFIG_H", "1");
     lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
     lib.addCSourceFiles(.{

--- a/zig-src/src/vendor/libssh2/build.zig
+++ b/zig-src/src/vendor/libssh2/build.zig
@@ -42,15 +42,8 @@ pub fn build(b: *std.Build) void {
     // Get optional libc file path from parent (as LazyPath)
     const libc_file = b.option(std.Build.LazyPath, "libc_file", "Path to libc configuration file");
 
-    // Build mbedtls with libc_file option (parent should pass this)
-    const mbedtls_dep = b.dependency("mbedtls", .{
-        .target = target,
-        .optimize = optimize,
-        .libc_file = libc_file,
-    });
-
-    // Get the upstream mbedtls dependency to access include paths
-    const mbedtls_upstream = mbedtls_dep.builder.dependency("mbedtls_upstream", .{
+    // Build openssl with libc_file option (parent should pass this)
+    const openssl_dep = b.dependency("openssl", .{
         .target = target,
         .optimize = optimize,
     });
@@ -88,18 +81,18 @@ pub fn build(b: *std.Build) void {
 
     lib.root_module.addConfigHeader(config_header);
     lib.root_module.addIncludePath(upstream.path("include"));
-    lib.root_module.addIncludePath(mbedtls_upstream.path("include"));
-    lib.addIncludePath(mbedtls_upstream.path("include"));
+    lib.addIncludePath(openssl_dep.path("include"));
+    lib.addIncludePath(openssl_dep.path("include_gen"));
     lib.root_module.addCMacro("HAVE_CONFIG_H", "1");
-    lib.root_module.addCMacro("LIBSSH2_MBEDTLS", "1");
+    lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
     lib.addCSourceFiles(.{
         .files = libssh2_src,
         .root = upstream.path(""),
     });
-    lib.linkLibrary(mbedtls_dep.artifact("mbedtls"));
+    lib.linkLibrary(openssl_dep.artifact("crypto"));
 
-    // Ensure mbedtls is built before libssh2
-    lib.step.dependOn(&mbedtls_dep.artifact("mbedtls").step);
+    // Ensure openssl is built before libssh2
+    lib.step.dependOn(&openssl_dep.artifact("crypto").step);
 
     b.installArtifact(lib);
 
@@ -109,5 +102,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     module.addIncludePath(upstream.path("include"));
-    module.addIncludePath(mbedtls_upstream.path("include"));
+    module.addIncludePath(openssl_dep.path("include"));
+    module.addIncludePath(openssl_dep.path("include_gen"));
 }

--- a/zig-src/src/vendor/libssh2/build.zig.zon
+++ b/zig-src/src/vendor/libssh2/build.zig.zon
@@ -7,8 +7,8 @@
             .url = "https://github.com/libssh2/libssh2/archive/refs/tags/libssh2-1.11.1.tar.gz",
             .hash = "N-V-__8AAATRLQBu_rNy4X2UK6RtcdYK_yAzkV6OcCqgo5aK",
         },
-        .mbedtls = .{
-            .path = "../mbedtls",
+        .openssl = .{
+            .path = "../../../../../openssl-zig",
         },
     },
     .paths = .{

--- a/zig-src/src/vendor/libssh2/build.zig.zon
+++ b/zig-src/src/vendor/libssh2/build.zig.zon
@@ -8,7 +8,8 @@
             .hash = "N-V-__8AAATRLQBu_rNy4X2UK6RtcdYK_yAzkV6OcCqgo5aK",
         },
         .openssl = .{
-            .path = "../../../../../openssl-zig",
+            .url = "git+https://github.com/jossephus/openssl-zig#bc228fc66b51610129b65a6f4590e26b409048cb",
+            .hash = "openssl-3.6.0-wZcA76Qb8gHOC9xYtu7mOgCh_5Fdf-ysBWyDaR9vvwgL",
         },
     },
     .paths = .{


### PR DESCRIPTION
dropping mbdetls for openssl because support for ed25519 is a must

- **feat: add openssl in replacement to mbdetls**
- **feat: replace mbdtls to by openssl**
