### PR TITLE
feat: add automatic light and dark terminal themes

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/MainActivity.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/MainActivity.kt
@@ -18,6 +18,7 @@ import com.jossephus.chuchu.ui.ApplicationNavController
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTheme
 import com.jossephus.chuchu.ui.theme.GhosttyThemeRegistry
+import com.jossephus.chuchu.ui.theme.resolveActiveThemeName
 
 class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,10 +38,18 @@ fun AppRoot() {
     val context = LocalContext.current
     GhosttyThemeRegistry.init(context)
     val settings = SettingsRepository.getInstance(context)
-    val themeName by settings.themeName.collectAsStateWithLifecycle()
     val fontName by settings.fontName.collectAsStateWithLifecycle()
+    val themeName by settings.themeName.collectAsStateWithLifecycle()
+    val themeMode by settings.themeMode.collectAsStateWithLifecycle()
+    val lightThemeName by settings.lightThemeName.collectAsStateWithLifecycle()
+    val resolvedThemeName = resolveActiveThemeName(
+        themeMode = themeMode,
+        manualThemeName = themeName,
+        autoDarkThemeName = themeName,
+        autoLightThemeName = lightThemeName,
+    )
 
-    ChuTheme(themeName = themeName, fontName = fontName) {
+    ChuTheme(themeName = resolvedThemeName, fontName = fontName) {
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.jossephus.chuchu.ui.terminal.TerminalAccessoryLayoutStore
 import com.jossephus.chuchu.ui.theme.ChuFontOption
+import com.jossephus.chuchu.ui.theme.ThemeMode
 import com.jossephus.chuchu.ui.terminal.TerminalCustomActionStore
 import com.jossephus.chuchu.ui.terminal.TerminalCustomKeyGroup
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +38,14 @@ class SettingsRepository(context: Context) {
 
     private val _requireAuthOnConnect = MutableStateFlow(prefs.getBoolean(KEY_REQUIRE_AUTH_ON_CONNECT, false))
     val requireAuthOnConnect: StateFlow<Boolean> = _requireAuthOnConnect.asStateFlow()
+
+    private val _themeMode = MutableStateFlow(parseThemeMode(prefs.getString(KEY_THEME_MODE, ThemeMode.Manual.name)))
+    val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
+
+    private val _lightThemeName = MutableStateFlow(
+        prefs.getString(KEY_LIGHT_THEME, DEFAULT_LIGHT_THEME) ?: DEFAULT_LIGHT_THEME,
+    )
+    val lightThemeName: StateFlow<String> = _lightThemeName.asStateFlow()
 
     fun setTheme(name: String) {
         prefs.edit().putString(KEY_THEME, name).apply()
@@ -77,6 +86,16 @@ class SettingsRepository(context: Context) {
         _requireAuthOnConnect.value = enabled
     }
 
+    fun setThemeMode(mode: ThemeMode) {
+        prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
+        _themeMode.value = mode
+    }
+
+    fun setLightTheme(name: String) {
+        prefs.edit().putString(KEY_LIGHT_THEME, name).apply()
+        _lightThemeName.value = name
+    }
+
     private fun loadAccessoryLayoutIds(): List<String> {
         val stored = prefs.getString(KEY_ACCESSORY_LAYOUT, null)
             ?: return TerminalAccessoryLayoutStore.defaultLayoutIds()
@@ -101,7 +120,10 @@ class SettingsRepository(context: Context) {
         private const val KEY_ACCESSORY_BAR_SINGLE_ROW = "terminal_accessory_bar_single_row"
         private const val KEY_APP_LOCK_ENABLED = "app_lock_enabled"
         private const val KEY_REQUIRE_AUTH_ON_CONNECT = "require_auth_on_connect"
+        private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_LIGHT_THEME = "light_theme_name"
         const val DEFAULT_THEME = "Catppuccin Mocha"
+        const val DEFAULT_LIGHT_THEME = "Catppuccin Latte"
         const val DEFAULT_FONT = "jetbrains_mono"
 
         @Volatile
@@ -112,5 +134,12 @@ class SettingsRepository(context: Context) {
                 instance ?: SettingsRepository(context.applicationContext).also { instance = it }
             }
         }
+
+        private fun parseThemeMode(value: String?): ThemeMode =
+            try {
+                ThemeMode.valueOf(value ?: ThemeMode.Manual.name)
+            } catch (_: IllegalArgumentException) {
+                ThemeMode.Manual
+            }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -96,6 +96,8 @@ fun ApplicationNavController() {
             val accessoryLayoutIds by settingsRepo.accessoryLayoutIds.collectAsStateWithLifecycle()
             val accessoryBarSingleRow by settingsRepo.accessoryBarSingleRow.collectAsStateWithLifecycle()
             val customKeyGroups by settingsRepo.terminalCustomKeyGroups.collectAsStateWithLifecycle()
+            val themeMode by settingsRepo.themeMode.collectAsStateWithLifecycle()
+            val lightThemeName by settingsRepo.lightThemeName.collectAsStateWithLifecycle()
             SettingsScreen(
                 currentTheme = themeName,
                 currentFont = fontName,
@@ -104,7 +106,11 @@ fun ApplicationNavController() {
                 currentAccessoryLayoutIds = accessoryLayoutIds,
                 accessoryBarSingleRow = accessoryBarSingleRow,
                 currentTerminalCustomKeyGroups = customKeyGroups,
+                themeMode = themeMode,
+                lightThemeName = lightThemeName,
                 onThemeSelected = settingsRepo::setTheme,
+                onThemeModeChanged = settingsRepo::setThemeMode,
+                onLightThemeSelected = settingsRepo::setLightTheme,
                 onFontSelected = settingsRepo::setFont,
                 onAppLockEnabledChanged = settingsRepo::setAppLockEnabled,
                 onRequireAuthOnConnectChanged = settingsRepo::setRequireAuthOnConnect,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,6 +32,7 @@ import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.terminal.TerminalCustomKeyGroup
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
+import com.jossephus.chuchu.ui.theme.ThemeMode
 
 enum class SettingsCategory(val label: String) {
     General("general"),
@@ -45,7 +48,11 @@ fun SettingsScreen(
     currentAccessoryLayoutIds: List<String>,
     accessoryBarSingleRow: Boolean,
     currentTerminalCustomKeyGroups: List<TerminalCustomKeyGroup>,
+    themeMode: ThemeMode,
+    lightThemeName: String,
     onThemeSelected: (String) -> Unit,
+    onThemeModeChanged: (ThemeMode) -> Unit,
+    onLightThemeSelected: (String) -> Unit,
     onFontSelected: (String) -> Unit,
     onAppLockEnabledChanged: (Boolean) -> Unit,
     onRequireAuthOnConnectChanged: (Boolean) -> Unit,
@@ -124,25 +131,33 @@ fun SettingsScreen(
             }
             Spacer(modifier = Modifier.height(16.dp))
 
-            when (selectedCategory) {
-                SettingsCategory.General -> GeneralSettings(
-                    currentTheme = currentTheme,
-                    currentFont = currentFont,
-                    onThemeSelected = onThemeSelected,
-                    onFontSelected = onFontSelected,
-                    appLockEnabled = appLockEnabled,
-                    requireAuthOnConnect = requireAuthOnConnect,
-                    onAppLockEnabledChanged = onAppLockEnabledChanged,
-                    onRequireAuthOnConnectChanged = onRequireAuthOnConnectChanged,
-                )
-                SettingsCategory.Terminal -> TerminalSettings(
-                    currentAccessoryLayoutIds = currentAccessoryLayoutIds,
-                    onEditAccessoryLayout = { showAccessoryEditor = true },
-                    accessoryBarSingleRow = accessoryBarSingleRow,
-                    onAccessoryBarSingleRowChanged = onAccessoryBarSingleRowChanged,
-                    currentTerminalCustomKeyGroups = currentTerminalCustomKeyGroups,
-                    onEditCustomActions = { showCustomActionEditor = true },
-                )
+            Column(
+                modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()),
+            ) {
+                when (selectedCategory) {
+                    SettingsCategory.General -> GeneralSettings(
+                        currentTheme = currentTheme,
+                        currentFont = currentFont,
+                        onThemeSelected = onThemeSelected,
+                        onThemeModeChanged = onThemeModeChanged,
+                        themeMode = themeMode,
+                        lightThemeName = lightThemeName,
+                        onLightThemeSelected = onLightThemeSelected,
+                        onFontSelected = onFontSelected,
+                        appLockEnabled = appLockEnabled,
+                        requireAuthOnConnect = requireAuthOnConnect,
+                        onAppLockEnabledChanged = onAppLockEnabledChanged,
+                        onRequireAuthOnConnectChanged = onRequireAuthOnConnectChanged,
+                    )
+                    SettingsCategory.Terminal -> TerminalSettings(
+                        currentAccessoryLayoutIds = currentAccessoryLayoutIds,
+                        onEditAccessoryLayout = { showAccessoryEditor = true },
+                        accessoryBarSingleRow = accessoryBarSingleRow,
+                        onAccessoryBarSingleRowChanged = onAccessoryBarSingleRowChanged,
+                        currentTerminalCustomKeyGroups = currentTerminalCustomKeyGroups,
+                        onEditCustomActions = { showCustomActionEditor = true },
+                    )
+                }
             }
         }
 
@@ -170,6 +185,10 @@ private fun GeneralSettings(
     currentTheme: String,
     currentFont: String,
     onThemeSelected: (String) -> Unit,
+    onThemeModeChanged: (ThemeMode) -> Unit,
+    themeMode: ThemeMode,
+    lightThemeName: String,
+    onLightThemeSelected: (String) -> Unit,
     onFontSelected: (String) -> Unit,
     appLockEnabled: Boolean,
     requireAuthOnConnect: Boolean,
@@ -181,6 +200,10 @@ private fun GeneralSettings(
     ThemeSelectorSection(
         currentTheme = currentTheme,
         onThemeSelected = onThemeSelected,
+        themeMode = themeMode,
+        onThemeModeChanged = onThemeModeChanged,
+        lightThemeName = lightThemeName,
+        onLightThemeSelected = onLightThemeSelected,
     )
     Spacer(modifier = Modifier.height(16.dp))
     FontSelectorSection(

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/ThemeSelectorSection.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/ThemeSelectorSection.kt
@@ -12,16 +12,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,11 +44,16 @@ import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
 import com.jossephus.chuchu.ui.theme.GhosttyTheme
 import com.jossephus.chuchu.ui.theme.GhosttyThemeRegistry
+import com.jossephus.chuchu.ui.theme.ThemeMode
 
 @Composable
 internal fun ThemeSelectorSection(
     currentTheme: String,
     onThemeSelected: (String) -> Unit,
+    themeMode: ThemeMode,
+    onThemeModeChanged: (ThemeMode) -> Unit,
+    lightThemeName: String,
+    onLightThemeSelected: (String) -> Unit,
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
@@ -61,24 +61,6 @@ internal fun ThemeSelectorSection(
     val availableThemes = remember { GhosttyThemeRegistry.availableThemeNames }
     val themeByName = remember(context, availableThemes) {
         availableThemes.associateWith { themeName -> GhosttyThemeRegistry.getTheme(context, themeName) }
-    }
-    var themeQuery by remember { mutableStateOf("") }
-    var expanded by remember { mutableStateOf(false) }
-    val themeListState = rememberLazyListState()
-    val filteredThemes = remember(availableThemes, themeQuery) {
-        val query = themeQuery.trim()
-        if (query.isEmpty()) availableThemes else availableThemes.filter { it.contains(query, ignoreCase = true) }
-    }
-    val previewTheme = remember(context, currentTheme) {
-        GhosttyThemeRegistry.getTheme(context, currentTheme)
-    }
-    var showPreview by rememberSaveable { mutableStateOf(false) }
-
-    LaunchedEffect(expanded, filteredThemes) {
-        if (expanded) {
-            val selectedIndex = filteredThemes.indexOf(currentTheme)
-            if (selectedIndex >= 0) themeListState.scrollToItem(selectedIndex)
-        }
     }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -88,6 +70,64 @@ internal fun ThemeSelectorSection(
         Box(modifier = Modifier.height(1.dp).background(colors.textMuted).fillMaxWidth())
     }
     Spacer(modifier = Modifier.height(12.dp))
+
+    // --- Mode toggle ---
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ThemeMode.entries.forEach { mode ->
+            val isSelected = mode == themeMode
+            ChuButton(
+                onClick = { onThemeModeChanged(mode) },
+                variant = ChuButtonVariant.Outlined,
+                borderColor = if (isSelected) colors.accent else colors.border,
+                backgroundColor = if (isSelected) colors.accent.copy(alpha = 0.12f) else null,
+                modifier = Modifier.weight(1f),
+            ) {
+                ChuText(
+                    mode.label,
+                    style = typography.label,
+                    color = if (isSelected) colors.accent else colors.textSecondary,
+                )
+            }
+        }
+    }
+    Spacer(modifier = Modifier.height(16.dp))
+
+    when (themeMode) {
+        ThemeMode.Manual -> SingleThemePicker(
+            currentTheme = currentTheme,
+            onThemeSelected = onThemeSelected,
+            themeByName = themeByName,
+        )
+        ThemeMode.Auto -> DualThemePickers(
+            darkThemeName = currentTheme,
+            onDarkThemeSelected = onThemeSelected,
+            lightThemeName = lightThemeName,
+            onLightThemeSelected = onLightThemeSelected,
+            themeByName = themeByName,
+        )
+    }
+}
+
+@Composable
+private fun SingleThemePicker(
+    currentTheme: String,
+    onThemeSelected: (String) -> Unit,
+    themeByName: Map<String, GhosttyTheme?>,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    var themeQuery by rememberSaveable { mutableStateOf("") }
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val filteredThemes = remember(themeByName.keys, themeQuery) {
+        val query = themeQuery.trim()
+        if (query.isEmpty()) themeByName.keys.toList() else themeByName.keys.filter { it.contains(query, ignoreCase = true) }
+    }
+    var showPreview by rememberSaveable { mutableStateOf(false) }
+
+    val previewTheme = remember(currentTheme, themeByName) { themeByName[currentTheme] }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Row(
@@ -106,70 +146,231 @@ internal fun ThemeSelectorSection(
 
         if (showPreview && previewTheme != null) ThemePreview(theme = previewTheme, name = currentTheme)
 
+        ThemePickerButton(
+            currentTheme = currentTheme,
+            expanded = expanded,
+            onToggle = { expanded = !expanded },
+        )
+
+        AnimatedVisibility(visible = expanded, enter = expandVertically(), exit = shrinkVertically()) {
+            ThemePickerDropdown(
+                query = themeQuery,
+                onQueryChange = { themeQuery = it },
+                filteredThemes = filteredThemes,
+                currentTheme = currentTheme,
+                onThemeSelected = { onThemeSelected(it); expanded = false },
+                themeByName = themeByName,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DualThemePickers(
+    darkThemeName: String,
+    onDarkThemeSelected: (String) -> Unit,
+    lightThemeName: String,
+    onLightThemeSelected: (String) -> Unit,
+    themeByName: Map<String, GhosttyTheme?>,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+
+    val darkTheme = remember(darkThemeName, themeByName) { themeByName[darkThemeName] }
+    val lightTheme = remember(lightThemeName, themeByName) { themeByName[lightThemeName] }
+
+    // Dark theme sub-section
+    ChuText("dark", style = typography.labelSmall, color = colors.textMuted)
+    Spacer(modifier = Modifier.height(8.dp))
+    ThemeSubPicker(
+        currentTheme = darkThemeName,
+        onThemeSelected = onDarkThemeSelected,
+        themeByName = themeByName,
+        label = "dark",
+        accentSwatch = darkTheme?.let { it.background } ?: colors.textMuted,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Light theme sub-section
+    ChuText("light", style = typography.labelSmall, color = colors.textMuted)
+    Spacer(modifier = Modifier.height(8.dp))
+    ThemeSubPicker(
+        currentTheme = lightThemeName,
+        onThemeSelected = onLightThemeSelected,
+        themeByName = themeByName,
+        label = "light",
+        accentSwatch = lightTheme?.let { it.background } ?: colors.textMuted,
+    )
+}
+
+/**
+ * Compact inline picker for one slot (dark or light). Always show the current
+ * selection button; on expand show a filterable list.
+ */
+@Composable
+private fun ThemeSubPicker(
+    currentTheme: String,
+    onThemeSelected: (String) -> Unit,
+    themeByName: Map<String, GhosttyTheme?>,
+    label: String,
+    accentSwatch: Color,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    var query by rememberSaveable { mutableStateOf("") }
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    val filteredThemes = remember(themeByName.keys, query) {
+        val q = query.trim()
+        if (q.isEmpty()) themeByName.keys.toList() else themeByName.keys.filter { it.contains(q, ignoreCase = true) }
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .width(8.dp)
+                .height(8.dp)
+                .background(accentSwatch),
+        )
+        ChuText(currentTheme, style = typography.labelSmall, color = colors.textPrimary)
         ChuButton(
             onClick = { expanded = !expanded },
-            variant = ChuButtonVariant.Outlined,
+            variant = ChuButtonVariant.Ghost,
             bracketed = true,
+            borderColor = colors.textMuted,
+        ) {
+            ChuText(if (expanded) "close" else "change", style = typography.labelSmall, color = colors.textMuted)
+        }
+    }
+
+    AnimatedVisibility(visible = expanded, enter = expandVertically(), exit = shrinkVertically()) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            ChuTextField(
+                value = query,
+                onValueChange = { query = it },
+                label = "Search $label themes",
+                placeholder = "Type to filter",
+                singleLine = true,
+                autoFocus = false,
+            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                filteredThemes.forEach { themeName ->
+                    ThemePickerRow(
+                        themeName = themeName,
+                        currentTheme = currentTheme,
+                        rowTheme = themeByName[themeName],
+                        onThemeSelected = {
+                            onThemeSelected(themeName)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ─── Shared widgets ─────────────────────────────────────────────────────────
+
+@Composable
+private fun ThemePickerButton(
+    currentTheme: String,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    ChuButton(
+        onClick = onToggle,
+        variant = ChuButtonVariant.Outlined,
+        bracketed = true,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ChuText(currentTheme, style = typography.label)
+            ChuText(if (expanded) "▲" else "▼", style = typography.labelSmall, color = colors.textMuted)
+        }
+    }
+}
+
+@Composable
+private fun ThemePickerDropdown(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    filteredThemes: List<String>,
+    currentTheme: String,
+    onThemeSelected: (String) -> Unit,
+    themeByName: Map<String, GhosttyTheme?>,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ChuTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            label = "Search themes",
+            placeholder = "Type to filter",
+            singleLine = true,
+            autoFocus = false,
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            filteredThemes.forEach { themeName ->
+                ThemePickerRow(
+                    themeName = themeName,
+                    currentTheme = currentTheme,
+                    rowTheme = themeByName[themeName],
+                    onThemeSelected = { onThemeSelected(themeName) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemePickerRow(
+    themeName: String,
+    currentTheme: String,
+    rowTheme: GhosttyTheme?,
+    onThemeSelected: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    val isSelected = themeName == currentTheme
+
+    Box(
+        modifier =
+            Modifier.fillMaxWidth()
+                .background(if (isSelected) colors.surface else colors.surfaceVariant)
+                .clickable(onClick = onThemeSelected)
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Row(
             modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f),
             ) {
-                ChuText(currentTheme, style = typography.label)
-                ChuText(if (expanded) "▲" else "▼", style = typography.labelSmall, color = colors.textMuted)
-            }
-        }
-
-        AnimatedVisibility(visible = expanded, enter = expandVertically(), exit = shrinkVertically()) {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                ChuTextField(
-                    value = themeQuery,
-                    onValueChange = { themeQuery = it },
-                    label = "Search themes",
-                    placeholder = "Type to filter",
-                    singleLine = true,
-                    autoFocus = false,
-                )
-
-                LazyColumn(
-                    state = themeListState,
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                    modifier = Modifier.fillMaxWidth().heightIn(max = 480.dp),
-                ) {
-                    items(filteredThemes, key = { it }) { themeName ->
-                        val isSelected = themeName == currentTheme
-                        val rowTheme = themeByName[themeName]
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(if (isSelected) colors.surface else colors.surfaceVariant)
-                                .clickable { onThemeSelected(themeName) }
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
-                        ) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier.weight(1f),
-                                ) {
-                                    if (rowTheme != null) PaletteSwatchStrip(theme = rowTheme)
-                                    ChuText(
-                                        themeName,
-                                        style = typography.label,
-                                        color = if (isSelected) colors.accent else colors.textPrimary,
-                                    )
-                                }
-                                if (isSelected) ChuText("●", style = typography.label, color = colors.accent)
-                            }
-                        }
-                    }
+                if (isSelected) {
+                    Box(modifier = Modifier.width(3.dp).height(24.dp).background(colors.accent))
                 }
+                if (rowTheme != null) PaletteSwatchStrip(theme = rowTheme)
+                ChuText(
+                    themeName,
+                    style = typography.label,
+                    color = if (isSelected) colors.accent else colors.textPrimary,
+                )
             }
+            if (isSelected) ChuText("●", style = typography.label, color = colors.accent)
         }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -95,6 +95,7 @@ import com.jossephus.chuchu.ui.terminal.toGhosttyKey
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
 import com.jossephus.chuchu.ui.theme.GhosttyThemeRegistry
+import com.jossephus.chuchu.ui.theme.resolveActiveThemeName
 import com.jossephus.chuchu.ui.theme.toRgbIntArray
 import com.jossephus.chuchu.ui.theme.toTerminalPaletteBytes
 import java.io.File
@@ -255,6 +256,14 @@ fun TerminalScreen(
     val terminalPrefs =
         remember(context) { context.getSharedPreferences("chuchu_terminal", Context.MODE_PRIVATE) }
     val currentTheme by settingsRepo.themeName.collectAsStateWithLifecycle()
+    val themeMode by settingsRepo.themeMode.collectAsStateWithLifecycle()
+    val lightThemeName by settingsRepo.lightThemeName.collectAsStateWithLifecycle()
+    val resolvedThemeName = resolveActiveThemeName(
+        themeMode = themeMode,
+        manualThemeName = currentTheme,
+        autoDarkThemeName = currentTheme,
+        autoLightThemeName = lightThemeName,
+    )
     val currentAccessoryLayoutIds by settingsRepo.accessoryLayoutIds.collectAsStateWithLifecycle()
     val useSingleRowAccessoryBar by settingsRepo.accessoryBarSingleRow.collectAsStateWithLifecycle()
     val currentTerminalCustomKeyGroups by
@@ -264,7 +273,7 @@ fun TerminalScreen(
             TerminalAccessoryLayoutStore.resolveSelectedLayout(currentAccessoryLayoutIds)
         }
     val ghosttyTheme =
-        remember(context, currentTheme) { GhosttyThemeRegistry.getTheme(context, currentTheme) }
+        remember(context, resolvedThemeName) { GhosttyThemeRegistry.getTheme(context, resolvedThemeName) }
     val isDarkTheme = (ghosttyTheme?.background ?: colors.background).luminance() < 0.5f
     var selectedText by remember { mutableStateOf<String?>(null) }
     var hasSelectionActive by remember { mutableStateOf(false) }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/theme/ThemeModeResolver.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/theme/ThemeModeResolver.kt
@@ -1,0 +1,33 @@
+package com.jossephus.chuchu.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+
+/**
+ * Theme mode: manual selection vs following the device's dark/light mode.
+ */
+enum class ThemeMode(val label: String) {
+    Manual("manual"),
+    Auto("follow system"),
+}
+
+/**
+ * Resolves the active terminal theme name based on the current mode and
+ * system dark/light state.
+ *
+ * - [Manual] → [manualThemeName]
+ * - [Auto]   → [autoDarkThemeName] when the device is in dark mode,
+ *              [autoLightThemeName] otherwise
+ */
+@Composable
+fun resolveActiveThemeName(
+    themeMode: ThemeMode,
+    manualThemeName: String,
+    autoDarkThemeName: String,
+    autoLightThemeName: String,
+): String = when (themeMode) {
+    ThemeMode.Manual -> manualThemeName
+    ThemeMode.Auto -> {
+        if (isSystemInDarkTheme()) autoDarkThemeName else autoLightThemeName
+    }
+}


### PR DESCRIPTION
## Summary

Adds an automatic terminal theme mode that follows Android's system light/dark setting, while preserving the existing manual theme behavior.

What changed:
- Added a `manual` / `follow system` theme mode setting.
- Added a separate light terminal theme preference for automatic mode.
- Uses the existing selected theme as the manual theme and the dark theme for automatic mode.
- Defaults automatic light mode to `Catppuccin Latte`, paired with the existing `Catppuccin Mocha` default.
- Resolves the active theme from Compose system dark-mode state and applies it to both:
  - app UI colors via `ChuTheme`
  - terminal foreground/background/cursor/palette via `TerminalScreen`
- Makes Settings content vertically scrollable so the expanded theme selectors remain usable on smaller devices.

## Testing

Implemented by AI, then tested by the user on-device using a debug APK.

Validation performed locally:
- `./gradlew :app:compileDebugKotlin` ✅
- `./gradlew :app:testDebugUnitTest` ✅
- `./gradlew assembleDebug` ✅
- Verified debug APK contains native JNI library: `lib/arm64-v8a/libchuchu_jni.so` ✅

User testing:
- User installed the debug APK and confirmed the app ran on device.
- During testing, user found an initial debug APK packaging issue unrelated to this feature: the APK had been built without the native JNI library, causing SSH key generation to crash. That was fixed by rebuilding native JNI before assembling the APK, and a corrected APK was sent for testing.

## AI disclosure

This PR was fully implemented by AI at the request of the user. The user tested the resulting APK on-device and requested that this be clearly disclosed to the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme mode selection to choose between manual theme or automatic system-based themes.
  * Added light theme customization option for automatic mode.
  * Enhanced settings interface with improved organization and scrolling for theme configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jossephus/chuchu/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->