### PR TITLE
fix: use ssh channel for mosh bootstrap

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/mosh/MoshBootstrapParser.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/mosh/MoshBootstrapParser.kt
@@ -53,11 +53,18 @@ object MoshBootstrapParser {
             }
         }
 
+        val lower = normalized.lowercase()
         return ParseResult.Error(
-            if (normalized.contains("mosh-server", ignoreCase = true)) {
-                "Server output missing valid MOSH CONNECT line"
-            } else {
-                "mosh-server not found on remote host"
+            when {
+                lower.contains("command not found") && lower.contains("mosh-server") -> {
+                    "mosh-server not found on remote host"
+                }
+                normalized.isBlank() -> {
+                    "No MOSH bootstrap output received"
+                }
+                else -> {
+                    "Server output missing valid MOSH CONNECT line"
+                }
             }
         )
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/ssh/NativeSshBridge.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/ssh/NativeSshBridge.kt
@@ -49,6 +49,10 @@ class NativeSshBridge {
         term: String,
     ): Boolean
 
+    external fun nativeOpenExec(handle: Long, command: String): Boolean
+
+    external fun nativeChannelEof(handle: Long): Boolean
+
     external fun nativeResize(
         handle: Long,
         cols: Int,

--- a/android/app/src/main/java/com/jossephus/chuchu/service/ssh/NativeSshService.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/ssh/NativeSshService.kt
@@ -205,6 +205,16 @@ class NativeSshService(
         }
     }
 
+    fun openExec(command: String): Boolean {
+        check(handle != 0L) { "Not connected" }
+        return bridge.nativeOpenExec(handle, command)
+    }
+
+    fun isChannelEof(): Boolean {
+        if (handle == 0L) return true
+        return bridge.nativeChannelEof(handle)
+    }
+
     fun resize(cols: Int, rows: Int, widthPx: Int, heightPx: Int) {
         if (handle == 0L) return
         if (!bridge.nativeResize(handle, cols, rows, widthPx, heightPx)) {

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -631,7 +631,6 @@ class TerminalSessionEngine(
                 val chunk = nativeSsh.read(4096)
                 if (chunk != null && chunk.isNotEmpty()) {
                     val text = String(chunk, Charsets.UTF_8)
-                    Log.d("TerminalSession", "MOSH: SSH chunk: ${text.take(200)}")
                     outputBuffer.append(text)
                     val result = MoshBootstrapParser.parse(params.host, outputBuffer.toString())
                     if (result is MoshBootstrapParser.ParseResult.Success) {
@@ -649,7 +648,6 @@ class TerminalSessionEngine(
                                     put("useNetworkCrypto", true)
                                 }
                                 .toString()
-                        Log.d("TerminalSession", "MOSH: Creating mosh client with JSON: $configJson")
                         if (!moshService.create(configJson)) {
                             throw IllegalStateException("Failed to create mosh client")
                         }
@@ -691,13 +689,6 @@ class TerminalSessionEngine(
                 } else {
                     rawOutput.trim()
                 }
-            val outputPreview =
-                if (rawOutput.isBlank()) {
-                    "<empty>"
-                } else {
-                    rawOutput.replace("\r", "\\r").replace("\n", "\\n").take(500)
-                }
-            Log.e("TerminalSession", "MOSH: Bootstrap raw output preview: $outputPreview")
             Log.e("TerminalSession", "MOSH: Bootstrap failed: $reason")
             throw IllegalStateException(reason)
         }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -606,67 +606,98 @@ class TerminalSessionEngine(
             privateKeyPem = params.privateKeyPem,
             keyPassphrase = params.keyPassphrase,
         )
-        nativeSsh.openShell(cols, rows, screenWidth, screenHeight)
-        Log.d("TerminalSession", "MOSH: SSH connected, shell opened")
+        // Use exec channel to bypass shell init noise and MOTD.
+        // Falls back to shell if the remote server doesn't support exec.
+        val moshCommand = "env LANG=C.UTF-8 LC_ALL=C.UTF-8 mosh-server new -s -c 256"
+        val execOpened = runCatching { nativeSsh.openExec(moshCommand) }.getOrDefault(false)
+        if (!execOpened) {
+            Log.w("TerminalSession", "MOSH: exec channel unavailable, falling back to shell")
+            nativeSsh.openShell(cols, rows, screenWidth, screenHeight)
+            val fallback = "$moshCommand\n"
+            nativeSsh.write(fallback.toByteArray(Charsets.UTF_8))
+        }
+        Log.d(
+            "TerminalSession",
+            "MOSH: SSH connected, ${if (execOpened) "exec" else "shell"} channel opened",
+        )
 
-        // Send the mosh-server command and collect output
-        val command = "mosh-server new -s -c 256 -l LC_ALL=en_US.UTF-8\n"
-        nativeSsh.write(command.toByteArray(Charsets.UTF_8))
-        Log.d("TerminalSession", "MOSH: Sent mosh-server command")
-
-        // Read output until we find MOSH CONNECT or timeout
+        // Read output until we find MOSH CONNECT, the channel hits EOF, or
+        // we time out. If the first window has no output and no EOF on exec,
+        // extend once to distinguish slow remote bootstrap from hard failure.
         val outputBuffer = StringBuilder()
-        val deadline = System.currentTimeMillis() + 10_000
-        var found = false
-        while (System.currentTimeMillis() < deadline) {
-            val chunk = nativeSsh.read(4096)
-            if (chunk != null && chunk.isNotEmpty()) {
-                val text = String(chunk, Charsets.UTF_8)
-                Log.d("TerminalSession", "MOSH: SSH chunk: ${text.take(200)}")
-                outputBuffer.append(text)
-                val result = MoshBootstrapParser.parse(params.host, outputBuffer.toString())
-                if (result is MoshBootstrapParser.ParseResult.Success) {
-                    found = true
-                    Log.d(
-                        "TerminalSession",
-                        "MOSH: Parsed endpoint host=${result.endpoint.host} port=${result.endpoint.port}",
-                    )
-                    nativeSsh.close()
-
-                    val configJson =
-                        JSONObject()
-                            .apply {
-                                put("host", result.endpoint.host)
-                                put("port", result.endpoint.port)
-                                put("keyBase64_22", result.endpoint.key)
-                                put("useNetworkCrypto", true)
-                            }
-                            .toString()
-                    Log.d("TerminalSession", "MOSH: Creating mosh client with JSON: $configJson")
-                    if (!moshService.create(configJson)) {
-                        throw IllegalStateException("Failed to create mosh client")
+        suspend fun readBootstrapWindow(timeoutMs: Long): Boolean {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (System.currentTimeMillis() < deadline) {
+                val chunk = nativeSsh.read(4096)
+                if (chunk != null && chunk.isNotEmpty()) {
+                    val text = String(chunk, Charsets.UTF_8)
+                    Log.d("TerminalSession", "MOSH: SSH chunk: ${text.take(200)}")
+                    outputBuffer.append(text)
+                    val result = MoshBootstrapParser.parse(params.host, outputBuffer.toString())
+                    if (result is MoshBootstrapParser.ParseResult.Success) {
+                        Log.d(
+                            "TerminalSession",
+                            "MOSH: Parsed endpoint host=${result.endpoint.host} port=${result.endpoint.port}",
+                        )
+                        nativeSsh.close()
+                        val configJson =
+                            JSONObject()
+                                .apply {
+                                    put("host", result.endpoint.host)
+                                    put("port", result.endpoint.port)
+                                    put("keyBase64_22", result.endpoint.key)
+                                    put("useNetworkCrypto", true)
+                                }
+                                .toString()
+                        Log.d("TerminalSession", "MOSH: Creating mosh client with JSON: $configJson")
+                        if (!moshService.create(configJson)) {
+                            throw IllegalStateException("Failed to create mosh client")
+                        }
+                        Log.d("TerminalSession", "MOSH: mosh client created, starting...")
+                        if (!moshService.start()) {
+                            throw IllegalStateException("Failed to start mosh client")
+                        }
+                        Log.d("TerminalSession", "MOSH: mosh client started, resizing $cols x $rows")
+                        moshService.resize(cols, rows)
+                        return true
                     }
-                    Log.d("TerminalSession", "MOSH: mosh client created, starting...")
-                    if (!moshService.start()) {
-                        throw IllegalStateException("Failed to start mosh client")
+                } else {
+                    if (execOpened && nativeSsh.isChannelEof()) {
+                        Log.d("TerminalSession", "MOSH: exec channel EOF reached")
+                        return false
                     }
-                    Log.d("TerminalSession", "MOSH: mosh client started, resizing $cols x $rows")
-                    moshService.resize(cols, rows)
-                    break
+                    delay(50)
                 }
-            } else {
-                delay(50)
             }
+            return false
+        }
+
+        var found = readBootstrapWindow(timeoutMs = 10_000)
+        if (!found && execOpened && outputBuffer.isEmpty() && !nativeSsh.isChannelEof()) {
+            Log.w("TerminalSession", "MOSH: bootstrap still running after 10s with no output; extending window by 15s")
+            found = readBootstrapWindow(timeoutMs = 15_000)
         }
         if (!found) {
+            val eofBeforeClose = if (execOpened) nativeSsh.isChannelEof() else true
             nativeSsh.close()
-            val result = MoshBootstrapParser.parse(params.host, outputBuffer.toString())
+            val rawOutput = outputBuffer.toString()
             val reason =
-                if (result is MoshBootstrapParser.ParseResult.Error) {
-                    result.reason
+                if (rawOutput.isBlank()) {
+                    if (execOpened && !eofBeforeClose) {
+                        "Mosh bootstrap command still running after timeout (no output, no EOF)"
+                    } else {
+                        "Mosh bootstrap produced no output"
+                    }
                 } else {
-                    "Mosh bootstrap timeout"
+                    rawOutput.trim()
                 }
+            val outputPreview =
+                if (rawOutput.isBlank()) {
+                    "<empty>"
+                } else {
+                    rawOutput.replace("\r", "\\r").replace("\n", "\\n").take(500)
+                }
+            Log.e("TerminalSession", "MOSH: Bootstrap raw output preview: $outputPreview")
             Log.e("TerminalSession", "MOSH: Bootstrap failed: $reason")
             throw IllegalStateException(reason)
         }

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -323,23 +323,31 @@ fn readChannel(alloc: std.mem.Allocator, session: *NativeSshSession, max_bytes: 
     const buf = alloc.alloc(u8, cap) catch return null;
     defer alloc.free(buf);
     var total_read: usize = 0;
-    while (true) {
-        const rc = c.libssh2_channel_read_ex(channel, 0, @ptrCast(buf.ptr + total_read), @intCast(buf.len - total_read));
-        if (rc == c.LIBSSH2_ERROR_EAGAIN) {
-            session.empty_reads +%= 1;
-            break;
-        }
-        if (rc == 0) {
-            break;
-        }
-        if (rc < 0) {
-            setLibssh2Error(session, "Read failed", @intCast(rc));
-            return null;
-        }
-        total_read += @intCast(rc);
-        if (total_read >= buf.len) {
+    var stalled_loops: u32 = 0;
+    // Read both stdout and stderr — exec channels may send
+    // diagnostics on stderr, blocking EOF if we ignore it.
+    const streams = [_]c_int{ 0, 1 };
+    for (streams) |stream_id| {
+        while (true) {
+            if (total_read >= buf.len) break;
+            const rc = c.libssh2_channel_read_ex(channel, stream_id, @ptrCast(buf.ptr + total_read), @intCast(buf.len - total_read));
+            if (rc == c.LIBSSH2_ERROR_EAGAIN) {
+                session.empty_reads +%= 1;
+                stalled_loops +%= 1;
+                if (stalled_loops > 16) break;
+                if (!waitSocket(session, io_wait_timeout_ms)) break;
+                continue;
+            }
+            if (rc == 0) {
+                break;
+            }
+            if (rc < 0) {
+                setLibssh2Error(session, "Read failed", @intCast(rc));
+                return null;
+            }
+            total_read += @intCast(rc);
             session.empty_reads = 0;
-            break;
+            stalled_loops = 0;
         }
     }
     if (total_read == 0) {
@@ -752,6 +760,10 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeOpenShell(
             return c.JNI_FALSE;
         }
     }
+    if (session.channel) |old_ch| {
+        _ = c.libssh2_channel_close(old_ch);
+        _ = c.libssh2_channel_free(old_ch);
+    }
     session.channel = channel;
     c.libssh2_channel_set_blocking(channel.?, 0);
     var term_buf = allocator.allocSentinel(u8, term_slice.len, 0) catch {
@@ -795,6 +807,78 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeOpenShell(
     c.libssh2_session_set_blocking(ssh_session, 0);
     c.libssh2_channel_set_blocking(channel.?, 0);
     return c.JNI_TRUE;
+}
+
+export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeOpenExec(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong, command: c.jstring) callconv(.c) c.jboolean {
+    _ = thiz;
+    const session = sessionFromHandle(handle) orelse return c.JNI_FALSE;
+    const ssh_session = session.session orelse {
+        setError(session, "Not connected", .{});
+        return c.JNI_FALSE;
+    };
+    const command_slice = jniDupString(env, command) orelse {
+        setError(session, "Missing exec command", .{});
+        return c.JNI_FALSE;
+    };
+    defer allocator.free(command_slice);
+    // Open a fresh session channel for the exec request. We do NOT request a
+    // PTY here — exec channels for non-interactive commands like
+    // `mosh-server new` should run without a TTY so the server can detach
+    // cleanly, write its output to stdout, and close the channel (giving us
+    // a real EOF signal instead of relying on a deadline).
+    var channel: ?*c.LIBSSH2_CHANNEL = null;
+    while (channel == null) {
+        channel = c.libssh2_channel_open_ex(ssh_session, "session", 7, c.LIBSSH2_CHANNEL_WINDOW_DEFAULT, c.LIBSSH2_CHANNEL_PACKET_DEFAULT, null, 0);
+        if (channel != null) break;
+        const open_rc = c.libssh2_session_last_errno(ssh_session);
+        if (open_rc != c.LIBSSH2_ERROR_EAGAIN) {
+            setLibssh2Error(session, "Channel open failed", open_rc);
+            return c.JNI_FALSE;
+        }
+        if (!waitSocket(session, setup_wait_timeout_ms)) {
+            setError(session, "Channel open timed out", .{});
+            return c.JNI_FALSE;
+        }
+    }
+    c.libssh2_channel_set_blocking(channel.?, 0);
+
+    while (true) {
+        const startup_rc = c.libssh2_channel_process_startup(channel.?, "exec", 4, command_slice.ptr, @intCast(command_slice.len));
+        if (startup_rc == 0) break;
+        if (startup_rc != c.LIBSSH2_ERROR_EAGAIN) {
+            setLibssh2Error(session, "Exec start failed", startup_rc);
+            _ = c.libssh2_channel_close(channel.?);
+            _ = c.libssh2_channel_free(channel.?);
+            return c.JNI_FALSE;
+        }
+        if (!waitSocket(session, setup_wait_timeout_ms)) {
+            setError(session, "Exec start timed out", .{});
+            _ = c.libssh2_channel_close(channel.?);
+            _ = c.libssh2_channel_free(channel.?);
+            return c.JNI_FALSE;
+        }
+    }
+    if (session.channel) |old_ch| {
+        _ = c.libssh2_channel_close(old_ch);
+        _ = c.libssh2_channel_free(old_ch);
+    }
+    session.channel = channel;
+    setSocketNonBlocking(session.socket_fd);
+    c.libssh2_session_set_blocking(ssh_session, 0);
+    c.libssh2_channel_set_blocking(channel.?, 0);
+    return c.JNI_TRUE;
+}
+
+export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeChannelEof(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong) callconv(.c) c.jboolean {
+    _ = env;
+    _ = thiz;
+    const session = sessionFromHandle(handle) orelse return c.JNI_TRUE;
+    const channel = session.channel orelse return c.JNI_TRUE;
+    // libssh2_channel_eof returns 1 when the remote sent EOF on the channel
+    // (e.g. mosh-server printed its CONNECT line and detached). Returning
+    // EOF as "true" lets the Kotlin bootstrap loop exit immediately on
+    // success instead of waiting out the full deadline.
+    return if (c.libssh2_channel_eof(channel) == 1) c.JNI_TRUE else c.JNI_FALSE;
 }
 
 export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeResize(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong, cols: c.jint, rows: c.jint, width_px: c.jint, height_px: c.jint) callconv(.c) c.jboolean {


### PR DESCRIPTION
replace pty shell bootstrap with exec channel to avoid shell noise, MOTD and slow dotfile init.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct exec support over SSH and channel EOF detection for more reliable remote command handling.

* **Bug Fixes**
  * More robust MOSH bootstrap with clearer, distinct error reasons (including blank-output) and improved timeout behavior.
  * Better fallback from exec to shell and enhanced diagnostics when connection bootstrap fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jossephus/chuchu/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->