### PR TITLE
feat: redesign components and screens with tui themed sense

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -105,7 +105,12 @@ fun ApplicationNavController() {
                 onRequireAuthOnConnectChanged = settingsRepo::setRequireAuthOnConnect,
                 onAccessoryLayoutChanged = settingsRepo::setAccessoryLayoutIds,
                 onTerminalCustomActionsChanged = settingsRepo::setTerminalCustomKeyGroups,
-                onBack = { navController.popBackStack() },
+                onBack = {
+                    val currentRoute = navController.currentBackStackEntry?.destination?.route
+                    if (currentRoute == "settings") {
+                        navController.popBackStack()
+                    }
+                },
             )
         }
         composable("servers/add") {

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuButton.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuButton.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -24,6 +26,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.ui.theme.ChuColors
+import com.jossephus.chuchu.ui.theme.ChuTypography
 
 enum class ChuButtonVariant {
     Filled,
@@ -37,26 +40,40 @@ fun ChuButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     variant: ChuButtonVariant = ChuButtonVariant.Filled,
+    bracketed: Boolean = false,
+    borderColor: Color? = null,
+    backgroundColor: Color? = null,
     contentPadding: PaddingValues = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
     testTag: String? = null,
     contentDescription: String? = null,
     content: @Composable () -> Unit,
 ) {
     val colors = ChuColors.current
+    val typography = ChuTypography.current
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
-    val shape = RoundedCornerShape(4.dp)
+    val shape = RectangleShape
 
     val background: Color = when {
         !enabled -> colors.disabledSurface
         variant == ChuButtonVariant.Filled -> colors.accent
+        backgroundColor != null -> backgroundColor
         else -> Color.Transparent
     }
 
+    val effectiveBorderColor: Color = borderColor ?: colors.border
+
     val border: BorderStroke? = when {
         !enabled && variant != ChuButtonVariant.Ghost -> BorderStroke(1.dp, colors.border)
-        variant == ChuButtonVariant.Outlined -> BorderStroke(1.dp, colors.border)
+        variant == ChuButtonVariant.Outlined -> BorderStroke(1.dp, effectiveBorderColor)
         else -> null
+    }
+
+    val bracketColor: Color = when {
+        !enabled -> colors.disabledText
+        variant == ChuButtonVariant.Filled -> colors.onAccent
+        borderColor != null -> borderColor
+        else -> colors.accent
     }
 
     val semanticsModifier = Modifier.semantics {
@@ -72,7 +89,7 @@ fun ChuButton(
         modifier = modifier
             .then(semanticsModifier)
             .clip(shape)
-            .background(background)
+            .background(background, shape)
             .then(if (border != null) Modifier.border(border, shape) else Modifier)
             .defaultMinSize(minHeight = 36.dp)
             .alpha(if (pressed && enabled) 0.7f else 1f)
@@ -85,6 +102,17 @@ fun ChuButton(
             .padding(contentPadding),
         contentAlignment = Alignment.Center,
     ) {
-        content()
+        if (bracketed) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                ChuText("[", style = typography.label, color = bracketColor)
+                content()
+                ChuText("]", style = typography.label, color = bracketColor)
+            }
+        } else {
+            content()
+        }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuCard.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuCard.kt
@@ -5,25 +5,25 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.ui.theme.ChuColors
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun ChuCard(
     modifier: Modifier = Modifier,
+    background: Color = ChuColors.current.surface,
+    border: Color = ChuColors.current.border,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val colors = ChuColors.current
-    val shape = RoundedCornerShape(4.dp)
+    val shape = RectangleShape
     Column(
         modifier = modifier
-            .clip(shape)
-            .background(colors.surface)
-            .border(BorderStroke(1.dp, colors.border), shape),
+            .background(background, shape)
+            .border(BorderStroke(1.dp, border), shape),
         content = content,
     )
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuDialog.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuDialog.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,7 +29,7 @@ fun ChuDialog(
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
-    val shape = RoundedCornerShape(4.dp)
+    val shape = RectangleShape
 
     Dialog(onDismissRequest = onDismiss) {
         Column(
@@ -49,10 +49,15 @@ fun ChuDialog(
                 ChuButton(
                     onClick = onDismiss,
                     variant = ChuButtonVariant.Ghost,
+                    bracketed = true,
+                    borderColor = colors.textMuted,
                 ) {
-                    ChuText(dismissLabel, style = typography.label, color = colors.accent)
+                    ChuText(dismissLabel, style = typography.label, color = colors.textMuted)
                 }
-                ChuButton(onClick = onConfirm) {
+                ChuButton(
+                    onClick = onConfirm,
+                    bracketed = true,
+                ) {
                     ChuText(confirmLabel, style = typography.label, color = colors.onAccent)
                 }
             }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuSegmentedControl.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuSegmentedControl.kt
@@ -28,13 +28,15 @@ fun <T> ChuSegmentedControl(
             val label = labels[option] ?: option.toString()
             ChuButton(
                 onClick = { onSelect(option) },
-                variant = if (isSelected) ChuButtonVariant.Filled else ChuButtonVariant.Outlined,
+                variant = ChuButtonVariant.Outlined,
+                borderColor = if (isSelected) colors.accent else colors.border,
+                backgroundColor = if (isSelected) colors.accent.copy(alpha = 0.12f) else null,
                 modifier = Modifier.weight(1f),
             ) {
                 ChuText(
                     text = label,
                     style = typography.label,
-                    color = if (isSelected) colors.onAccent else colors.textSecondary,
+                    color = if (isSelected) colors.accent else colors.textSecondary,
                 )
             }
         }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuSwitch.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuSwitch.kt
@@ -2,19 +2,18 @@ package com.jossephus.chuchu.ui.components
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.ui.theme.ChuColors
 
@@ -26,14 +25,15 @@ fun ChuSwitch(
 ) {
     val colors = ChuColors.current
     val interactionSource = remember { MutableInteractionSource() }
-    val trackColor = if (checked) colors.accent else colors.border
-    val thumbOffset by animateDpAsState(if (checked) 16.dp else 2.dp, label = "chu-switch")
+    val trackColor = if (checked) colors.accent else colors.surface
+    val thumbColor = if (checked) colors.onAccent else colors.textPrimary
+    val thumbOffset by animateDpAsState(if (checked) 17.dp else 2.dp, label = "chu-switch")
 
     Box(
         modifier = modifier
-            .size(width = 34.dp, height = 20.dp)
-            .clip(RoundedCornerShape(10.dp))
+            .size(width = 36.dp, height = 18.dp)
             .background(trackColor)
+            .border(1.dp, colors.border)
             .alpha(1f)
             .clickable(
                 interactionSource = interactionSource,
@@ -43,10 +43,9 @@ fun ChuSwitch(
     ) {
         Box(
             modifier = Modifier
-                .offset(x = thumbOffset, y = 2.dp)
+                .offset(x = thumbOffset, y = 1.dp)
                 .size(16.dp)
-                .clip(CircleShape)
-                .background(colors.textPrimary),
+                .background(thumbColor),
         )
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuTextField.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuTextField.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -41,7 +43,7 @@ fun ChuTextField(
     val typography = ChuTypography.current
     val interactionSource = remember { MutableInteractionSource() }
     val focused by interactionSource.collectIsFocusedAsState()
-    val shape = RoundedCornerShape(4.dp)
+    val shape = RectangleShape
     val focusRequester = remember { FocusRequester() }
 
     // Only request focus if autoFocus is true
@@ -53,9 +55,9 @@ fun ChuTextField(
 
     Column(modifier = modifier) {
         ChuText(
-            text = label,
+            text = "> $label",
             style = typography.labelSmall,
-            color = colors.textSecondary,
+            color = if (focused) colors.accent else colors.textSecondary,
             modifier = Modifier.padding(bottom = 4.dp),
         )
         BasicTextField(
@@ -64,8 +66,11 @@ fun ChuTextField(
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(focusRequester)
-                .background(colors.surface, shape)
-                .border(BorderStroke(1.dp, if (focused) colors.accent else colors.border), shape)
+                .background(if (focused) colors.surface else Color.Transparent, shape)
+                .border(
+                    BorderStroke(1.dp, if (focused) colors.accent else colors.border),
+                    shape,
+                )
                 .padding(horizontal = 10.dp, vertical = 9.dp),
             singleLine = singleLine,
             textStyle = typography.body.copy(color = colors.textPrimary),
@@ -74,13 +79,15 @@ fun ChuTextField(
             interactionSource = interactionSource,
             cursorBrush = SolidColor(colors.accent),
             decorationBox = { innerTextField ->
-                if (value.isEmpty() && placeholder.isNotBlank()) {
-                    BasicText(
-                        text = placeholder,
-                        style = typography.body.copy(color = colors.textMuted),
-                    )
+                Box {
+                    if (value.isEmpty() && placeholder.isNotBlank()) {
+                        BasicText(
+                            text = placeholder,
+                            style = typography.body.copy(color = colors.textMuted),
+                        )
+                    }
+                    innerTextField()
                 }
-                innerTextField()
             },
         )
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/TuiBadge.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/TuiBadge.kt
@@ -1,0 +1,28 @@
+package com.jossephus.chuchu.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.jossephus.chuchu.ui.theme.ChuTypography
+
+@Composable
+fun TuiBadge(text: String, color: Color) {
+    val typography = ChuTypography.current
+    Box(
+        modifier = Modifier
+            .background(color.copy(alpha = 0.12f))
+            .border(1.dp, color.copy(alpha = 0.6f))
+            .padding(horizontal = 6.dp, vertical = 1.dp),
+    ) {
+        ChuText(
+            text,
+            style = typography.labelSmall,
+            color = color,
+        )
+    }
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
@@ -4,10 +4,7 @@ import android.content.Context
 import android.content.ClipboardManager
 import android.content.ClipData
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,32 +15,21 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.input.pointer.pointerInput
-import kotlin.math.roundToInt
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jossephus.chuchu.model.AuthMethod
 import com.jossephus.chuchu.model.Transport
@@ -72,20 +58,6 @@ fun AddServerScreen(
 
     val scrollState = rememberScrollState()
     val context = LocalContext.current
-    val exportKeyLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/x-pem-file"),
-    ) { uri ->
-        if (uri == null) return@rememberLauncherForActivityResult
-        val privateKeyPem = form.privateKeyPem
-        if (privateKeyPem.isBlank()) return@rememberLauncherForActivityResult
-        val ok = context.contentResolver.openOutputStream(uri)?.use { output ->
-            output.write(privateKeyPem.toByteArray(Charsets.UTF_8))
-            true
-        } ?: false
-        if (ok) {
-            Toast.makeText(context, "Private key saved", Toast.LENGTH_SHORT).show()
-        }
-    }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -95,10 +67,12 @@ fun AddServerScreen(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        ChuText("Add Server", style = typography.headline)
+        Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            ChuText("$ ", style = typography.headline, color = colors.textMuted)
+            ChuText("add server", style = typography.headline)
+        }
 
-        // --- Connection ---
-        SectionHeader("Connection")
+        SectionHeader("CONNECTION")
         ChuTextField(
             value = form.name,
             onValueChange = vm::updateName,
@@ -113,6 +87,7 @@ fun AddServerScreen(
             label = "Host",
             placeholder = "192.168.1.10",
             singleLine = true,
+            autoFocus = false,
             modifier = Modifier.fillMaxWidth(),
         )
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -122,6 +97,7 @@ fun AddServerScreen(
                 label = "Port",
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                autoFocus = false,
                 modifier = Modifier.weight(0.3f),
             )
             ChuTextField(
@@ -130,20 +106,20 @@ fun AddServerScreen(
                 label = "Username",
                 placeholder = "root",
                 singleLine = true,
+                autoFocus = false,
                 modifier = Modifier.weight(0.7f),
             )
         }
 
         SectionDivider()
 
-        // --- Transport ---
-        SectionHeader("Transport")
+        SectionHeader("TRANSPORT")
         ChuSegmentedControl(
             options = listOf(Transport.SSH, Transport.TailscaleSSH, Transport.Mosh),
             labels = mapOf(
-                Transport.SSH to "SSH",
-                Transport.TailscaleSSH to "Tailscale",
-                Transport.Mosh to "Mosh",
+                Transport.SSH to "ssh",
+                Transport.TailscaleSSH to "tailscale",
+                Transport.Mosh to "mosh",
             ),
             selected = form.transport,
             onSelect = vm::updateTransport,
@@ -158,20 +134,23 @@ fun AddServerScreen(
 
         SectionDivider()
 
-        // --- Auth ---
-        SectionHeader("Authentication")
-        val authOptions = listOf(
-            AuthMethod.Password,
-            AuthMethod.Key,
-            AuthMethod.None,
-        )
+        SectionHeader("AUTHENTICATION")
+        val authOptions = when (form.transport) {
+            Transport.TailscaleSSH -> listOf(AuthMethod.Password, AuthMethod.Key, AuthMethod.None)
+            else -> listOf(AuthMethod.Password, AuthMethod.Key)
+        }
+        if (form.authMethod == AuthMethod.None && form.transport != Transport.TailscaleSSH) {
+            androidx.compose.runtime.SideEffect {
+                vm.updateAuthMethod(AuthMethod.Password)
+            }
+        }
         val segmentSelected = if (form.authMethod == AuthMethod.KeyWithPassphrase) AuthMethod.Key else form.authMethod
         ChuSegmentedControl(
             options = authOptions,
             labels = mapOf(
-                AuthMethod.Password to "Password",
-                AuthMethod.Key to "SSH Key",
-                AuthMethod.None to "None",
+                AuthMethod.Password to "password",
+                AuthMethod.Key to "ssh key",
+                AuthMethod.None to "none",
             ),
             selected = segmentSelected,
             onSelect = vm::updateAuthMethod,
@@ -185,6 +164,7 @@ fun AddServerScreen(
                     label = "Password",
                     singleLine = true,
                     visualTransformation = PasswordVisualTransformation(),
+                    autoFocus = false,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
@@ -193,12 +173,6 @@ fun AddServerScreen(
                     form = form,
                     keys = keys,
                     onGenerate = { vm.generateKey(form.name) },
-                    onSelectStoredKey = vm::selectStoredKey,
-                    onDeleteStoredKey = vm::deleteStoredKey,
-                    onSavePrivateKey = {
-                        val name = form.name.trim().ifBlank { "android-ed25519" }
-                        exportKeyLauncher.launch("$name.pem")
-                    },
                     onCopyPublicKey = {
                         if (form.publicKeyOpenSsh.isBlank()) {
                             Toast.makeText(context, "No public key available", Toast.LENGTH_SHORT).show()
@@ -225,7 +199,7 @@ fun AddServerScreen(
                             }
                         },
                     )
-                    ChuText("Set passphrase", style = typography.label)
+                    ChuText("set passphrase", style = typography.label)
                 }
                 if (form.authMethod == AuthMethod.KeyWithPassphrase) {
                     ChuTextField(
@@ -234,13 +208,14 @@ fun AddServerScreen(
                         label = "Passphrase",
                         singleLine = true,
                         visualTransformation = PasswordVisualTransformation(),
+                        autoFocus = false,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
             }
             AuthMethod.None -> {
                 ChuText(
-                    "No SSH auth uses Tailscale SSH policy (`tailscale up --ssh`) on the server. We'll connect through Tailscale SSH instead of regular sshd credentials.",
+                    "no SSH auth uses Tailscale SSH policy (`tailscale up --ssh`) on the server. connect through Tailscale SSH instead of regular sshd credentials.",
                     style = typography.bodySmall,
                     color = colors.textMuted,
                 )
@@ -249,13 +224,13 @@ fun AddServerScreen(
 
         SectionDivider()
 
-        SectionHeader("Security")
+        SectionHeader("SECURITY")
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
         ) {
-            ChuText("Require verification before connect", style = typography.label)
+            ChuText("require biometric auth", style = typography.label)
             ChuSwitch(
                 checked = form.requireAuthOnConnect,
                 onCheckedChange = vm::updateRequireAuthOnConnect,
@@ -264,17 +239,18 @@ fun AddServerScreen(
 
         SectionDivider()
 
-        // --- Actions ---
+
         val canTest = form.host.isNotBlank() && form.username.isNotBlank()
         ChuButton(
             onClick = vm::testConnection,
             enabled = canTest,
             variant = ChuButtonVariant.Outlined,
+            bracketed = true,
             modifier = Modifier.fillMaxWidth(),
         ) {
             val label = when (testState.status) {
-                ConnectionTestStatus.Running -> "Testing…"
-                else -> "Test connection"
+                ConnectionTestStatus.Running -> "testing…"
+                else -> "test connection"
             }
             ChuText(label, style = typography.label)
         }
@@ -289,9 +265,12 @@ fun AddServerScreen(
         ChuButton(
             onClick = { vm.save(onBack) },
             enabled = form.canSave(),
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            borderColor = colors.accent,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            ChuText("Save", style = typography.label, color = colors.onAccent)
+            ChuText("save", style = typography.label, color = colors.accent)
         }
     }
 }
@@ -302,17 +281,25 @@ private fun SectionDivider() {
         modifier = Modifier
             .fillMaxWidth()
             .height(1.dp)
-            .background(ChuColors.current.border.copy(alpha = 0.5f)),
+            .background(ChuColors.current.border),
     )
 }
 
 @Composable
 private fun SectionHeader(label: String) {
-    ChuText(
-        label,
-        style = ChuTypography.current.title,
-        color = ChuColors.current.textPrimary,
-    )
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+        ChuText("── ", style = typography.labelSmall, color = colors.textMuted)
+        ChuText(label, style = typography.labelSmall, color = colors.textMuted)
+        ChuText(" ", style = typography.labelSmall, color = colors.textMuted)
+        Box(
+            modifier = Modifier
+                .height(1.dp)
+                .background(colors.textMuted)
+                .fillMaxWidth(),
+        )
+    }
 }
 
 @Composable
@@ -320,191 +307,54 @@ private fun KeyAuthSection(
     form: AddServerForm,
     keys: List<com.jossephus.chuchu.model.SshKey>,
     onGenerate: () -> Unit,
-    onSelectStoredKey: (Long?) -> Unit,
-    onDeleteStoredKey: (Long) -> Unit,
-    onSavePrivateKey: () -> Unit,
     onCopyPublicKey: () -> Unit,
 ) {
     val typography = ChuTypography.current
     val colors = ChuColors.current
     val selectedKey = keys.firstOrNull { it.id == form.keyId }
-    var showKeyPicker by remember { mutableStateOf(false) }
 
     if (selectedKey != null) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(4.dp))
-                .background(colors.surface)
-                .padding(10.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            ChuText("● ", style = typography.body, color = colors.accent)
+            ChuText(selectedKey.name, style = typography.body, color = colors.textPrimary)
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            ChuText(
-                "Using: ${selectedKey.name}",
-                style = typography.label,
-                color = colors.textPrimary,
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ChuButton(
+                onClick = onCopyPublicKey,
+                variant = ChuButtonVariant.Outlined,
+                bracketed = true,
+                borderColor = colors.accent,
+                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 6.dp),
+                modifier = Modifier.weight(1f),
             ) {
-                ChuButton(
-                    onClick = onCopyPublicKey,
-                    variant = ChuButtonVariant.Outlined,
-                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 6.dp),
-                    modifier = Modifier.weight(1f),
-                ) {
-                    ChuText("Copy public key", style = typography.labelSmall)
-                }
-                ChuButton(
-                    onClick = onSavePrivateKey,
-                    variant = ChuButtonVariant.Outlined,
-                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 6.dp),
-                    modifier = Modifier.weight(1f),
-                ) {
-                    ChuText("Export private key", style = typography.labelSmall)
-                }
+                ChuText("copy public key", style = typography.labelSmall, color = colors.accent)
+            }
+            ChuButton(
+                onClick = onGenerate,
+                variant = ChuButtonVariant.Outlined,
+                bracketed = true,
+                modifier = Modifier.weight(1f),
+            ) {
+                ChuText("new key", style = typography.label)
             }
         }
     } else {
         ChuText(
-            "Generate an Ed25519 key, then copy the public key to ~/.ssh/authorized_keys on the remote host.",
+            "generate an Ed25519 key, then copy the public key to ~/.ssh/authorized_keys on the remote host.",
             style = typography.bodySmall,
             color = colors.textMuted,
         )
-    }
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
         ChuButton(
             onClick = onGenerate,
             variant = ChuButtonVariant.Outlined,
-            modifier = Modifier.weight(1f),
+            bracketed = true,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            ChuText(if (selectedKey != null) "New key" else "Generate key", style = typography.label)
-        }
-        if (keys.isNotEmpty()) {
-            ChuButton(
-                onClick = { showKeyPicker = true },
-                variant = ChuButtonVariant.Outlined,
-                modifier = Modifier.weight(1f),
-            ) {
-                ChuText(
-                    "Stored (${keys.size})",
-                    style = typography.label,
-                )
-            }
+            ChuText("generate key", style = typography.label)
         }
     }
 
-    if (showKeyPicker) {
-        KeyPickerDialog(
-            keys = keys,
-            selectedKeyId = form.keyId,
-            onSelect = { id ->
-                onSelectStoredKey(id)
-                showKeyPicker = false
-            },
-            onDelete = onDeleteStoredKey,
-            onDismiss = { showKeyPicker = false },
-        )
-    }
-}
-
-@Composable
-private fun KeyPickerDialog(
-    keys: List<com.jossephus.chuchu.model.SshKey>,
-    selectedKeyId: Long?,
-    onSelect: (Long?) -> Unit,
-    onDelete: (Long) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    ChuDialog(
-        title = "Stored keys",
-        confirmLabel = "Done",
-        onConfirm = onDismiss,
-        onDismiss = onDismiss,
-    ) {
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            keys.forEach { key ->
-                val isSelected = selectedKeyId == key.id
-                SwipeToDeleteKeyRow(
-                    keyName = key.name,
-                    isSelected = isSelected,
-                    onSelect = { onSelect(key.id) },
-                    onDelete = { onDelete(key.id) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun SwipeToDeleteKeyRow(
-    keyName: String,
-    isSelected: Boolean,
-    onSelect: () -> Unit,
-    onDelete: () -> Unit,
-) {
-    val colors = ChuColors.current
-    val typography = ChuTypography.current
-    val density = LocalDensity.current
-    val scope = rememberCoroutineScope()
-    val rowShape = RoundedCornerShape(4.dp)
-    val rowHeight = 40.dp
-    val maxSwipePx = with(density) { 120.dp.toPx() }
-    val deleteThresholdPx = with(density) { 72.dp.toPx() }
-    val offsetX = remember(keyName) { Animatable(0f) }
-
-    Box(modifier = Modifier.fillMaxWidth().height(rowHeight)) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(colors.error.copy(alpha = 0.78f))
-                .padding(end = 14.dp),
-        ) {
-            ChuText(
-                "Delete",
-                style = typography.labelSmall,
-                color = colors.background,
-                modifier = Modifier.align(androidx.compose.ui.Alignment.CenterEnd),
-            )
-        }
-
-        Box(
-            modifier = Modifier
-                .clip(rowShape)
-                .offset { IntOffset(offsetX.value.roundToInt(), 0) }
-                .background(colors.surface)
-                .pointerInput(keyName) {
-                    detectHorizontalDragGestures(
-                        onHorizontalDrag = { change, dragAmount ->
-                            change.consume()
-                            val next = (offsetX.value + dragAmount).coerceIn(-maxSwipePx, 0f)
-                            scope.launch { offsetX.snapTo(next) }
-                        },
-                        onDragEnd = {
-                            if (offsetX.value <= -deleteThresholdPx) {
-                                onDelete()
-                                scope.launch { offsetX.snapTo(0f) }
-                            } else {
-                                scope.launch { offsetX.animateTo(0f, animationSpec = tween(140)) }
-                            }
-                        },
-                    )
-                },
-        ) {
-            ChuButton(
-                onClick = onSelect,
-                variant = if (isSelected) ChuButtonVariant.Filled else ChuButtonVariant.Outlined,
-                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                val label = if (isSelected) "✓ $keyName" else keyName
-                ChuText(label, style = typography.labelSmall, color = if (isSelected) colors.onAccent else colors.textPrimary)
-            }
-        }
-    }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/ServerList/ServerListScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/ServerList/ServerListScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.animation.core.Animatable
@@ -33,7 +32,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -51,6 +49,7 @@ import com.jossephus.chuchu.ui.components.ChuButton
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
 import com.jossephus.chuchu.ui.components.ChuCard
 import com.jossephus.chuchu.ui.components.ChuText
+import com.jossephus.chuchu.ui.components.TuiBadge
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
 
@@ -92,20 +91,23 @@ fun ServerListScreen(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                ChuText("Chuchu", style = typography.headline)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    ChuText("$ ", style = typography.headline, color = colors.textMuted)
+                    ChuText("chuchu", style = typography.headline)
+                }
 
                 ChuButton(
                     onClick = onOpenSettings,
-                    variant = ChuButtonVariant.Ghost,
-                    contentPadding = PaddingValues(8.dp),
+                    variant = ChuButtonVariant.Outlined,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                 ) {
-                    ChuText("⚙", style = typography.title, color = colors.textMuted)
+                    ChuText("settings", style = typography.label, color = colors.textSecondary)
                 }
             }
 
-            SectionHeader("Active connections and saved servers")
+            SectionHeader("HOSTS")
 
             if (hosts.isEmpty()) {
                 EmptyState()
@@ -137,15 +139,28 @@ fun ServerListScreen(
             }
         }
 
-        ChuButton(
-            onClick = onAddServer,
+        Column(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .windowInsetsPadding(WindowInsets.safeDrawing)
-                .padding(16.dp)
-                .height(44.dp),
+                .padding(16.dp),
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            ChuText("Add Server", style = typography.label, color = colors.onAccent)
+            ChuButton(
+                onClick = onAddServer,
+                variant = ChuButtonVariant.Filled,
+                bracketed = true,
+                modifier = Modifier.height(44.dp),
+            ) {
+                ChuText("+ add server", style = typography.label, color = colors.onAccent)
+            }
+
+            ChuText(
+                text = "theme: ${colors.name}",
+                style = typography.labelSmall,
+                color = colors.textMuted,
+            )
         }
 
     }
@@ -153,20 +168,32 @@ fun ServerListScreen(
 
 @Composable
 private fun SectionHeader(label: String) {
-    ChuText(label, style = ChuTypography.current.label, color = ChuColors.current.textSecondary)
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        ChuText("── ", style = typography.labelSmall, color = colors.border)
+        ChuText(label, style = typography.labelSmall, color = colors.textSecondary)
+        ChuText(" ", style = typography.labelSmall, color = colors.border)
+        Box(
+            modifier = Modifier
+                .height(1.dp)
+                .background(colors.border)
+                .fillMaxWidth(),
+        )
+    }
 }
 
 @Composable
 private fun EmptyState() {
     val colors = ChuColors.current
     val typography = ChuTypography.current
-    ChuCard {
+    ChuCard(background = colors.surfaceVariant) {
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-            ChuText("No servers yet", style = typography.title)
+            ChuText("# no hosts configured", style = typography.body, color = colors.textMuted)
             Spacer(modifier = Modifier.height(8.dp))
             ChuText(
-                "Add your first host profile to connect quickly.",
-                style = typography.body,
+                "add your first host to connect quickly.",
+                style = typography.bodySmall,
                 color = colors.textSecondary,
             )
         }
@@ -190,19 +217,16 @@ private fun HostCard(
     val deleteThresholdPx = with(density) { 72.dp.toPx() }
     val offsetX = remember(host.id) { Animatable(0f) }
     var revealAddress by remember(host.id) { mutableStateOf(false) }
-    val cardShape = RoundedCornerShape(4.dp)
-    val activeBorderColor = colors.success.copy(alpha = 0.8f)
 
     Box(modifier = Modifier.fillMaxWidth().height(114.dp)) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .clip(cardShape)
                 .background(if (isConnected) colors.warning.copy(alpha = 0.78f) else colors.error.copy(alpha = 0.78f))
                 .padding(end = 14.dp),
         ) {
             ChuText(
-                if (isConnected) "Disconnect" else "Delete",
+                if (isConnected) "[ disconnect ]" else "[ delete ]",
                 style = typography.label,
                 color = colors.background,
                 modifier = Modifier.align(Alignment.CenterEnd),
@@ -212,9 +236,7 @@ private fun HostCard(
         Box(
             modifier = Modifier
                 .offset { IntOffset(offsetX.value.roundToInt(), 0) }
-                .clip(cardShape)
-                .background(colors.surface)
-                .then(if (isConnected) Modifier.border(1.dp, activeBorderColor, cardShape) else Modifier)
+                .fillMaxSize()
                 .clickable(onClick = onConnect)
                 .pointerInput(host.id) {
                     detectHorizontalDragGestures(
@@ -238,28 +260,30 @@ private fun HostCard(
                     )
                 },
         ) {
-            ChuCard(modifier = Modifier.fillMaxSize()) {
+            ChuCard(
+                modifier = Modifier.fillMaxSize(),
+                background = colors.surfaceVariant,
+                border = if (isConnected) colors.success else colors.border,
+            ) {
                 Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        ChuText(host.name, style = typography.title)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            ChuText(
+                                if (isConnected) "● " else "○ ",
+                                style = typography.title,
+                                color = if (isConnected) colors.success else colors.textMuted,
+                            )
+                            ChuText(host.name, style = typography.title)
+                        }
                         if (isConnected) {
-                            Box(
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(999.dp))
-                                    .background(colors.success.copy(alpha = 0.2f))
-                                    .border(1.dp, colors.success.copy(alpha = 0.6f), RoundedCornerShape(999.dp))
-                                    .padding(horizontal = 8.dp, vertical = 2.dp),
-                            ) {
-                                ChuText(
-                                    "Connected",
-                                    style = typography.labelSmall,
-                                    color = colors.success,
-                                )
-                            }
+                            TuiBadge(
+                                text = "CONNECTED",
+                                color = colors.success,
+                            )
                         }
                     }
                     Spacer(modifier = Modifier.height(2.dp))
@@ -269,47 +293,42 @@ private fun HostCard(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         ChuText(
-                            "${host.username}@${host.host}:${host.port}",
+                            "> ${host.username}@${host.host}:${host.port}",
                             style = typography.body,
                             color = colors.textSecondary,
                             modifier = Modifier
-                                .clip(RoundedCornerShape(4.dp))
                                 .clickable { revealAddress = !revealAddress }
                                 .then(if (revealAddress) Modifier else Modifier.blur(8.dp)),
                         )
                         if (host.transport == Transport.TailscaleSSH) {
-                            Box(
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(999.dp))
-                                    .background(colors.accent.copy(alpha = 0.15f))
-                                    .border(1.dp, colors.accent.copy(alpha = 0.5f), RoundedCornerShape(999.dp))
-                                    .padding(horizontal = 6.dp, vertical = 1.dp),
-                            ) {
-                                ChuText(
-                                    "Tailscale",
-                                    style = typography.labelSmall,
-                                    color = colors.accent,
-                                )
-                            }
+                            TuiBadge(
+                                text = "tailscale",
+                                color = colors.accent,
+                            )
                         }
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                         ChuButton(
                             onClick = onEdit,
-                            variant = ChuButtonVariant.Outlined,
+                            variant = ChuButtonVariant.Ghost,
+                            bracketed = true,
+                            borderColor = colors.textMuted,
                             testTag = "host_edit_${host.id}",
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                         ) {
-                            ChuText("Edit", style = typography.label)
+                            ChuText("edit", style = typography.label, color = colors.textMuted)
                         }
                         ChuButton(
                             onClick = onConnect,
+                            variant = ChuButtonVariant.Outlined,
+                            bracketed = true,
+                            borderColor = colors.accentSecondary,
                             testTag = "host_connect_${host.id}",
                             contentDescription = "Connect to ${host.name}",
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                         ) {
-                            ChuText("Connect", style = typography.label, color = colors.onAccent)
+                            ChuText("connect", style = typography.label, color = colors.accentSecondary)
                         }
                     }
                 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -32,8 +32,8 @@ import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
 
 enum class SettingsCategory(val label: String) {
-    General("General"),
-    Terminal("Terminal"),
+    General("general"),
+    Terminal("terminal"),
 }
 
 @Composable
@@ -81,30 +81,39 @@ fun SettingsScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                ChuText("Settings", style = typography.headline)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    ChuText("$ ", style = typography.headline, color = colors.textMuted)
+                    ChuText("settings", style = typography.headline)
+                }
                 ChuButton(
                     onClick = onBack,
                     variant = ChuButtonVariant.Ghost,
-                    contentPadding = PaddingValues(8.dp),
+                    bracketed = true,
+                    borderColor = colors.textMuted,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                 ) {
-                    ChuText("Close", style = typography.label, color = colors.textMuted)
+                    ChuText("x", style = typography.label, color = colors.textMuted)
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
 
             Row(
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 SettingsCategory.entries.forEach { category ->
                     val isSelected = category == selectedCategory
                     ChuButton(
                         onClick = { selectedCategory = category },
-                        variant = if (isSelected) ChuButtonVariant.Filled else ChuButtonVariant.Outlined,
+                        variant = ChuButtonVariant.Outlined,
+                        borderColor = if (isSelected) colors.accent else colors.border,
+                        backgroundColor = if (isSelected) colors.accent.copy(alpha = 0.12f) else null,
+                        modifier = Modifier.weight(1f),
                     ) {
                         ChuText(
                             category.label,
                             style = typography.label,
-                            color = if (isSelected) colors.onAccent else colors.textSecondary,
+                            color = if (isSelected) colors.accent else colors.textSecondary,
                         )
                     }
                 }
@@ -164,25 +173,30 @@ private fun GeneralSettings(
         onThemeSelected = onThemeSelected,
     )
     Spacer(modifier = Modifier.height(16.dp))
-    ChuText("Security", style = typography.title)
-    Spacer(modifier = Modifier.height(8.dp))
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        ChuText("── ", style = typography.labelSmall, color = colors.textMuted)
+        ChuText("SECURITY", style = typography.labelSmall, color = colors.textMuted)
+        ChuText(" ", style = typography.labelSmall, color = colors.textMuted)
+        Box(modifier = Modifier.height(1.dp).background(colors.textMuted).fillMaxWidth())
+    }
+    Spacer(modifier = Modifier.height(12.dp))
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        ChuText("Lock app on open", style = typography.label)
+        ChuText("lock app on open", style = typography.label)
         ChuSwitch(checked = appLockEnabled, onCheckedChange = onAppLockEnabledChanged)
     }
-    Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(20.dp))
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        ChuText("Verify before server connect", style = typography.label)
+        ChuText("verify before server connect", style = typography.label)
         ChuSwitch(checked = requireAuthOnConnect, onCheckedChange = onRequireAuthOnConnectChanged)
     }
     Spacer(modifier = Modifier.height(4.dp))
-    ChuText("Use biometrics or device PIN/pattern.", style = typography.bodySmall, color = colors.textMuted)
+    ChuText("use biometrics or device PIN/pattern.", style = typography.bodySmall, color = colors.textMuted)
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
@@ -15,15 +15,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
@@ -41,6 +45,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.ui.components.ChuButton
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
+import com.jossephus.chuchu.ui.components.ChuCard
 import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.terminal.AccessoryKeyItem
 import com.jossephus.chuchu.ui.terminal.KeyboardAccessoryBar
@@ -64,100 +69,103 @@ internal fun TerminalSettings(
         TerminalAccessoryLayoutStore.resolveSelectedLayout(currentAccessoryLayoutIds)
     }
 
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        ChuText("── ", style = typography.labelSmall, color = colors.textMuted)
+        ChuText("TERMINAL", style = typography.labelSmall, color = colors.textMuted)
+        ChuText(" ", style = typography.labelSmall, color = colors.textMuted)
+        Box(modifier = Modifier.height(1.dp).background(colors.textMuted).fillMaxWidth())
+    }
+    Spacer(modifier = Modifier.height(12.dp))
+
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        ChuText("Terminal", style = typography.title)
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
-                .background(colors.surface)
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+        ChuCard(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    ChuText("Accessory keys", style = typography.label)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        ChuText("accessory keys", style = typography.label)
+                        ChuText(
+                            if (selectedItems.isEmpty()) "no keys enabled" else "${selectedItems.size} keys enabled",
+                            style = typography.body,
+                            color = colors.textMuted,
+                        )
+                    }
+
+                    ChuButton(
+                        onClick = onEditAccessoryLayout,
+                        variant = ChuButtonVariant.Outlined,
+                        bracketed = true,
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+                    ) {
+                        ChuText("customize", style = typography.label)
+                    }
+                }
+
+                if (selectedItems.isEmpty()) {
                     ChuText(
-                        if (selectedItems.isEmpty()) "No keys enabled" else "${selectedItems.size} keys enabled",
+                        "choose the accessory keys you want in the terminal bar.",
                         style = typography.body,
-                        color = colors.textMuted,
+                        color = colors.textSecondary,
                     )
-                }
-
-                ChuButton(
-                    onClick = onEditAccessoryLayout,
-                    variant = ChuButtonVariant.Outlined,
-                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
-                ) {
-                    ChuText("Customize", style = typography.label)
-                }
-            }
-
-            if (selectedItems.isEmpty()) {
-                ChuText(
-                    "Choose the accessory keys you want in the terminal bar.",
-                    style = typography.body,
-                    color = colors.textSecondary,
-                )
-            } else {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(colors.surfaceVariant),
-                ) {
-                    KeyboardAccessoryBar(
-                        items = selectedItems,
-                        modifierState = ModifierState(),
-                        onAction = {},
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(colors.surfaceVariant),
+                    ) {
+                        KeyboardAccessoryBar(
+                            items = selectedItems,
+                            modifierState = ModifierState(),
+                            onAction = {},
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
             }
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
-                .background(colors.surface)
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+        ChuCard(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    ChuText("Custom actions", style = typography.label)
-                    val actionCount = currentTerminalCustomKeyGroups.sumOf { it.actions.size }
-                    ChuText(
-                        if (actionCount == 0) "No custom actions" else "$actionCount actions",
-                        style = typography.body,
-                        color = colors.textMuted,
-                    )
-                }
-
-                ChuButton(
-                    onClick = onEditCustomActions,
-                    variant = ChuButtonVariant.Outlined,
-                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ChuText("Customize", style = typography.label)
-                }
-            }
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        ChuText("custom actions", style = typography.label)
+                        val actionCount = currentTerminalCustomKeyGroups.sumOf { it.actions.size }
+                        ChuText(
+                            if (actionCount == 0) "no custom actions" else "$actionCount actions",
+                            style = typography.body,
+                            color = colors.textMuted,
+                        )
+                    }
 
-            ChuText(
-                "Create quick keys.",
-                style = typography.body,
-                color = colors.textSecondary,
-            )
+                    ChuButton(
+                        onClick = onEditCustomActions,
+                        variant = ChuButtonVariant.Outlined,
+                        bracketed = true,
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+                    ) {
+                        ChuText("customize", style = typography.label)
+                    }
+                }
+
+                ChuText(
+                    "create quick keys.",
+                    style = typography.body,
+                    color = colors.textSecondary,
+                )
+            }
         }
     }
 }
@@ -233,34 +241,25 @@ internal fun AccessoryLayoutEditorSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .fillMaxHeight(0.82f)
-                    .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
                     .background(colors.surfaceVariant)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                         onClick = {},
                     )
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .width(36.dp)
-                        .height(4.dp)
-                        .clip(RoundedCornerShape(2.dp))
-                        .background(colors.textMuted),
-                )
-
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.Top,
                 ) {
                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        ChuText("Accessory keys", style = typography.headline)
+                        ChuText("accessory keys", style = typography.headline)
                         ChuText(
-                            "Choose which keys appear in the bar.",
+                            "choose which keys appear in the bar.",
                             style = typography.body,
                             color = colors.textSecondary,
                         )
@@ -269,40 +268,39 @@ internal fun AccessoryLayoutEditorSheet(
                     ChuButton(
                         onClick = onDismiss,
                         variant = ChuButtonVariant.Ghost,
+                        bracketed = true,
+                        borderColor = colors.textMuted,
                         contentPadding = PaddingValues(6.dp),
                     ) {
-                        ChuText("Close", style = typography.label, color = colors.textMuted)
+                        ChuText("x", style = typography.label, color = colors.textMuted)
                     }
                 }
 
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(colors.surface)
-                        .padding(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
+                ChuCard(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        ChuText("Preview", style = typography.label)
-                        ChuText(
-                            if (selectedItems.isEmpty()) "0" else selectedItems.size.toString(),
-                            style = typography.labelSmall,
-                            color = colors.textMuted,
-                        )
-                    }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            ChuText("preview", style = typography.label)
+                            ChuText(
+                                if (selectedItems.isEmpty()) "0" else selectedItems.size.toString(),
+                                style = typography.labelSmall,
+                                color = colors.textMuted,
+                            )
+                        }
 
-                    if (selectedItems.isEmpty()) {
-                        ChuText(
-                            "No accessory keys selected.",
-                            style = typography.body,
-                            color = colors.textMuted,
-                        )
-                    } else {
+                        if (selectedItems.isEmpty()) {
+                            ChuText(
+                                "no accessory keys selected.",
+                                style = typography.body,
+                                color = colors.textMuted,
+                            )
+                        } else {
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -362,11 +360,12 @@ internal fun AccessoryLayoutEditorSheet(
                         }
 
                         ChuText(
-                            "Long-press a key in preview, then drag to place it where you want.",
+                            "long-press a key in preview, then drag to place it where you want.",
                             style = typography.body,
                             color = colors.textMuted,
                         )
                     }
+                }
                 }
 
                 Column(
@@ -393,16 +392,18 @@ internal fun AccessoryLayoutEditorSheet(
                     ChuButton(
                         onClick = { draftSelectedIds = TerminalAccessoryLayoutStore.defaultLayoutIds() },
                         variant = ChuButtonVariant.Outlined,
+                        bracketed = true,
                         modifier = Modifier.weight(1f),
                     ) {
-                        ChuText("Reset", style = typography.label)
+                        ChuText("reset", style = typography.label)
                     }
 
                     ChuButton(
                         onClick = { onSave(draftSelectedIds) },
+                        bracketed = true,
                         modifier = Modifier.weight(1f),
                     ) {
-                        ChuText("Save", style = typography.label, color = colors.onAccent)
+                        ChuText("save", style = typography.label, color = colors.onAccent)
                     }
                 }
             }
@@ -423,7 +424,6 @@ private fun PreviewKeyChip(
     Box(
         modifier = modifier
             .offset { IntOffset(x = dragOffsetPx.roundToInt(), y = 0) }
-            .clip(RoundedCornerShape(6.dp))
             .background(if (dragging) colors.accent.copy(alpha = 0.2f) else colors.surfaceVariant)
             .padding(horizontal = 10.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
@@ -448,7 +448,6 @@ private fun AccessoryChooserRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
             .background(if (selected) colors.surface else colors.surfaceVariant)
             .clickable(onClick = onClick)
             .padding(10.dp),
@@ -459,12 +458,11 @@ private fun AccessoryChooserRow(
             modifier = Modifier
                 .width(34.dp)
                 .height(34.dp)
-                .clip(RoundedCornerShape(6.dp))
                 .background(if (selected) colors.accent.copy(alpha = 0.18f) else colors.surface),
             contentAlignment = Alignment.Center,
         ) {
             ChuText(
-                text = if (selected) "✓" else "+",
+                text = if (selected) "●" else "+",
                 style = typography.label,
                 color = if (selected) colors.accent else colors.textMuted,
             )

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalCustomActionsEditor.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalCustomActionsEditor.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,7 +27,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -40,12 +44,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.ui.components.ChuButton
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
+import com.jossephus.chuchu.ui.components.ChuCard
 import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.components.ChuTextField
 import com.jossephus.chuchu.ui.terminal.CustomActionModifier
@@ -173,13 +179,13 @@ internal fun TerminalCustomActionsEditorSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .fillMaxHeight(0.88f)
-                    .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
                     .background(colors.surfaceVariant)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                         onClick = {},
                     )
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
@@ -188,13 +194,15 @@ internal fun TerminalCustomActionsEditorSheet(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ChuText("Custom actions", style = typography.headline)
+                    ChuText("custom actions", style = typography.headline)
                     ChuButton(
                         onClick = onDismiss,
                         variant = ChuButtonVariant.Ghost,
+                        bracketed = true,
+                        borderColor = colors.textMuted,
                         contentPadding = PaddingValues(6.dp),
                     ) {
-                        ChuText("Close", style = typography.label, color = colors.textMuted)
+                        ChuText("x", style = typography.label, color = colors.textMuted)
                     }
                 }
 
@@ -280,19 +288,17 @@ internal fun TerminalCustomActionsEditorSheet(
                                 showAddRow = true
                             },
                             variant = ChuButtonVariant.Outlined,
+                            bracketed = true,
                             modifier = Modifier.fillMaxWidth(),
                         ) {
-                            ChuText("+ Add", style = typography.label)
+                            ChuText("+ add", style = typography.label)
                         }
                     } else {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
-                                .background(colors.surface)
-                                .padding(10.dp),
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
+                        ChuCard(modifier = Modifier.fillMaxWidth()) {
+                            Column(
+                                modifier = Modifier.padding(10.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
                             ChuTextField(
                                 value = keyInput,
                                 onValueChange = { keyInput = it },
@@ -374,9 +380,10 @@ internal fun TerminalCustomActionsEditorSheet(
                                 ChuButton(
                                     onClick = ::registerDraftItem,
                                     variant = ChuButtonVariant.Outlined,
+                                    bracketed = true,
                                     modifier = Modifier.weight(1f),
                                 ) {
-                                    ChuText("Add", style = typography.label)
+                                    ChuText("add", style = typography.label)
                                 }
                                 ChuButton(
                                     onClick = {
@@ -388,9 +395,11 @@ internal fun TerminalCustomActionsEditorSheet(
                                         editingIndex = null
                                     },
                                     variant = ChuButtonVariant.Ghost,
+                                    bracketed = true,
+                                    borderColor = colors.textMuted,
                                     modifier = Modifier.weight(1f),
                                 ) {
-                                    ChuText("Cancel", style = typography.label, color = colors.textMuted)
+                                    ChuText("cancel", style = typography.label, color = colors.textMuted)
                                 }
                             }
                         }
@@ -400,6 +409,8 @@ internal fun TerminalCustomActionsEditorSheet(
             }
         }
     }
+}
+
 }
 
 @Composable
@@ -421,7 +432,7 @@ private fun CustomActionSwipeRow(
     val maxSwipePx = with(density) { 120.dp.toPx() }
     val deleteThresholdPx = with(density) { 72.dp.toPx() }
     val offsetX = remember(keyText, valueText) { Animatable(0f) }
-    val cardShape = RoundedCornerShape(8.dp)
+    val cardShape = RectangleShape
 
     Box(
         modifier = Modifier
@@ -431,19 +442,17 @@ private fun CustomActionSwipeRow(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .clip(cardShape)
                 .background(colors.error.copy(alpha = 0.78f))
                 .padding(end = 12.dp),
             contentAlignment = Alignment.CenterEnd,
         ) {
-            ChuText("Delete", style = typography.label, color = colors.background)
+            ChuText("[ delete ]", style = typography.label, color = colors.background)
         }
 
         Row(
             modifier = Modifier
                 .offset { IntOffset(offsetX.value.roundToInt(), dragOffsetPx.roundToInt()) }
                 .fillMaxSize()
-                .clip(cardShape)
                 .background(if (dragging) colors.accent.copy(alpha = 0.12f) else colors.surface)
                 .padding(horizontal = 12.dp)
                 .clickable(onClick = onEdit)

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/ThemeSelectorSection.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/ThemeSelectorSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -58,6 +59,9 @@ internal fun ThemeSelectorSection(
     val typography = ChuTypography.current
     val context = LocalContext.current
     val availableThemes = remember { GhosttyThemeRegistry.availableThemeNames }
+    val themeByName = remember(context, availableThemes) {
+        availableThemes.associateWith { themeName -> GhosttyThemeRegistry.getTheme(context, themeName) }
+    }
     var themeQuery by remember { mutableStateOf("") }
     var expanded by remember { mutableStateOf(false) }
     val themeListState = rememberLazyListState()
@@ -77,18 +81,25 @@ internal fun ThemeSelectorSection(
         }
     }
 
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        ChuText("── ", style = typography.labelSmall, color = colors.textMuted)
+        ChuText("THEME", style = typography.labelSmall, color = colors.textMuted)
+        ChuText(" ", style = typography.labelSmall, color = colors.textMuted)
+        Box(modifier = Modifier.height(1.dp).background(colors.textMuted).fillMaxWidth())
+    }
+    Spacer(modifier = Modifier.height(12.dp))
+
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            ChuText("Theme", style = typography.title)
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                ChuText("Show preview", style = typography.label, color = colors.textSecondary)
+                ChuText("show preview", style = typography.label, color = colors.textSecondary)
                 ChuSwitch(checked = showPreview, onCheckedChange = { showPreview = it })
             }
         }
@@ -98,10 +109,13 @@ internal fun ThemeSelectorSection(
         ChuButton(
             onClick = { expanded = !expanded },
             variant = ChuButtonVariant.Outlined,
+            bracketed = true,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -126,13 +140,12 @@ internal fun ThemeSelectorSection(
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                     modifier = Modifier.fillMaxWidth().heightIn(max = 480.dp),
                 ) {
-                    items(filteredThemes) { themeName ->
+                    items(filteredThemes, key = { it }) { themeName ->
                         val isSelected = themeName == currentTheme
-                        val rowTheme = remember(themeName) { GhosttyThemeRegistry.getTheme(context, themeName) }
+                        val rowTheme = themeByName[themeName]
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(4.dp))
                                 .background(if (isSelected) colors.surface else colors.surfaceVariant)
                                 .clickable { onThemeSelected(themeName) }
                                 .padding(horizontal = 12.dp, vertical = 10.dp),
@@ -154,7 +167,7 @@ internal fun ThemeSelectorSection(
                                         color = if (isSelected) colors.accent else colors.textPrimary,
                                     )
                                 }
-                                if (isSelected) ChuText("✓", style = typography.label, color = colors.accent)
+                                if (isSelected) ChuText("●", style = typography.label, color = colors.accent)
                             }
                         }
                     }
@@ -170,7 +183,7 @@ private fun ThemePreview(theme: GhosttyTheme, name: String) {
     val typography = ChuTypography.current
 
     Column(
-        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).background(colors.surface).padding(1.dp),
+        modifier = Modifier.fillMaxWidth().background(colors.surface).padding(1.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().background(colors.surface).padding(horizontal = 10.dp, vertical = 6.dp),
@@ -179,9 +192,9 @@ private fun ThemePreview(theme: GhosttyTheme, name: String) {
         ) {
             Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
                 Box(
-                    modifier = Modifier.width(6.dp).height(6.dp).clip(RoundedCornerShape(3.dp)).background(colors.accent),
+                    modifier = Modifier.width(6.dp).height(6.dp).background(colors.accent),
                 )
-                ChuText("PREVIEW", style = typography.labelSmall, color = colors.textSecondary)
+                ChuText("preview", style = typography.labelSmall, color = colors.textSecondary)
             }
             ChuText(name, style = typography.labelSmall, color = colors.textMuted)
         }
@@ -229,7 +242,7 @@ private fun ThemePreviewBody(theme: GhosttyTheme) {
         }
         Row(modifier = Modifier.fillMaxWidth().padding(top = 6.dp), horizontalArrangement = Arrangement.spacedBy(2.dp)) {
             theme.palette.forEach { paletteColor ->
-                Box(modifier = Modifier.weight(1f).height(10.dp).clip(RoundedCornerShape(2.dp)).background(paletteColor))
+                Box(modifier = Modifier.weight(1f).height(10.dp).background(paletteColor))
             }
         }
     }
@@ -302,11 +315,11 @@ private fun PaletteSwatchStrip(theme: GhosttyTheme) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clip(RoundedCornerShape(3.dp)).background(theme.background).padding(horizontal = 3.dp, vertical = 3.dp),
+        modifier = Modifier.background(theme.background).padding(horizontal = 3.dp, vertical = 3.dp),
     ) {
         SwatchIndices.forEach { idx ->
             val color: Color = theme.palette.getOrNull(idx) ?: theme.foreground
-            Box(modifier = Modifier.width(8.dp).height(12.dp).clip(RoundedCornerShape(1.dp)).background(color))
+            Box(modifier = Modifier.width(8.dp).height(12.dp).background(color))
         }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -8,14 +8,14 @@ import android.view.inputmethod.InputMethodManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
+
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -40,7 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.shadow
+
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
@@ -130,8 +130,8 @@ private fun TerminalCustomActionsFab(
     ) {
         AnimatedVisibility(
             visible = expanded,
-            enter = fadeIn() + scaleIn(),
-            exit = fadeOut() + scaleOut(),
+            enter = fadeIn(),
+            exit = fadeOut(),
         ) {
             Column(
                 horizontalAlignment = Alignment.End,
@@ -150,6 +150,7 @@ private fun TerminalCustomActionsFab(
                                 }
                             },
                             variant = ChuButtonVariant.Outlined,
+                            bracketed = true,
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                         ) {
                             ChuText(group.keyLabel, style = typography.label)
@@ -164,6 +165,7 @@ private fun TerminalCustomActionsFab(
                                 selectedGroupKey = null
                             },
                             variant = ChuButtonVariant.Outlined,
+                            bracketed = true,
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                         ) {
                             ChuText(action.label, style = typography.label)
@@ -172,6 +174,8 @@ private fun TerminalCustomActionsFab(
                     ChuButton(
                         onClick = { selectedGroupKey = null },
                         variant = ChuButtonVariant.Ghost,
+                        bracketed = true,
+                        borderColor = colors.textMuted,
                         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                     ) {
                         ChuText("<", style = typography.label, color = colors.textMuted)
@@ -180,24 +184,24 @@ private fun TerminalCustomActionsFab(
             }
         }
 
-        Box(
-            modifier = Modifier
-                .shadow(6.dp, CircleShape)
-                .clip(CircleShape)
-                .background(colors.accent)
-                .clickable {
-                    expanded = !expanded
-                    if (!expanded) {
-                        selectedGroupKey = null
-                    }
+        // TUI-style action toggle — square bracketed button instead of a
+        // circular Material FAB. Reads like a macro/quick-key trigger.
+        ChuButton(
+            onClick = {
+                expanded = !expanded
+                if (!expanded) {
+                    selectedGroupKey = null
                 }
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            contentAlignment = Alignment.Center,
+            },
+            variant = if (expanded) ChuButtonVariant.Ghost else ChuButtonVariant.Filled,
+            bracketed = true,
+            borderColor = if (expanded) colors.textMuted else null,
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
         ) {
             ChuText(
                 if (expanded) "x" else "+",
                 style = typography.label,
-                color = colors.onAccent,
+                color = if (expanded) colors.textMuted else colors.onAccent,
             )
         }
     }
@@ -538,8 +542,8 @@ fun TerminalScreen(
                             Row(
                                 modifier = Modifier
                                     .offset(x = menuOffsetX, y = menuOffsetY)
-                                    .shadow(4.dp, shape = RoundedCornerShape(8.dp))
-                                    .background(colors.background, shape = RoundedCornerShape(8.dp))
+                                    .background(colors.background)
+                                    .border(1.dp, colors.border)
                                     .padding(horizontal = 4.dp, vertical = 2.dp),
                                 horizontalArrangement = Arrangement.spacedBy(2.dp),
                                 verticalAlignment = Alignment.CenterVertically,
@@ -548,18 +552,22 @@ fun TerminalScreen(
                                     ChuButton(
                                         onClick = ::copySelection,
                                         variant = ChuButtonVariant.Ghost,
+                                        bracketed = true,
+                                        borderColor = colors.textMuted,
                                         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
                                     ) {
-                                        ChuText("Copy", style = typography.label, color = colors.textPrimary)
+                                        ChuText("copy", style = typography.label, color = colors.textMuted)
                                     }
                                 }
                                 if (hasClipboardText) {
                                     ChuButton(
                                         onClick = { pasteClipboard() },
                                         variant = ChuButtonVariant.Ghost,
+                                        bracketed = true,
+                                        borderColor = colors.textMuted,
                                         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
                                     ) {
-                                        ChuText("Paste", style = typography.label, color = colors.textPrimary)
+                                        ChuText("paste", style = typography.label, color = colors.textMuted)
                                     }
                                 }
                             }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/theme/ChuColors.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/theme/ChuColors.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 
 @Immutable
 data class ChuColorPalette(
+    val name: String,
     val background: Color,
     val surface: Color,
     val surfaceVariant: Color,
@@ -26,6 +27,7 @@ data class ChuColorPalette(
 )
 
 val ChuDarkColors: ChuColorPalette = ChuColorPalette(
+    name = "mocha",
     background = Color(0xFF1E1E2E),
     surface = Color(0xFF313244),
     surfaceVariant = Color(0xFF181825),

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/theme/GhosttyTheme.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/theme/GhosttyTheme.kt
@@ -101,6 +101,7 @@ fun GhosttyTheme.toChuColorPalette(): ChuColorPalette {
     val disabledText = textMuted
 
     return ChuColorPalette(
+        name = this.name,
         background = background,
         surface = surface,
         surfaceVariant = surfaceVariant,


### PR DESCRIPTION
I havent been happy with how the core component and the non terminal screens look. This is a redesign introducing
- squared corners
- bracetted actions 

giving more a tui liked theme for the whole app. Here is a demo of the screens.

https://github.com/user-attachments/assets/5107610b-9a88-42bf-9be5-496aaf974aa5

