### PR TITLE
feat/enhance terminal tabs

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
@@ -1,0 +1,297 @@
+package com.jossephus.chuchu.ui.screens.Terminal
+
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
+import com.jossephus.chuchu.service.terminal.TabSession
+import com.jossephus.chuchu.ui.components.ChuButton
+import com.jossephus.chuchu.ui.components.ChuButtonVariant
+import com.jossephus.chuchu.ui.components.ChuText
+import com.jossephus.chuchu.ui.terminal.AccessoryAction
+import com.jossephus.chuchu.ui.terminal.AccessoryKeyItem
+import com.jossephus.chuchu.ui.terminal.KeyboardAccessoryBar
+import com.jossephus.chuchu.ui.terminal.ModifierState
+import com.jossephus.chuchu.ui.terminal.TerminalCanvas
+import com.jossephus.chuchu.ui.theme.ChuColors
+import com.jossephus.chuchu.ui.theme.ChuTypography
+
+@Composable
+fun CommandPalette(
+    tabs: List<TabSession>,
+    activeTabId: String?,
+    focusedTabIndex: Int,
+    onFocusedTabIndexChange: (Int) -> Unit,
+    accessoryItems: List<AccessoryKeyItem>,
+    onAccessoryAction: (AccessoryAction) -> Unit,
+    onChuchuKey: () -> Unit,
+    chuchuKeyActive: Boolean,
+    onOpenFiles: () -> Unit,
+    onOpenSettings: () -> Unit,
+    useSingleRowAccessoryBar: Boolean,
+    onSelectTab: (String) -> Unit,
+    onCloseTab: (String) -> Unit,
+    onAddTab: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+  val colors = ChuColors.current
+  val typography = ChuTypography.current
+  val context = LocalContext.current
+  val view = LocalView.current
+  val keyboardController = LocalSoftwareKeyboardController.current
+  val entries = remember(tabs) { tabs.map { it to tabAlias(it) } }
+  val maxIndex = (entries.size - 1).coerceAtLeast(0)
+  LaunchedEffect(entries.size) { onFocusedTabIndexChange(focusedTabIndex.coerceIn(0, maxIndex)) }
+  LaunchedEffect(activeTabId, entries) {
+    val activeIndex = entries.indexOfFirst { it.first.id == activeTabId }
+    if (activeIndex >= 0) onFocusedTabIndexChange(activeIndex)
+  }
+  val listState = rememberLazyListState()
+  LaunchedEffect(focusedTabIndex, entries.size) {
+    if (entries.isNotEmpty()) listState.animateScrollToItem(focusedTabIndex.coerceIn(0, maxIndex))
+  }
+  LaunchedEffect(Unit) {
+    keyboardController?.hide()
+    val imm = context.getSystemService(InputMethodManager::class.java)
+    imm?.hideSoftInputFromWindow(view.windowToken, 0)
+  }
+
+  AnimatedVisibility(visible = true, enter = fadeIn(), exit = fadeOut()) {
+    Box(
+        modifier =
+            Modifier.fillMaxSize().background(colors.background).clickable(onClick = onDismiss)
+    ) {
+      Column(
+          modifier =
+              Modifier.align(Alignment.TopCenter)
+                  .windowInsetsPadding(WindowInsets.safeDrawing)
+                  .padding(top = 56.dp, start = 16.dp, end = 16.dp)
+                  .fillMaxWidth()
+                  .background(colors.surface)
+                  .border(1.dp, colors.border.copy(alpha = 0.65f)),
+      ) {
+        Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp)) {
+          ChuText(
+              "tabs",
+              style = typography.body,
+              color = colors.textSecondary,
+              modifier = Modifier.align(Alignment.Center),
+          )
+          ChuText(
+              "${entries.size}/${tabs.size}",
+              style = typography.labelSmall,
+              color = colors.textMuted,
+              modifier = Modifier.align(Alignment.CenterEnd),
+          )
+        }
+        if (entries.isNotEmpty()) {
+          LazyColumn(state = listState, modifier = Modifier.fillMaxWidth().heightIn(max = 280.dp)) {
+            items(entries.size) { idx ->
+              val (tab, alias) = entries[idx]
+              val isActive = tab.id == activeTabId
+              val isFocused = idx == focusedTabIndex
+              val state = tab.sessionState.value
+              val displayLabel = state.title?.takeIf { it.isNotBlank() } ?: alias
+              Row(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .background(if (isFocused) colors.surface else Color.Transparent)
+                          .border(
+                              1.dp,
+                              if (isFocused) colors.accent.copy(alpha = 0.7f)
+                              else colors.border.copy(alpha = 0.35f),
+                          )
+                          .clickable { onSelectTab(tab.id) }
+                          .padding(horizontal = 12.dp, vertical = 8.dp),
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.spacedBy(10.dp),
+              ) {
+                Box(modifier = Modifier.width(10.dp)) {
+                  if (isFocused) ChuText("▌", style = typography.body, color = colors.accent)
+                }
+                Box(
+                    modifier =
+                        Modifier.size(8.dp)
+                            .background(if (isActive) colors.success else Color.Transparent)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                  ChuText(
+                      displayLabel,
+                      style = typography.body,
+                      color = if (isFocused) colors.accent else colors.textPrimary,
+                  )
+                }
+                if (tabs.size > 1) {
+                  ChuButton(
+                      onClick = { onCloseTab(tab.id) },
+                      variant = ChuButtonVariant.Ghost,
+                      bracketed = true,
+                      borderColor = colors.textMuted,
+                      contentPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp),
+                  ) {
+                    ChuText("x", style = typography.labelSmall, color = colors.textMuted)
+                  }
+                }
+              }
+            }
+          }
+        }
+        val focusedSnapshot =
+            entries.getOrNull(focusedTabIndex)?.first?.sessionState?.value?.snapshot
+        if (focusedSnapshot != null) {
+          Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(colors.border))
+          Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Box(
+                modifier =
+                    Modifier.fillMaxWidth(0.68f)
+                        .height(104.dp)
+                        .background(colors.background.copy(alpha = 0.86f))
+                        .border(1.dp, colors.border.copy(alpha = 0.8f))
+                        .align(Alignment.Center)
+            ) {
+              TerminalCanvas(
+                  snapshot = focusedSnapshot,
+                  fontSizeSp = 10.5f,
+                  fitSnapshotToCanvas = true,
+                  enableGestures = false,
+                  cursorColor = Color.Transparent,
+                  selectionBackgroundColor = Color.Transparent,
+                  selectionForegroundColor = Color.Transparent,
+                  onTap = {},
+                  onPrimaryClick = { _, _ -> },
+                  onScroll = {},
+                  onZoom = {},
+                  onSelectionChanged = { _, _, _, _ -> },
+                  modifier = Modifier.fillMaxSize(),
+              )
+            }
+          }
+        }
+        Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(colors.border))
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+          PaletteHint("↵", "open")
+          PaletteHint("esc", "dismiss")
+          Spacer(modifier = Modifier.weight(1f))
+          ChuButton(
+              onClick = onAddTab,
+              variant = ChuButtonVariant.Outlined,
+              bracketed = true,
+              contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
+          ) {
+            ChuText("+ new", style = typography.labelSmall, color = colors.accent)
+          }
+        }
+      }
+      KeyboardAccessoryBar(
+          items = accessoryItems,
+          modifierState = ModifierState(),
+          onAction = onAccessoryAction,
+          onSettings = onOpenSettings,
+          onChuchuKey = onChuchuKey,
+          chuchuKeyActive = chuchuKeyActive,
+          onOpenFiles = onOpenFiles,
+          useSingleRow = useSingleRowAccessoryBar,
+          modifier =
+              Modifier.align(Alignment.BottomCenter)
+                  .windowInsetsPadding(WindowInsets.safeDrawing)
+                  .background(colors.background.copy(alpha = 0.92f)),
+      )
+    }
+  }
+}
+
+@Composable
+private fun PaletteHint(key: String, label: String) {
+  val colors = ChuColors.current
+  val typography = ChuTypography.current
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Box(
+        modifier = Modifier.border(1.dp, colors.border).padding(horizontal = 5.dp, vertical = 1.dp)
+    ) {
+      ChuText(key, style = typography.labelSmall, color = colors.textSecondary)
+    }
+    ChuText(label, style = typography.labelSmall, color = colors.textMuted)
+  }
+}
+
+private fun tabAlias(tab: TabSession): String {
+  val adjectives =
+      listOf(
+          "amber",
+          "brisk",
+          "cedar",
+          "delta",
+          "ember",
+          "frost",
+          "golden",
+          "hazel",
+          "indigo",
+          "jade",
+          "kilo",
+          "lunar",
+          "mango",
+          "nova",
+          "onyx",
+          "pluto",
+      )
+  val nouns =
+      listOf(
+          "otter",
+          "falcon",
+          "pine",
+          "river",
+          "comet",
+          "harbor",
+          "meadow",
+          "quartz",
+          "signal",
+          "orbit",
+          "anchor",
+          "summit",
+          "thunder",
+          "voyager",
+          "willow",
+          "zenith",
+      )
+  val seed = tab.id.hashCode().let { if (it == Int.MIN_VALUE) 0 else kotlin.math.abs(it) }
+  return "${adjectives[seed % adjectives.size]}-${nouns[(seed / adjectives.size) % nouns.size]}"
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -80,6 +80,9 @@ import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.components.ChuTextField
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import com.jossephus.chuchu.ui.terminal.AccessoryAction
+import com.jossephus.chuchu.ui.terminal.AccessoryKeyItem
+import com.jossephus.chuchu.ui.terminal.ChuchuKeyBindings
+import com.jossephus.chuchu.ui.terminal.ChuchuHint
 import com.jossephus.chuchu.ui.terminal.GhosttyKey
 import com.jossephus.chuchu.ui.terminal.GhosttyKeyAction
 import com.jossephus.chuchu.ui.terminal.KeyboardAccessoryBar
@@ -274,6 +277,30 @@ fun TerminalScreen(
     var pendingTabSpec by remember { mutableStateOf<TabSpec?>(null) }
     var showTabSheet by remember { mutableStateOf(false) }
     var hasSeenTabsForHost by remember(hostId) { mutableStateOf(false) }
+    var focusedTabIndex by remember { mutableStateOf(0) }
+    var terminalFontSizeSp by remember {
+        mutableStateOf(terminalPrefs.getFloat("terminal_font_size_sp", 14f).coerceAtLeast(0.1f))
+    }
+    val chuchuKeys = remember(vm) {
+        ChuchuKeyBindings(
+            hints = listOf(
+                ChuchuHint(key = "t", description = "tabs"),
+                ChuchuHint(key = "n", description = "new tab"),
+            ),
+            handlers = mapOf(
+                't' to { showTabSheet = true },
+                'n' to {
+                    vm.duplicateActiveTab()
+                    vm.selectConnectionTab(ConnectionTab.Terminal)
+                    showTabSheet = false
+                },
+            ),
+        )
+    }
+
+    LaunchedEffect(terminalFontSizeSp) {
+        terminalPrefs.edit().putFloat("terminal_font_size_sp", terminalFontSizeSp).apply()
+    }
 
     LaunchedEffect(hostId) {
         showPassphrasePrompt = false
@@ -505,6 +532,12 @@ fun TerminalScreen(
                     }
 
                     fun dispatchAccessoryAction(action: AccessoryAction) {
+                        if (action is AccessoryAction.SendText && chuchuKeys.handleText(action.text)) {
+                            return
+                        }
+                        if (chuchuKeys.isPrefixActive) {
+                            chuchuKeys.reset()
+                        }
                         val currentModifierState = modifierState
                         val result = TerminalAccessoryDispatcher.dispatch(action, currentModifierState)
                         modifierState = result.modifierState
@@ -778,11 +811,30 @@ fun TerminalScreen(
 
                     Spacer(modifier = Modifier.height(6.dp))
                     if (selectedTab == ConnectionTab.Terminal) {
+                        AnimatedVisibility(visible = chuchuKeys.isPrefixActive, enter = fadeIn(), exit = fadeOut()) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 10.dp, vertical = 4.dp)
+                                    .background(colors.surface)
+                                    .border(1.dp, colors.border)
+                                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                ChuText("⌘ key", style = typography.label, color = colors.accent)
+                                chuchuKeys.hints().forEach { hint ->
+                                    ChuText("${hint.key}: ${hint.description}", style = typography.labelSmall, color = colors.textSecondary)
+                                }
+                            }
+                        }
                         KeyboardAccessoryBar(
                             items = accessoryLayout,
                             modifierState = modifierState,
                             onAction = ::dispatchAccessoryAction,
                             onSettings = onOpenSettings,
+                            onChuchuKey = { chuchuKeys.togglePrefix() },
+                            chuchuKeyActive = chuchuKeys.isPrefixActive,
                             onOpenFiles = { vm.selectConnectionTab(ConnectionTab.Files) },
                             useSingleRow = useSingleRowAccessoryBar,
                             modifier = Modifier.padding(bottom = 2.dp),

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -255,6 +255,9 @@ fun TerminalScreen(
     val screenInsetsModifier = modifier.windowInsetsPadding(WindowInsets.safeDrawing)
     var lastSessionStatus by remember { mutableStateOf<SessionStatus?>(null) }
     val settingsRepo = remember(context) { SettingsRepository.getInstance(context) }
+    val terminalPrefs = remember(context) {
+        context.getSharedPreferences("chuchu_terminal", Context.MODE_PRIVATE)
+    }
     val currentTheme by settingsRepo.themeName.collectAsStateWithLifecycle()
     val currentAccessoryLayoutIds by settingsRepo.accessoryLayoutIds.collectAsStateWithLifecycle()
     val useSingleRowAccessoryBar by settingsRepo.accessoryBarSingleRow.collectAsStateWithLifecycle()
@@ -499,17 +502,7 @@ fun TerminalScreen(
                             clipboard?.removePrimaryClipChangedListener(listener)
                         }
                     }
-                    val terminalPrefs = remember(context) {
-                        context.getSharedPreferences("chuchu_terminal", Context.MODE_PRIVATE)
-                    }
                     var modifierState by remember { mutableStateOf(ModifierState()) }
-                    var terminalFontSizeSp by remember {
-                        mutableStateOf(terminalPrefs.getFloat("terminal_font_size_sp", 14f).coerceAtLeast(0.1f))
-                    }
-
-                    LaunchedEffect(terminalFontSizeSp) {
-                        terminalPrefs.edit().putFloat("terminal_font_size_sp", terminalFontSizeSp).apply()
-                    }
 
                     fun resetModifiers() {
                         modifierState = modifierState.reset()
@@ -711,14 +704,6 @@ fun TerminalScreen(
                             }
                             if (pwdText != null) {
                                 ChuText(text = pwdText, style = typography.labelSmall, color = colors.textPrimary.copy(alpha = 0.7f))
-                            }
-                            ChuButton(
-                                onClick = { showTabSheet = true },
-                                variant = ChuButtonVariant.Outlined,
-                                bracketed = true,
-                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
-                            ) {
-                                ChuText("+", style = typography.label, color = colors.accent)
                             }
                         }
 
@@ -989,11 +974,17 @@ private fun TabSwitcherOverlay(
                 modifier = Modifier
                     .fillMaxSize()
                     .windowInsetsPadding(WindowInsets.safeDrawing)
-                    .padding(12.dp)
+                    .padding(vertical = 12.dp)
                     .clickable(enabled = false) {},
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     ChuText("tabs", style = typography.title)
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                         ChuButton(onClick = onDismiss, variant = ChuButtonVariant.Outlined, bracketed = true, contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp)) {
@@ -1006,20 +997,31 @@ private fun TabSwitcherOverlay(
                 }
 
                 val rows = remember(labeledTabs) { labeledTabs.chunked(2) }
-                androidx.compose.foundation.lazy.LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                androidx.compose.foundation.lazy.LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
                     items(rows.size) { rowIndex ->
                         val row = rows[rowIndex]
-                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth().height(208.dp)) {
                             row.forEach { (tab, label) ->
                                 val isActive = tab.id == activeTabId
+                                val isFocused = tab.id == focusedTabId
                                 val state = tab.sessionState.value
                                 Column(
                                     modifier = Modifier
                                         .weight(1f)
+                                        .fillMaxHeight()
                                         .background(if (isActive) colors.surface else colors.surfaceVariant)
                                         .border(
-                                            2.dp,
-                                            if (isActive) colors.accent else colors.border.copy(alpha = 0.55f),
+                                            1.dp,
+                                            when {
+                                                isFocused -> colors.accent
+                                                isActive -> colors.textPrimary
+                                                else -> colors.border.copy(alpha = 0.55f)
+                                            },
                                         )
                                         .clickable { onSelectTab(tab.id) },
                                     verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -1027,7 +1029,7 @@ private fun TabSwitcherOverlay(
                                     Row(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(horizontal = 8.dp, vertical = 6.dp),
+                                            .padding(horizontal = 6.dp, vertical = 2.dp),
                                         horizontalArrangement = Arrangement.SpaceBetween,
                                         verticalAlignment = Alignment.CenterVertically,
                                     ) {
@@ -1091,6 +1093,17 @@ private fun TabSwitcherOverlay(
                         }
                     }
                 }
+                KeyboardAccessoryBar(
+                    items = accessoryItems,
+                    modifierState = accessoryModifierState,
+                    onAction = onAccessoryAction,
+                    onChuchuKey = onChuchuKey,
+                    chuchuKeyActive = chuchuKeyActive,
+                    onOpenFiles = onOpenFiles,
+                    onSettings = onOpenSettings,
+                    useSingleRow = useSingleRowAccessoryBar,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 2.dp),
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -481,6 +482,12 @@ fun TerminalScreen(
                             view.showKeyboard(inputMethodManager)
                         }
                     }
+                    val hideSoftKeyboard: () -> Unit = {
+                        val view = inputViewRef.value
+                        if (view != null) {
+                            inputMethodManager?.hideSoftInputFromWindow(view.windowToken, 0)
+                        }
+                    }
                     val clipboard = remember {
                         context.getSystemService(ClipboardManager::class.java)
                     }
@@ -761,6 +768,24 @@ fun TerminalScreen(
                                         var shouldForwardToTerminal = true
                                         if (showTabSheet && tabsForHost.isNotEmpty()) {
                                             var consumedByTabSwitcher = true
+                                            val isPress = action == GhosttyKeyAction.Press
+                                            if (isPress && chuchuKeys.isPrefixActive) {
+                                                when (codepoint.toChar().lowercaseChar()) {
+                                                    'n' -> {
+                                                        vm.duplicateActiveTab()
+                                                        vm.selectConnectionTab(ConnectionTab.Terminal)
+                                                        showTabSheet = false
+                                                    }
+                                                    't' -> {
+                                                        showTabSheet = true
+                                                    }
+                                                    else -> {
+                                                    }
+                                                }
+                                                chuchuKeys.reset()
+                                                shouldForwardToTerminal = false
+                                                consumedByTabSwitcher = true
+                                            }
                                             when (key) {
                                                 TerminalSpecialKey.Left.engineKey,
                                                 TerminalSpecialKey.Up.engineKey,
@@ -855,7 +880,10 @@ fun TerminalScreen(
                             modifierState = modifierState,
                             onAction = ::dispatchAccessoryAction,
                             onSettings = onOpenSettings,
-                            onChuchuKey = { chuchuKeys.togglePrefix() },
+                            onChuchuKey = {
+                                chuchuKeys.togglePrefix()
+                                requestInputFocus()
+                            },
                             chuchuKeyActive = chuchuKeys.isPrefixActive,
                             onOpenFiles = { vm.selectConnectionTab(ConnectionTab.Files) },
                             useSingleRow = useSingleRowAccessoryBar,
@@ -871,38 +899,48 @@ fun TerminalScreen(
                     UploadProgressDialog(progress = uploadProgress)
                 }
                 if (showTabSheet) {
-                    val overlayAccessoryAction: (AccessoryAction) -> Unit = { action ->
-                        val result = TerminalAccessoryDispatcher.dispatch(action, ModifierState())
-                        when (result.specialKey) {
-                            TerminalSpecialKey.Left, TerminalSpecialKey.Up -> {
-                                if (tabsForHost.isNotEmpty()) focusedTabIndex = (focusedTabIndex - 1).mod(tabsForHost.size)
+                    val paletteAccessoryAction: (AccessoryAction) -> Unit = { action ->
+                        if (!(action is AccessoryAction.SendText && chuchuKeys.handleText(action.text))) {
+                            if (chuchuKeys.isPrefixActive) {
+                                chuchuKeys.reset()
                             }
-                            TerminalSpecialKey.Right, TerminalSpecialKey.Down -> {
-                                if (tabsForHost.isNotEmpty()) focusedTabIndex = (focusedTabIndex + 1).mod(tabsForHost.size)
-                            }
-                            TerminalSpecialKey.Enter -> {
-                                tabsForHost.getOrNull(focusedTabIndex)?.let {
-                                    vm.selectTab(it.id)
+                            val result = TerminalAccessoryDispatcher.dispatch(action, ModifierState())
+                            when (result.specialKey) {
+                                TerminalSpecialKey.Left, TerminalSpecialKey.Up -> {
+                                    if (tabsForHost.isNotEmpty()) focusedTabIndex = (focusedTabIndex - 1).mod(tabsForHost.size)
+                                }
+                                TerminalSpecialKey.Right, TerminalSpecialKey.Down -> {
+                                    if (tabsForHost.isNotEmpty()) focusedTabIndex = (focusedTabIndex + 1).mod(tabsForHost.size)
+                                }
+                                TerminalSpecialKey.Enter -> {
+                                    tabsForHost.getOrNull(focusedTabIndex)?.let {
+                                        vm.selectTab(it.id)
+                                        showTabSheet = false
+                                    }
+                                }
+                                TerminalSpecialKey.Escape -> {
                                     showTabSheet = false
                                 }
-                            }
-                            TerminalSpecialKey.Escape -> {
-                                showTabSheet = false
-                            }
-                            else -> {
-                                result.text?.let { vm.onTextInput(it) }
+                                else -> {
+                                    result.text?.let { text ->
+                                        if (!chuchuKeys.handleText(text)) {
+                                            vm.onTextInput(text)
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
-                    TabSwitcherOverlay(
+                    CommandPalette(
                         tabs = tabsForHost,
                         activeTabId = activeTabId,
-                        focusedTabId = tabsForHost.getOrNull(focusedTabIndex)?.id,
-                        terminalFontSizeSp = terminalFontSizeSp,
+                        focusedTabIndex = focusedTabIndex,
+                        onFocusedTabIndexChange = { focusedTabIndex = it },
                         accessoryItems = accessoryLayout,
-                        accessoryModifierState = ModifierState(),
-                        onAccessoryAction = overlayAccessoryAction,
-                        onChuchuKey = { chuchuKeys.togglePrefix() },
+                        onAccessoryAction = paletteAccessoryAction,
+                        onChuchuKey = {
+                            chuchuKeys.togglePrefix()
+                        },
                         chuchuKeyActive = chuchuKeys.isPrefixActive,
                         onOpenFiles = {
                             vm.selectConnectionTab(ConnectionTab.Files)
@@ -939,190 +977,6 @@ fun TerminalScreen(
     }
 }
 
-@Composable
-private fun TabSwitcherOverlay(
-    tabs: List<TabSession>,
-    activeTabId: String?,
-    focusedTabId: String?,
-    terminalFontSizeSp: Float,
-    accessoryItems: List<AccessoryKeyItem>,
-    accessoryModifierState: ModifierState,
-    onAccessoryAction: (AccessoryAction) -> Unit,
-    onChuchuKey: () -> Unit,
-    chuchuKeyActive: Boolean,
-    onOpenFiles: () -> Unit,
-    onOpenSettings: () -> Unit,
-    useSingleRowAccessoryBar: Boolean,
-    onSelectTab: (String) -> Unit,
-    onCloseTab: (String) -> Unit,
-    onAddTab: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val colors = ChuColors.current
-    val typography = ChuTypography.current
-    val labeledTabs = remember(tabs) {
-        tabs.map { tab -> tab to tabAlias(tab) }
-    }
-    AnimatedVisibility(visible = true, enter = fadeIn() + slideInVertically { it / 5 }, exit = fadeOut() + slideOutVertically { it / 4 }) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(colors.background)
-                .clickable { onDismiss() },
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .windowInsetsPadding(WindowInsets.safeDrawing)
-                    .padding(vertical = 12.dp)
-                    .clickable(enabled = false) {},
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    ChuText("tabs", style = typography.title)
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                        ChuButton(onClick = onDismiss, variant = ChuButtonVariant.Outlined, bracketed = true, contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp)) {
-                            ChuText("done", style = typography.label, color = colors.textMuted)
-                        }
-                        ChuButton(onClick = onAddTab, variant = ChuButtonVariant.Outlined, bracketed = true, contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp)) {
-                            ChuText("+", style = typography.label, color = colors.accent)
-                        }
-                    }
-                }
-
-                val rows = remember(labeledTabs) { labeledTabs.chunked(2) }
-                androidx.compose.foundation.lazy.LazyColumn(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    items(rows.size) { rowIndex ->
-                        val row = rows[rowIndex]
-                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth().height(208.dp)) {
-                            row.forEach { (tab, label) ->
-                                val isActive = tab.id == activeTabId
-                                val isFocused = tab.id == focusedTabId
-                                val state = tab.sessionState.value
-                                Column(
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .fillMaxHeight()
-                                        .background(if (isActive) colors.surface else colors.surfaceVariant)
-                                        .border(
-                                            1.dp,
-                                            when {
-                                                isFocused -> colors.accent
-                                                isActive -> colors.textPrimary
-                                                else -> colors.border.copy(alpha = 0.55f)
-                                            },
-                                        )
-                                        .clickable { onSelectTab(tab.id) },
-                                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                                ) {
-                                    Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(horizontal = 6.dp, vertical = 2.dp),
-                                        horizontalArrangement = Arrangement.SpaceBetween,
-                                        verticalAlignment = Alignment.CenterVertically,
-                                    ) {
-                                        ChuText(label, style = typography.label, color = colors.textPrimary)
-                                        if (tabs.size > 1) {
-                                            Box(
-                                                modifier = Modifier
-                                                    .size(26.dp)
-                                                    .clickable { onCloseTab(tab.id) },
-                                                contentAlignment = Alignment.Center,
-                                            ) {
-                                                ChuText("x", style = typography.label, color = colors.textMuted)
-                                            }
-                                        }
-                                    }
-                                    val previewBackground = if (isActive) {
-                                        colors.background.copy(alpha = 0.9f)
-                                    } else {
-                                        colors.background.copy(alpha = 0.75f)
-                                    }
-                                    val snapshot = state.snapshot
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .weight(1f)
-                                            .background(previewBackground)
-                                            .clickable { onSelectTab(tab.id) },
-                                    ) {
-                                        if (snapshot != null) {
-                                            TerminalCanvas(
-                                                snapshot = snapshot,
-                                                fontSizeSp = terminalFontSizeSp,
-                                                fitSnapshotToCanvas = true,
-                                                enableGestures = false,
-                                                cursorColor = Color.Transparent,
-                                                selectionBackgroundColor = Color.Transparent,
-                                                selectionForegroundColor = Color.Transparent,
-                                                onTap = { onSelectTab(tab.id) },
-                                                onPrimaryClick = { _, _ -> onSelectTab(tab.id) },
-                                                onScroll = {},
-                                                onZoom = {},
-                                                onSelectionChanged = { _, _, _, _ -> },
-                                                modifier = Modifier.fillMaxSize(),
-                                            )
-                                        } else {
-                                            Column(
-                                                modifier = Modifier.padding(8.dp),
-                                                verticalArrangement = Arrangement.spacedBy(4.dp),
-                                            ) {
-                                                ChuText(tab.spec.notificationLabel, style = typography.labelSmall, color = colors.textMuted)
-                                                ChuText("status: ${state.status}", style = typography.bodySmall, color = colors.textSecondary)
-                                                state.title?.let { ChuText(it, style = typography.bodySmall, color = colors.textPrimary) }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            if (row.size == 1) {
-                                Spacer(modifier = Modifier.weight(1f))
-                            }
-                        }
-                    }
-                }
-                KeyboardAccessoryBar(
-                    items = accessoryItems,
-                    modifierState = accessoryModifierState,
-                    onAction = onAccessoryAction,
-                    onChuchuKey = onChuchuKey,
-                    chuchuKeyActive = chuchuKeyActive,
-                    onOpenFiles = onOpenFiles,
-                    onSettings = onOpenSettings,
-                    useSingleRow = useSingleRowAccessoryBar,
-                    modifier = Modifier.padding(top = 4.dp, bottom = 2.dp),
-                )
-            }
-        }
-    }
-}
-
-private fun tabAlias(tab: TabSession): String {
-    val adjectives = listOf(
-        "amber", "brisk", "cedar", "delta", "ember", "frost", "golden", "hazel",
-        "indigo", "jade", "kilo", "lunar", "mango", "nova", "onyx", "pluto",
-    )
-    val nouns = listOf(
-        "otter", "falcon", "pine", "river", "comet", "harbor", "meadow", "quartz",
-        "signal", "orbit", "anchor", "summit", "thunder", "voyager", "willow", "zenith",
-    )
-    val seed = tab.id.hashCode().let { if (it == Int.MIN_VALUE) 0 else kotlin.math.abs(it) }
-    val adjective = adjectives[seed % adjectives.size]
-    val noun = nouns[(seed / adjectives.size) % nouns.size]
-    return "$adjective-$noun"
-}
 
 @Composable
 private fun UploadProgressDialog(progress: UploadProgress) {

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -21,9 +21,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -49,7 +47,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.alpha
 
 import androidx.compose.ui.geometry.Offset
@@ -93,6 +90,7 @@ import com.jossephus.chuchu.ui.terminal.TerminalAccessoryLayoutStore
 import com.jossephus.chuchu.ui.terminal.TerminalCustomAction
 import com.jossephus.chuchu.ui.terminal.TerminalCustomKeyGroup
 import com.jossephus.chuchu.ui.terminal.TerminalInputView
+import com.jossephus.chuchu.ui.terminal.TerminalSpecialKey
 import com.jossephus.chuchu.ui.terminal.CustomActionModifier
 import com.jossephus.chuchu.ui.terminal.decodeCustomActionValue
 import com.jossephus.chuchu.ui.terminal.modifierStateForCustomAction
@@ -344,6 +342,12 @@ fun TerminalScreen(
         if (hasSeenTabsForHost && tabsForHost.isEmpty()) {
             onBack()
         }
+    }
+
+    LaunchedEffect(showTabSheet, tabsForHost, activeTabId) {
+        if (!showTabSheet || tabsForHost.isEmpty()) return@LaunchedEffect
+        val activeIndex = tabsForHost.indexOfFirst { it.id == activeTabId }
+        focusedTabIndex = if (activeIndex >= 0) activeIndex else focusedTabIndex.coerceIn(0, tabsForHost.lastIndex)
     }
 
     if (showPassphrasePrompt) {
@@ -763,14 +767,47 @@ fun TerminalScreen(
                             factory = { viewContext ->
                                 TerminalInputView(viewContext).apply {
                                     onTerminalText = { text ->
-                                        vm.dispatchTextWithModifierState(text, modifierState)
-                                        resetModifiers()
+                                        if (!chuchuKeys.handleText(text)) {
+                                            vm.dispatchTextWithModifierState(text, modifierState)
+                                            resetModifiers()
+                                        }
                                     }
                                     onTerminalKey = { key, codepoint, mods, action ->
-                                        val mergedMods = mods or modifierState.terminalMods()
-                                        vm.onHardwareKey(key, codepoint, mergedMods, action)
-                                        if (modifierState.hasActiveModifiers()) {
-                                            resetModifiers()
+                                        var shouldForwardToTerminal = true
+                                        if (showTabSheet && tabsForHost.isNotEmpty()) {
+                                            var consumedByTabSwitcher = true
+                                            when (key) {
+                                                TerminalSpecialKey.Left.engineKey,
+                                                TerminalSpecialKey.Up.engineKey,
+                                                -> focusedTabIndex = (focusedTabIndex - 1).mod(tabsForHost.size)
+
+                                                TerminalSpecialKey.Right.engineKey,
+                                                TerminalSpecialKey.Down.engineKey,
+                                                -> focusedTabIndex = (focusedTabIndex + 1).mod(tabsForHost.size)
+
+                                                TerminalSpecialKey.Enter.engineKey -> {
+                                                    tabsForHost.getOrNull(focusedTabIndex)?.let {
+                                                        vm.selectTab(it.id)
+                                                        showTabSheet = false
+                                                    }
+                                                }
+
+                                                TerminalSpecialKey.Escape.engineKey -> {
+                                                    showTabSheet = false
+                                                }
+
+                                                else -> consumedByTabSwitcher = false
+                                            }
+                                            if (consumedByTabSwitcher) {
+                                                shouldForwardToTerminal = false
+                                            }
+                                        }
+                                        if (shouldForwardToTerminal) {
+                                            val mergedMods = mods or modifierState.terminalMods()
+                                            vm.onHardwareKey(key, codepoint, mergedMods, action)
+                                            if (modifierState.hasActiveModifiers()) {
+                                                resetModifiers()
+                                            }
                                         }
                                     }
                                     setOnFocusChangeListener { _, hasFocus ->
@@ -849,9 +886,45 @@ fun TerminalScreen(
                     UploadProgressDialog(progress = uploadProgress)
                 }
                 if (showTabSheet) {
+                    val overlayAccessoryAction: (AccessoryAction) -> Unit = { action ->
+                        val result = TerminalAccessoryDispatcher.dispatch(action, ModifierState())
+                        when (result.specialKey) {
+                            TerminalSpecialKey.Left, TerminalSpecialKey.Up -> {
+                                if (tabsForHost.isNotEmpty()) focusedTabIndex = (focusedTabIndex - 1).mod(tabsForHost.size)
+                            }
+                            TerminalSpecialKey.Right, TerminalSpecialKey.Down -> {
+                                if (tabsForHost.isNotEmpty()) focusedTabIndex = (focusedTabIndex + 1).mod(tabsForHost.size)
+                            }
+                            TerminalSpecialKey.Enter -> {
+                                tabsForHost.getOrNull(focusedTabIndex)?.let {
+                                    vm.selectTab(it.id)
+                                    showTabSheet = false
+                                }
+                            }
+                            TerminalSpecialKey.Escape -> {
+                                showTabSheet = false
+                            }
+                            else -> {
+                                result.text?.let { vm.onTextInput(it) }
+                            }
+                        }
+                    }
                     TabSwitcherOverlay(
                         tabs = tabsForHost,
                         activeTabId = activeTabId,
+                        focusedTabId = tabsForHost.getOrNull(focusedTabIndex)?.id,
+                        terminalFontSizeSp = terminalFontSizeSp,
+                        accessoryItems = accessoryLayout,
+                        accessoryModifierState = ModifierState(),
+                        onAccessoryAction = overlayAccessoryAction,
+                        onChuchuKey = { chuchuKeys.togglePrefix() },
+                        chuchuKeyActive = chuchuKeys.isPrefixActive,
+                        onOpenFiles = {
+                            vm.selectConnectionTab(ConnectionTab.Files)
+                            showTabSheet = false
+                        },
+                        onOpenSettings = onOpenSettings,
+                        useSingleRowAccessoryBar = useSingleRowAccessoryBar,
                         onSelectTab = {
                             vm.selectTab(it)
                             showTabSheet = false
@@ -885,6 +958,16 @@ fun TerminalScreen(
 private fun TabSwitcherOverlay(
     tabs: List<TabSession>,
     activeTabId: String?,
+    focusedTabId: String?,
+    terminalFontSizeSp: Float,
+    accessoryItems: List<AccessoryKeyItem>,
+    accessoryModifierState: ModifierState,
+    onAccessoryAction: (AccessoryAction) -> Unit,
+    onChuchuKey: () -> Unit,
+    chuchuKeyActive: Boolean,
+    onOpenFiles: () -> Unit,
+    onOpenSettings: () -> Unit,
+    useSingleRowAccessoryBar: Boolean,
     onSelectTab: (String) -> Unit,
     onCloseTab: (String) -> Unit,
     onAddTab: () -> Unit,
@@ -969,35 +1052,26 @@ private fun TabSwitcherOverlay(
                                     Box(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .height(150.dp)
+                                            .weight(1f)
                                             .background(previewBackground)
                                             .clickable { onSelectTab(tab.id) },
                                     ) {
                                         if (snapshot != null) {
-                                            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                                                val widthDp = maxWidth.value.coerceAtLeast(1f)
-                                                val heightDp = maxHeight.value.coerceAtLeast(1f)
-                                                val cols = snapshot.cols.coerceAtLeast(1)
-                                                val rows = snapshot.rows.coerceAtLeast(1)
-                                                val charAspect = 2.05f
-                                                val byWidth = widthDp / cols.toFloat()
-                                                val byHeight = (heightDp / rows.toFloat()) / charAspect
-                                                val previewFontSizeSp = minOf(byWidth, byHeight).coerceIn(2.8f, 6.5f)
-                                                TerminalCanvas(
-                                                    snapshot = snapshot,
-                                                    fontSizeSp = previewFontSizeSp,
-                                                    cursorColor = Color.Transparent,
-                                                    selectionBackgroundColor = Color.Transparent,
-                                                    onTap = { onSelectTab(tab.id) },
-                                                    onPrimaryClick = { _, _ -> onSelectTab(tab.id) },
-                                                    onScroll = {},
-                                                    onZoom = {},
-                                                    onSelectionChanged = { _, _, _, _ -> },
-                                                    modifier = Modifier
-                                                        .fillMaxSize()
-                                                        .clip(RectangleShape),
-                                                )
-                                            }
+                                            TerminalCanvas(
+                                                snapshot = snapshot,
+                                                fontSizeSp = terminalFontSizeSp,
+                                                fitSnapshotToCanvas = true,
+                                                enableGestures = false,
+                                                cursorColor = Color.Transparent,
+                                                selectionBackgroundColor = Color.Transparent,
+                                                selectionForegroundColor = Color.Transparent,
+                                                onTap = { onSelectTab(tab.id) },
+                                                onPrimaryClick = { _, _ -> onSelectTab(tab.id) },
+                                                onScroll = {},
+                                                onZoom = {},
+                                                onSelectionChanged = { _, _, _, _ -> },
+                                                modifier = Modifier.fillMaxSize(),
+                                            )
                                         } else {
                                             Column(
                                                 modifier = Modifier.padding(8.dp),

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -786,27 +786,29 @@ fun TerminalScreen(
                                                 shouldForwardToTerminal = false
                                                 consumedByTabSwitcher = true
                                             }
-                                            when (key) {
-                                                TerminalSpecialKey.Left.engineKey,
-                                                TerminalSpecialKey.Up.engineKey,
-                                                -> focusedTabIndex = (focusedTabIndex - 1).mod(tabsForHost.size)
+                                            if (isPress) {
+                                                when (key) {
+                                                    TerminalSpecialKey.Left.engineKey,
+                                                    TerminalSpecialKey.Up.engineKey,
+                                                    -> focusedTabIndex = (focusedTabIndex - 1).mod(tabsForHost.size)
 
-                                                TerminalSpecialKey.Right.engineKey,
-                                                TerminalSpecialKey.Down.engineKey,
-                                                -> focusedTabIndex = (focusedTabIndex + 1).mod(tabsForHost.size)
+                                                    TerminalSpecialKey.Right.engineKey,
+                                                    TerminalSpecialKey.Down.engineKey,
+                                                    -> focusedTabIndex = (focusedTabIndex + 1).mod(tabsForHost.size)
 
-                                                TerminalSpecialKey.Enter.engineKey -> {
-                                                    tabsForHost.getOrNull(focusedTabIndex)?.let {
-                                                        vm.selectTab(it.id)
+                                                    TerminalSpecialKey.Enter.engineKey -> {
+                                                        tabsForHost.getOrNull(focusedTabIndex)?.let {
+                                                            vm.selectTab(it.id)
+                                                            showTabSheet = false
+                                                        }
+                                                    }
+
+                                                    TerminalSpecialKey.Escape.engineKey -> {
                                                         showTabSheet = false
                                                     }
-                                                }
 
-                                                TerminalSpecialKey.Escape.engineKey -> {
-                                                    showTabSheet = false
+                                                    else -> consumedByTabSwitcher = false
                                                 }
-
-                                                else -> consumedByTabSwitcher = false
                                             }
                                             if (consumedByTabSwitcher) {
                                                 shouldForwardToTerminal = false

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/ChuchuKeyBindings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/ChuchuKeyBindings.kt
@@ -1,0 +1,36 @@
+package com.jossephus.chuchu.ui.terminal
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+data class ChuchuHint(
+    val key: String,
+    val description: String,
+)
+
+class ChuchuKeyBindings(
+    private val hints: List<ChuchuHint>,
+    private val handlers: Map<Char, () -> Unit>,
+) {
+    var isPrefixActive: Boolean by mutableStateOf(false)
+        private set
+
+    fun togglePrefix() {
+        isPrefixActive = !isPrefixActive
+    }
+
+    fun reset() {
+        isPrefixActive = false
+    }
+
+    fun handleText(text: String): Boolean {
+        if (!isPrefixActive || text.isBlank()) return false
+        val key = text.first().lowercaseChar()
+        handlers[key]?.invoke()
+        isPrefixActive = false
+        return true
+    }
+
+    fun hints(): List<ChuchuHint> = hints
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
@@ -31,8 +31,12 @@ fun KeyboardAccessoryBar(
     modifierState: ModifierState,
     onAction: (AccessoryAction) -> Unit,
     onSettings: (() -> Unit)? = null,
+    onChuchuKey: (() -> Unit)? = null,
+    chuchuKeyActive: Boolean = false,
     onOpenFiles: (() -> Unit)? = null,
     useSingleRow: Boolean = false,
+    horizontalPadding: Dp = 8.dp,
+    verticalPadding: Dp = 6.dp,
     modifier: Modifier = Modifier,
 ) {
     val buttonHeight = 30.dp
@@ -42,7 +46,7 @@ fun KeyboardAccessoryBar(
         Row(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 6.dp)
+                .padding(horizontal = horizontalPadding, vertical = verticalPadding)
                 .horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -57,6 +61,8 @@ fun KeyboardAccessoryBar(
                 )
             }
             FilesButton(
+                onChuchuKey = onChuchuKey,
+                chuchuKeyActive = chuchuKeyActive,
                 onOpenFiles = onOpenFiles,
                 buttonHeight = buttonHeight,
                 buttonPadding = buttonPadding,
@@ -73,7 +79,7 @@ fun KeyboardAccessoryBar(
     FlowRow(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 6.dp),
+            .padding(horizontal = horizontalPadding, vertical = verticalPadding),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
         maxLines = 2,
@@ -88,6 +94,8 @@ fun KeyboardAccessoryBar(
             )
         }
         FilesButton(
+            onChuchuKey = onChuchuKey,
+            chuchuKeyActive = chuchuKeyActive,
             onOpenFiles = onOpenFiles,
             buttonHeight = buttonHeight,
             buttonPadding = buttonPadding,
@@ -132,12 +140,28 @@ private fun AccessoryButton(
 
 @Composable
 private fun FilesButton(
+    onChuchuKey: (() -> Unit)?,
+    chuchuKeyActive: Boolean,
     onOpenFiles: (() -> Unit)?,
     buttonHeight: Dp,
     buttonPadding: PaddingValues,
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
+    if (onChuchuKey != null) {
+        ChuButton(
+            onClick = onChuchuKey,
+            variant = if (chuchuKeyActive) ChuButtonVariant.Filled else ChuButtonVariant.Outlined,
+            modifier = Modifier.height(buttonHeight),
+            contentPadding = buttonPadding,
+        ) {
+            ChuText(
+                "⌘",
+                style = typography.label,
+                color = if (chuchuKeyActive) colors.onAccent else colors.textPrimary,
+            )
+        }
+    }
     if (onOpenFiles == null) return
     ChuButton(
         onClick = onOpenFiles,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -50,6 +50,8 @@ fun TerminalCanvas(
     snapshot: TerminalSnapshot,
     modifier: Modifier = Modifier,
     fontSizeSp: Float = 14f,
+    fitSnapshotToCanvas: Boolean = false,
+    enableGestures: Boolean = true,
     cursorColor: Color = Color.White.copy(alpha = 0.28f),
     cursorTextColor: Color? = null,
     selectionBackgroundColor: Color = Color(0x663B82F6),
@@ -189,168 +191,191 @@ fun TerminalCanvas(
         }
     }
 
-    Canvas(
-        modifier = modifier
-            .fillMaxSize()
-            .onSizeChanged { size ->
-                canvasSize = size
-            }
-            .pointerInput(cellWidthPx, cellHeightPx, selectionResetKey) {
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    var dragRemainder = 0f
-                    var lastPinchDistance: Float? = null
-                    var didScroll = false
-                    var didPinch = false
-                    var didDragGesture = false
-                    var didSelect = false
-                    var selectionCleared = false
-                    var lastSinglePointerId = down.id
-                    var longPressActive = false
-                    var lastEventUptime = down.uptimeMillis
-                    val longPressDeadline = down.uptimeMillis + longPressTimeoutMillis
+    val canvasModifier = modifier
+        .fillMaxSize()
+        .onSizeChanged { size ->
+            canvasSize = size
+        }
+        .let { baseModifier ->
+            if (!enableGestures) {
+                baseModifier
+            } else {
+                baseModifier.pointerInput(cellWidthPx, cellHeightPx, selectionResetKey) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        var dragRemainder = 0f
+                        var lastPinchDistance: Float? = null
+                        var didScroll = false
+                        var didPinch = false
+                        var didDragGesture = false
+                        var didSelect = false
+                        var selectionCleared = false
+                        var lastSinglePointerId = down.id
+                        var longPressActive = false
+                        var lastEventUptime = down.uptimeMillis
+                        val longPressDeadline = down.uptimeMillis + longPressTimeoutMillis
 
-                    while (true) {
-                        val timeoutMs = (longPressDeadline - lastEventUptime).coerceAtLeast(1L)
-                        val event = if (!longPressActive && !didScroll && !didPinch && !didSelect && !didDragGesture) {
-                            withTimeoutOrNull(timeoutMs) { awaitPointerEvent() }
-                        } else {
-                            awaitPointerEvent()
-                        }
-
-                        if (event == null) {
-                            val s = currentSnapshot.value
-                            val selectedCell = s.cellAt(down.position.x, down.position.y, cellWidthPx, cellHeightPx)
-                            selection = selectedCell?.let { TerminalSelection(it, it) }
-                            if (selectedCell != null) {
-                                selectionAnchorOffset = down.position
-                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                                didSelect = true
-                                longPressActive = true
+                        while (true) {
+                            val timeoutMs = (longPressDeadline - lastEventUptime).coerceAtLeast(1L)
+                            val event = if (!longPressActive && !didScroll && !didPinch && !didSelect && !didDragGesture) {
+                                withTimeoutOrNull(timeoutMs) { awaitPointerEvent() }
+                            } else {
+                                awaitPointerEvent()
                             }
-                            continue
-                        }
 
-                        lastEventUptime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
-                        val pressed = event.changes.filter { it.pressed }
-                        if (pressed.isEmpty()) {
-                            if (didSelect) {
+                            if (event == null) {
+                                val s = currentSnapshot.value
+                                val selectedCell = s.cellAt(down.position.x, down.position.y, cellWidthPx, cellHeightPx)
+                                selection = selectedCell?.let { TerminalSelection(it, it) }
+                                if (selectedCell != null) {
+                                    selectionAnchorOffset = down.position
+                                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    didSelect = true
+                                    longPressActive = true
+                                }
+                                continue
+                            }
+
+                            lastEventUptime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
+                            val pressed = event.changes.filter { it.pressed }
+                            if (pressed.isEmpty()) {
+                                if (didSelect) {
+                                    break
+                                }
+                                if (!didScroll && !didPinch && !didDragGesture) {
+                                    val tapTime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
+                                    val tapPos = down.position
+                                    val timeSinceLastTap = tapTime - doubleTapState.lastTime
+                                    val distSinceLastTap = hypot(
+                                        (tapPos.x - doubleTapState.lastPos.x).toDouble(),
+                                        (tapPos.y - doubleTapState.lastPos.y).toDouble(),
+                                    ).toFloat()
+                                    doubleTapState.lastTime = tapTime
+                                    doubleTapState.lastPos = tapPos
+
+                                    if (timeSinceLastTap < doubleTapTimeoutMillis && distSinceLastTap < doubleTapSlopPx) {
+                                        val s = currentSnapshot.value
+                                        val cellIdx = s.cellAt(tapPos.x, tapPos.y, cellWidthPx, cellHeightPx)
+                                        if (cellIdx != null) {
+                                            val wordRange = s.wordAt(cellIdx)
+                                            if (wordRange != null) {
+                                                selection = TerminalSelection(wordRange.first, wordRange.last)
+                                                selectionAnchorOffset = tapPos
+                                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                            }
+                                        }
+                                    } else {
+                                        if (selection != null) {
+                                            selection = null
+                                            selectionAnchorOffset = Offset.Zero
+                                        }
+                                        onPrimaryClick(tapPos.x, tapPos.y)
+                                        onTap()
+                                    }
+                                }
                                 break
                             }
-                            if (!didScroll && !didPinch && !didDragGesture) {
-                                val tapTime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
-                                val tapPos = down.position
-                                val timeSinceLastTap = tapTime - doubleTapState.lastTime
-                                val distSinceLastTap = hypot(
-                                    (tapPos.x - doubleTapState.lastPos.x).toDouble(),
-                                    (tapPos.y - doubleTapState.lastPos.y).toDouble(),
+
+                            if (pressed.size >= 2) {
+                                didPinch = true
+                                val first = pressed[0].position
+                                val second = pressed[1].position
+                                val distance = hypot(
+                                    (first.x - second.x).toDouble(),
+                                    (first.y - second.y).toDouble(),
                                 ).toFloat()
-                                doubleTapState.lastTime = tapTime
-                                doubleTapState.lastPos = tapPos
-
-                                if (timeSinceLastTap < doubleTapTimeoutMillis && distSinceLastTap < doubleTapSlopPx) {
-                                    val s = currentSnapshot.value
-                                    val cellIdx = s.cellAt(tapPos.x, tapPos.y, cellWidthPx, cellHeightPx)
-                                    if (cellIdx != null) {
-                                        val wordRange = s.wordAt(cellIdx)
-                                        if (wordRange != null) {
-                                            selection = TerminalSelection(wordRange.first, wordRange.last)
-                                            selectionAnchorOffset = tapPos
-                                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        }
+                                val previous = lastPinchDistance
+                                if (previous != null && previous > 0f && distance > 0f) {
+                                    val zoomFactor = distance / previous
+                                    if (abs(zoomFactor - 1f) > 0.02f) {
+                                        onZoom(zoomFactor)
                                     }
-                                } else {
-                                    if (selection != null) {
-                                        selection = null
-                                        selectionAnchorOffset = Offset.Zero
-                                    }
-                                    onPrimaryClick(tapPos.x, tapPos.y)
-                                    onTap()
                                 }
+                                lastPinchDistance = distance
+                                pressed.forEach { change ->
+                                    if (change.position != change.previousPosition) change.consume()
+                                }
+                                continue
                             }
-                            break
-                        }
 
-                        if (pressed.size >= 2) {
-                            didPinch = true
-                            val first = pressed[0].position
-                            val second = pressed[1].position
-                            val distance = hypot(
-                                (first.x - second.x).toDouble(),
-                                (first.y - second.y).toDouble(),
+                            lastPinchDistance = null
+                            val change = pressed.firstOrNull { it.id == lastSinglePointerId } ?: pressed.first().also {
+                                lastSinglePointerId = it.id
+                            }
+
+                            // Selection drag takes priority once activated
+                            val s = currentSnapshot.value
+                            val selectedCell = s.cellAt(change.position.x, change.position.y, cellWidthPx, cellHeightPx)
+                            if (longPressActive && selectedCell != null) {
+                                val currentSelection = selection
+                                if (currentSelection == null || currentSelection.focusIndex != selectedCell) {
+                                    selection = (currentSelection ?: TerminalSelection(selectedCell, selectedCell)).copy(focusIndex = selectedCell)
+                                }
+                                if (change.position != change.previousPosition) {
+                                    change.consume()
+                                }
+                                continue
+                            }
+
+                            val dragX = change.position.x - change.previousPosition.x
+                            val dragY = change.position.y - change.previousPosition.y
+                            val movedDistance = hypot(
+                                (change.position.x - down.position.x).toDouble(),
+                                (change.position.y - down.position.y).toDouble(),
                             ).toFloat()
-                            val previous = lastPinchDistance
-                            if (previous != null && previous > 0f && distance > 0f) {
-                                val zoomFactor = distance / previous
-                                if (abs(zoomFactor - 1f) > 0.02f) {
-                                    onZoom(zoomFactor)
+                            if (movedDistance > touchSlopPx) {
+                                didDragGesture = true
+                                if (selection != null && !selectionCleared) {
+                                    selection = null
+                                    selectionAnchorOffset = Offset.Zero
+                                    selectionCleared = true
                                 }
                             }
-                            lastPinchDistance = distance
-                            pressed.forEach { change ->
-                                if (change.position != change.previousPosition) change.consume()
+                            val verticalIntent = abs(dragY) > abs(dragX) * 1.2f
+                            if (verticalIntent) {
+                                dragRemainder += dragY / cellHeightPx
                             }
-                            continue
-                        }
 
-                        lastPinchDistance = null
-                        val change = pressed.firstOrNull { it.id == lastSinglePointerId } ?: pressed.first().also {
-                            lastSinglePointerId = it.id
-                        }
-
-                        // Selection drag takes priority once activated
-                        val s = currentSnapshot.value
-                        val selectedCell = s.cellAt(change.position.x, change.position.y, cellWidthPx, cellHeightPx)
-                        if (longPressActive && selectedCell != null) {
-                            val currentSelection = selection
-                            if (currentSelection == null || currentSelection.focusIndex != selectedCell) {
-                                selection = (currentSelection ?: TerminalSelection(selectedCell, selectedCell)).copy(focusIndex = selectedCell)
+                            if (didDragGesture && abs(dragRemainder) >= 1f) {
+                                val delta = dragRemainder.toInt()
+                                dragRemainder -= delta
+                                if (delta != 0) {
+                                    didScroll = true
+                                    scrollDeltaChannel.trySend(-delta)
+                                }
                             }
+
                             if (change.position != change.previousPosition) {
                                 change.consume()
                             }
-                            continue
-                        }
-
-                        val dragX = change.position.x - change.previousPosition.x
-                        val dragY = change.position.y - change.previousPosition.y
-                        val movedDistance = hypot(
-                            (change.position.x - down.position.x).toDouble(),
-                            (change.position.y - down.position.y).toDouble(),
-                        ).toFloat()
-                        if (movedDistance > touchSlopPx) {
-                            didDragGesture = true
-                            if (selection != null && !selectionCleared) {
-                                selection = null
-                                selectionAnchorOffset = Offset.Zero
-                                selectionCleared = true
-                            }
-                        }
-                        val verticalIntent = abs(dragY) > abs(dragX) * 1.2f
-                        if (verticalIntent) {
-                            dragRemainder += dragY / cellHeightPx
-                        }
-
-                        if (didDragGesture && abs(dragRemainder) >= 1f) {
-                            val delta = dragRemainder.toInt()
-                            dragRemainder -= delta
-                            if (delta != 0) {
-                                didScroll = true
-                                scrollDeltaChannel.trySend(-delta)
-                            }
-                        }
-
-                        if (change.position != change.previousPosition) {
-                            change.consume()
                         }
                     }
                 }
-            },
-    ) {
+            }
+        }
+
+    Canvas(modifier = canvasModifier) {
         val cols = max(snapshot.cols, 1)
         val rows = max(snapshot.rows, 1)
         val cellWidth = cellWidthPx
         val cellHeight = cellHeightPx
+        val contentWidth = cols * cellWidth
+        val contentHeight = rows * cellHeight
+        val previewScale = if (fitSnapshotToCanvas && contentWidth > 0f && contentHeight > 0f) {
+            minOf(size.width / contentWidth, size.height / contentHeight)
+        } else {
+            1f
+        }
+        val contentOffsetX = if (fitSnapshotToCanvas) {
+            ((size.width - (contentWidth * previewScale)) * 0.5f).coerceAtLeast(0f)
+        } else {
+            0f
+        }
+        val contentOffsetY = if (fitSnapshotToCanvas) {
+            ((size.height - (contentHeight * previewScale)) * 0.5f).coerceAtLeast(0f)
+        } else {
+            0f
+        }
         val sel = selection?.normalized(snapshot.codepoints.size)
         val selStart = sel?.first ?: -1
         val selEnd = sel?.last ?: -1
@@ -360,6 +385,11 @@ fun TerminalCanvas(
 
         drawIntoCanvas { canvas ->
             val nCanvas = canvas.nativeCanvas
+            nCanvas.save()
+            nCanvas.translate(contentOffsetX, contentOffsetY)
+            if (previewScale != 1f) {
+                nCanvas.scale(previewScale, previewScale)
+            }
             val sb = drawBuffer
             val defaultBg = snapshot.defaultBgArgb
 
@@ -482,6 +512,7 @@ fun TerminalCanvas(
                     }
                 }
             }
+            nCanvas.restore()
         }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -203,6 +203,19 @@ fun TerminalCanvas(
                 baseModifier.pointerInput(cellWidthPx, cellHeightPx, selectionResetKey) {
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
+                        fun toSnapshotSpace(position: Offset, s: TerminalSnapshot): Offset {
+                            if (!fitSnapshotToCanvas) return position
+                            val cols = max(s.cols, 1)
+                            val rows = max(s.rows, 1)
+                            val contentWidth = cols * cellWidthPx
+                            val contentHeight = rows * cellHeightPx
+                            if (contentWidth <= 0f || contentHeight <= 0f) return position
+                            val scale = minOf(canvasSize.width / contentWidth, canvasSize.height / contentHeight)
+                            if (scale <= 0f) return position
+                            val offsetX = ((canvasSize.width - (contentWidth * scale)) * 0.5f).coerceAtLeast(0f)
+                            val offsetY = ((canvasSize.height - (contentHeight * scale)) * 0.5f).coerceAtLeast(0f)
+                            return Offset((position.x - offsetX) / scale, (position.y - offsetY) / scale)
+                        }
                         var dragRemainder = 0f
                         var lastPinchDistance: Float? = null
                         var didScroll = false
@@ -225,10 +238,11 @@ fun TerminalCanvas(
 
                             if (event == null) {
                                 val s = currentSnapshot.value
-                                val selectedCell = s.cellAt(down.position.x, down.position.y, cellWidthPx, cellHeightPx)
+                                val downPos = toSnapshotSpace(down.position, s)
+                                val selectedCell = s.cellAt(downPos.x, downPos.y, cellWidthPx, cellHeightPx)
                                 selection = selectedCell?.let { TerminalSelection(it, it) }
                                 if (selectedCell != null) {
-                                    selectionAnchorOffset = down.position
+                                    selectionAnchorOffset = downPos
                                     haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                                     didSelect = true
                                     longPressActive = true
@@ -244,7 +258,8 @@ fun TerminalCanvas(
                                 }
                                 if (!didScroll && !didPinch && !didDragGesture) {
                                     val tapTime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
-                                    val tapPos = down.position
+                                    val s = currentSnapshot.value
+                                    val tapPos = toSnapshotSpace(down.position, s)
                                     val timeSinceLastTap = tapTime - doubleTapState.lastTime
                                     val distSinceLastTap = hypot(
                                         (tapPos.x - doubleTapState.lastPos.x).toDouble(),
@@ -254,7 +269,6 @@ fun TerminalCanvas(
                                     doubleTapState.lastPos = tapPos
 
                                     if (timeSinceLastTap < doubleTapTimeoutMillis && distSinceLastTap < doubleTapSlopPx) {
-                                        val s = currentSnapshot.value
                                         val cellIdx = s.cellAt(tapPos.x, tapPos.y, cellWidthPx, cellHeightPx)
                                         if (cellIdx != null) {
                                             val wordRange = s.wordAt(cellIdx)
@@ -278,8 +292,9 @@ fun TerminalCanvas(
 
                             if (pressed.size >= 2) {
                                 didPinch = true
-                                val first = pressed[0].position
-                                val second = pressed[1].position
+                                val s = currentSnapshot.value
+                                val first = toSnapshotSpace(pressed[0].position, s)
+                                val second = toSnapshotSpace(pressed[1].position, s)
                                 val distance = hypot(
                                     (first.x - second.x).toDouble(),
                                     (first.y - second.y).toDouble(),
@@ -305,7 +320,10 @@ fun TerminalCanvas(
 
                             // Selection drag takes priority once activated
                             val s = currentSnapshot.value
-                            val selectedCell = s.cellAt(change.position.x, change.position.y, cellWidthPx, cellHeightPx)
+                            val changePos = toSnapshotSpace(change.position, s)
+                            val changePrevPos = toSnapshotSpace(change.previousPosition, s)
+                            val downPos = toSnapshotSpace(down.position, s)
+                            val selectedCell = s.cellAt(changePos.x, changePos.y, cellWidthPx, cellHeightPx)
                             if (longPressActive && selectedCell != null) {
                                 val currentSelection = selection
                                 if (currentSelection == null || currentSelection.focusIndex != selectedCell) {
@@ -317,11 +335,11 @@ fun TerminalCanvas(
                                 continue
                             }
 
-                            val dragX = change.position.x - change.previousPosition.x
-                            val dragY = change.position.y - change.previousPosition.y
+                            val dragX = changePos.x - changePrevPos.x
+                            val dragY = changePos.y - changePrevPos.y
                             val movedDistance = hypot(
-                                (change.position.x - down.position.x).toDouble(),
-                                (change.position.y - down.position.y).toDouble(),
+                                (changePos.x - downPos.x).toDouble(),
+                                (changePos.y - downPos.y).toDouble(),
                             ).toFloat()
                             if (movedDistance > touchSlopPx) {
                                 didDragGesture = true


### PR DESCRIPTION
we now have command pallette for tabs

- **feat: add '⌘' as chuchu leader key**
- **feat: add new tab, tab list shortcuts**
- **fix: ui refinement for tab preview cards**


https://github.com/user-attachments/assets/e7c1db45-e82d-4e63-874f-34f5af32fb0a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal font-size now persists across sessions
  * Quick-key (prefix) system with an in-screen hint row for shortcuts
  * Command Palette overlay for tab selection with live tab previews and keyboard navigation
  * New chuchu (⌘) key button in the accessory toolbar

* **Enhancements**
  * Keyboard-driven tab navigation and selection integrated into overlays
  * Terminal canvas supports optional gesture disabling and snapshot fitting
  * Accessory bar layout/padding made more flexible

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jossephus/chuchu/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->