### PR TITLE
fix: proper emoji renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ android/app/key.jks
 zig-src/.zig-cache/
 zig-src/zig-out/
 zig-out/
+.comview/

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -1,5 +1,6 @@
 package com.jossephus.chuchu.service.terminal
 
+import android.os.SystemClock
 import android.util.Log
 import com.jossephus.chuchu.model.AuthMethod
 import com.jossephus.chuchu.model.Transport
@@ -105,6 +106,7 @@ class TerminalSessionEngine(
     private var lastConnectionParams: ConnectionParams? = null
     private var reconnectJob: Job? = null
     private var disconnectRequested = false
+    private val snapshotPerfTracker = SnapshotPerfTracker()
 
     private val nativeVersion =
         if (bridge.isLoaded()) {
@@ -847,14 +849,20 @@ class TerminalSessionEngine(
 
     private fun emitSnapshot() {
         if (handle == 0L) return
+        val t0 = SystemClock.elapsedRealtimeNanos()
         try {
             val raw = bridge.nativeSnapshot(handle)
+            val t1 = SystemClock.elapsedRealtimeNanos()
             val rawImages = bridge.nativeSnapshotImages(handle)
+            val t2 = SystemClock.elapsedRealtimeNanos()
             images = TerminalSnapshot.parseImages(rawImages)
+            val t3 = SystemClock.elapsedRealtimeNanos()
             val snap = TerminalSnapshot.fromByteBuffer(raw, images)
+            val t4 = SystemClock.elapsedRealtimeNanos()
             val nextTitle = bridge.nativePollTitle(handle)
             val nextPwd = bridge.nativePollPwd(handle)
             val bellCount = bridge.nativeDrainBellCount(handle)
+            val t5 = SystemClock.elapsedRealtimeNanos()
             if (nextTitle != null) {
                 title = nextTitle
             }
@@ -870,8 +878,97 @@ class TerminalSessionEngine(
                     nativeVersion = nativeVersion,
                     handle = handle,
                 )
+            val t6 = SystemClock.elapsedRealtimeNanos()
+            val nonBlankCells = countNonBlankCells(snap)
+            snapshotPerfTracker.record(
+                nativeTextNs = t1 - t0,
+                nativeImagesNs = t2 - t1,
+                parseImagesNs = t3 - t2,
+                parseSnapshotNs = t4 - t3,
+                metadataPollNs = t5 - t4,
+                stateUpdateNs = t6 - t5,
+                totalNs = t6 - t0,
+                textBytes = raw.capacity(),
+                imageBytes = rawImages.capacity(),
+                cols = snap.cols,
+                rows = snap.rows,
+                extras = snap.graphemeExtras.size,
+                nonBlank = nonBlankCells,
+            )
+            if (nonBlankCells == 0 && snap.cursorVisible) {
+                Log.w(
+                    "TerminalPerf",
+                    "snapshot_content_anomaly nonBlank=0 cursor=(${snap.cursorX},${snap.cursorY}) " +
+                        "grid=${snap.cols}x${snap.rows} sample='${sampleRowText(snap, snap.cursorY)}'",
+                )
+            }
         } catch (e: Exception) {
             Log.e("TerminalSession", "emitSnapshot failed", e)
+        }
+    }
+
+    private fun countNonBlankCells(snapshot: TerminalSnapshot): Int {
+        var count = 0
+        for (cp in snapshot.codepoints) {
+            if (cp != 0 && cp != 32) count++
+        }
+        return count
+    }
+
+    private fun sampleRowText(snapshot: TerminalSnapshot, row: Int): String {
+        if (snapshot.cols <= 0 || snapshot.rows <= 0) return ""
+        val r = row.coerceIn(0, snapshot.rows - 1)
+        val start = r * snapshot.cols
+        val endExclusive = (start + snapshot.cols).coerceAtMost(snapshot.codepoints.size)
+        val sb = StringBuilder(snapshot.cols)
+        for (i in start until endExclusive) {
+            val cp = snapshot.codepoints[i]
+            when {
+                cp == 0 -> sb.append('·')
+                cp == 32 -> sb.append(' ')
+                cp in 0x20..0x7E -> sb.append(cp.toChar())
+                else -> sb.append('?')
+            }
+        }
+        return sb.toString().trimEnd()
+    }
+
+    private class SnapshotPerfTracker {
+        private var calls: Long = 0
+        private var totalNs: Long = 0
+        private var lastLogNs: Long = 0
+
+        fun record(
+            nativeTextNs: Long,
+            nativeImagesNs: Long,
+            parseImagesNs: Long,
+            parseSnapshotNs: Long,
+            metadataPollNs: Long,
+            stateUpdateNs: Long,
+            totalNs: Long,
+            textBytes: Int,
+            imageBytes: Int,
+            cols: Int,
+            rows: Int,
+            extras: Int,
+            nonBlank: Int,
+        ) {
+            calls++
+            this.totalNs += totalNs
+            val now = SystemClock.elapsedRealtimeNanos()
+            val slow = totalNs >= 20_000_000L || parseSnapshotNs >= 10_000_000L || nativeTextNs >= 10_000_000L
+            if (!slow) return
+
+            val avgMs = if (calls > 0) (this.totalNs / calls) / 1_000_000.0 else 0.0
+            Log.w(
+                "TerminalPerf",
+                "emitSnapshot SLOW total=${"%.2f".format(totalNs / 1_000_000.0)}ms avg=${"%.2f".format(avgMs)}ms " +
+                    "nativeText=${"%.2f".format(nativeTextNs / 1_000_000.0)}ms nativeImages=${"%.2f".format(nativeImagesNs / 1_000_000.0)}ms " +
+                    "parseImages=${"%.2f".format(parseImagesNs / 1_000_000.0)}ms parseSnapshot=${"%.2f".format(parseSnapshotNs / 1_000_000.0)}ms " +
+                    "meta=${"%.2f".format(metadataPollNs / 1_000_000.0)}ms state=${"%.2f".format(stateUpdateNs / 1_000_000.0)}ms " +
+                    "grid=${cols}x${rows} extras=$extras nonBlank=$nonBlank bytes(text=$textBytes,img=$imageBytes) calls=$calls",
+            )
+            lastLogNs = now
         }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -1,6 +1,5 @@
 package com.jossephus.chuchu.service.terminal
 
-import android.os.SystemClock
 import android.util.Log
 import com.jossephus.chuchu.model.AuthMethod
 import com.jossephus.chuchu.model.Transport
@@ -106,7 +105,7 @@ class TerminalSessionEngine(
     private var lastConnectionParams: ConnectionParams? = null
     private var reconnectJob: Job? = null
     private var disconnectRequested = false
-    private val snapshotPerfTracker = SnapshotPerfTracker()
+
 
     private val nativeVersion =
         if (bridge.isLoaded()) {
@@ -849,20 +848,14 @@ class TerminalSessionEngine(
 
     private fun emitSnapshot() {
         if (handle == 0L) return
-        val t0 = SystemClock.elapsedRealtimeNanos()
         try {
             val raw = bridge.nativeSnapshot(handle)
-            val t1 = SystemClock.elapsedRealtimeNanos()
             val rawImages = bridge.nativeSnapshotImages(handle)
-            val t2 = SystemClock.elapsedRealtimeNanos()
             images = TerminalSnapshot.parseImages(rawImages)
-            val t3 = SystemClock.elapsedRealtimeNanos()
             val snap = TerminalSnapshot.fromByteBuffer(raw, images)
-            val t4 = SystemClock.elapsedRealtimeNanos()
             val nextTitle = bridge.nativePollTitle(handle)
             val nextPwd = bridge.nativePollPwd(handle)
             val bellCount = bridge.nativeDrainBellCount(handle)
-            val t5 = SystemClock.elapsedRealtimeNanos()
             if (nextTitle != null) {
                 title = nextTitle
             }
@@ -878,97 +871,9 @@ class TerminalSessionEngine(
                     nativeVersion = nativeVersion,
                     handle = handle,
                 )
-            val t6 = SystemClock.elapsedRealtimeNanos()
-            val nonBlankCells = countNonBlankCells(snap)
-            snapshotPerfTracker.record(
-                nativeTextNs = t1 - t0,
-                nativeImagesNs = t2 - t1,
-                parseImagesNs = t3 - t2,
-                parseSnapshotNs = t4 - t3,
-                metadataPollNs = t5 - t4,
-                stateUpdateNs = t6 - t5,
-                totalNs = t6 - t0,
-                textBytes = raw.capacity(),
-                imageBytes = rawImages.capacity(),
-                cols = snap.cols,
-                rows = snap.rows,
-                extras = snap.graphemeExtras.size,
-                nonBlank = nonBlankCells,
-            )
-            if (nonBlankCells == 0 && snap.cursorVisible) {
-                Log.w(
-                    "TerminalPerf",
-                    "snapshot_content_anomaly nonBlank=0 cursor=(${snap.cursorX},${snap.cursorY}) " +
-                        "grid=${snap.cols}x${snap.rows} sample='${sampleRowText(snap, snap.cursorY)}'",
-                )
-            }
         } catch (e: Exception) {
             Log.e("TerminalSession", "emitSnapshot failed", e)
         }
     }
 
-    private fun countNonBlankCells(snapshot: TerminalSnapshot): Int {
-        var count = 0
-        for (cp in snapshot.codepoints) {
-            if (cp != 0 && cp != 32) count++
-        }
-        return count
-    }
-
-    private fun sampleRowText(snapshot: TerminalSnapshot, row: Int): String {
-        if (snapshot.cols <= 0 || snapshot.rows <= 0) return ""
-        val r = row.coerceIn(0, snapshot.rows - 1)
-        val start = r * snapshot.cols
-        val endExclusive = (start + snapshot.cols).coerceAtMost(snapshot.codepoints.size)
-        val sb = StringBuilder(snapshot.cols)
-        for (i in start until endExclusive) {
-            val cp = snapshot.codepoints[i]
-            when {
-                cp == 0 -> sb.append('·')
-                cp == 32 -> sb.append(' ')
-                cp in 0x20..0x7E -> sb.append(cp.toChar())
-                else -> sb.append('?')
-            }
-        }
-        return sb.toString().trimEnd()
-    }
-
-    private class SnapshotPerfTracker {
-        private var calls: Long = 0
-        private var totalNs: Long = 0
-        private var lastLogNs: Long = 0
-
-        fun record(
-            nativeTextNs: Long,
-            nativeImagesNs: Long,
-            parseImagesNs: Long,
-            parseSnapshotNs: Long,
-            metadataPollNs: Long,
-            stateUpdateNs: Long,
-            totalNs: Long,
-            textBytes: Int,
-            imageBytes: Int,
-            cols: Int,
-            rows: Int,
-            extras: Int,
-            nonBlank: Int,
-        ) {
-            calls++
-            this.totalNs += totalNs
-            val now = SystemClock.elapsedRealtimeNanos()
-            val slow = totalNs >= 20_000_000L || parseSnapshotNs >= 10_000_000L || nativeTextNs >= 10_000_000L
-            if (!slow) return
-
-            val avgMs = if (calls > 0) (this.totalNs / calls) / 1_000_000.0 else 0.0
-            Log.w(
-                "TerminalPerf",
-                "emitSnapshot SLOW total=${"%.2f".format(totalNs / 1_000_000.0)}ms avg=${"%.2f".format(avgMs)}ms " +
-                    "nativeText=${"%.2f".format(nativeTextNs / 1_000_000.0)}ms nativeImages=${"%.2f".format(nativeImagesNs / 1_000_000.0)}ms " +
-                    "parseImages=${"%.2f".format(parseImagesNs / 1_000_000.0)}ms parseSnapshot=${"%.2f".format(parseSnapshotNs / 1_000_000.0)}ms " +
-                    "meta=${"%.2f".format(metadataPollNs / 1_000_000.0)}ms state=${"%.2f".format(stateUpdateNs / 1_000_000.0)}ms " +
-                    "grid=${cols}x${rows} extras=$extras nonBlank=$nonBlank bytes(text=$textBytes,img=$imageBytes) calls=$calls",
-            )
-            lastLogNs = now
-        }
-    }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
@@ -31,6 +31,12 @@ data class TerminalSnapshot(
     val fgArgb: IntArray,
     val bgArgb: IntArray,
     val flags: ByteArray,
+    /**
+     * Sparse map: cell index -> extra grapheme codepoints (appended after the
+     * base codepoint stored in [codepoints]). Present when the corresponding
+     * cell has [CELL_FLAG_HAS_GRAPHEME] set.
+     */
+    val graphemeExtras: Map<Int, IntArray> = emptyMap(),
     val images: List<ImagePlacement> = emptyList(),
 ) {
     override fun equals(other: Any?): Boolean {
@@ -45,6 +51,7 @@ data class TerminalSnapshot(
             fgArgb.contentEquals(other.fgArgb) &&
             bgArgb.contentEquals(other.bgArgb) &&
             flags.contentEquals(other.flags) &&
+            graphemeExtrasEquals(graphemeExtras, other.graphemeExtras) &&
             images == other.images
     }
 
@@ -60,22 +67,41 @@ data class TerminalSnapshot(
         result = 31 * result + fgArgb.contentHashCode()
         result = 31 * result + bgArgb.contentHashCode()
         result = 31 * result + flags.contentHashCode()
+        result = 31 * result + graphemeExtras.size
         result = 31 * result + images.hashCode()
         return result
     }
 
     companion object {
-        private const val HEADER_I32_COUNT = 11
+        const val CELL_FLAG_HAS_GRAPHEME: Int = 0x40
+        const val CELL_FLAG_SPACER: Int = 0x80
+        private const val HEADER_I32_COUNT = 12
         private const val CELL_SIZE_BYTES = 11
         private const val IMAGE_HEADER_BYTES = 44
 
+        private fun graphemeExtrasEquals(
+            a: Map<Int, IntArray>,
+            b: Map<Int, IntArray>,
+        ): Boolean {
+            if (a.size != b.size) return false
+            for ((k, v) in a) {
+                val o = b[k] ?: return false
+                if (!v.contentEquals(o)) return false
+            }
+            return true
+        }
+
         private fun packArgb(r: Int, g: Int, b: Int): Int =
             (0xFF shl 24) or (r shl 16) or (g shl 8) or b
+
+        private var parseCalls: Long = 0
+        private var parseTotalNs: Long = 0
 
         fun fromByteBuffer(
             buffer: ByteBuffer,
             images: List<ImagePlacement> = emptyList(),
         ): TerminalSnapshot {
+            val t0 = System.nanoTime()
             val wrapped = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN)
             wrapped.position(0)
 
@@ -90,6 +116,7 @@ data class TerminalSnapshot(
             val defaultFgR = wrapped.int
             val defaultFgG = wrapped.int
             val defaultFgB = wrapped.int
+            val extrasOffset = wrapped.int
 
             val cellCount = cols * rows
             val expectedSize = (HEADER_I32_COUNT * 4) + (cellCount * CELL_SIZE_BYTES)
@@ -97,25 +124,72 @@ data class TerminalSnapshot(
                 "Snapshot buffer too small: cap=${buffer.capacity()} expected=$expectedSize"
             }
 
+            // Bulk-read all cell bytes in one operation, then parse from the
+            // byte array to avoid thousands of virtual-dispatch ByteBuffer
+            // calls that dominate the parse cost on Android.
+            // Allocate fresh arrays each frame — the old arrays are held by the
+            // previous TerminalSnapshot visible to the UI thread, so reusing
+            // them would cause a data race.
+            val cellDataLen = cellCount * CELL_SIZE_BYTES
+            val cellBytes = ByteArray(cellDataLen)
+            wrapped.get(cellBytes, 0, cellDataLen)
+
             val codepoints = IntArray(cellCount)
             val fgArgb = IntArray(cellCount)
             val bgArgb = IntArray(cellCount)
             val flags = ByteArray(cellCount)
 
+            var off = 0
             for (i in 0 until cellCount) {
-                codepoints[i] = wrapped.int
-                val fgR = wrapped.get().toInt() and 0xff
-                val fgG = wrapped.get().toInt() and 0xff
-                val fgB = wrapped.get().toInt() and 0xff
-                val bgR = wrapped.get().toInt() and 0xff
-                val bgG = wrapped.get().toInt() and 0xff
-                val bgB = wrapped.get().toInt() and 0xff
-                flags[i] = wrapped.get()
+                // codepoint: little-endian i32 from 4 bytes
+                codepoints[i] = (cellBytes[off].toInt() and 0xFF) or
+                    ((cellBytes[off + 1].toInt() and 0xFF) shl 8) or
+                    ((cellBytes[off + 2].toInt() and 0xFF) shl 16) or
+                    ((cellBytes[off + 3].toInt() and 0xFF) shl 24)
+                off += 4
+                val fgR = cellBytes[off].toInt() and 0xFF; off++
+                val fgG = cellBytes[off].toInt() and 0xFF; off++
+                val fgB = cellBytes[off].toInt() and 0xFF; off++
+                val bgR = cellBytes[off].toInt() and 0xFF; off++
+                val bgG = cellBytes[off].toInt() and 0xFF; off++
+                val bgB = cellBytes[off].toInt() and 0xFF; off++
                 fgArgb[i] = packArgb(fgR, fgG, fgB)
                 bgArgb[i] = packArgb(bgR, bgG, bgB)
+                flags[i] = cellBytes[off]; off++
             }
 
-            return TerminalSnapshot(
+            val graphemeExtras: Map<Int, IntArray> =
+                if (extrasOffset > 0 && extrasOffset < wrapped.capacity()) {
+                    val extras = wrapped.duplicate().order(ByteOrder.LITTLE_ENDIAN)
+                    extras.position(extrasOffset)
+                    if (extras.remaining() < 4) {
+                        emptyMap()
+                    } else {
+                        val recordCount = extras.int
+                        val parsed = HashMap<Int, IntArray>(recordCount.coerceAtLeast(0))
+                        var valid = true
+                        for (record in 0 until recordCount) {
+                            if (extras.remaining() < 8) {
+                                valid = false
+                                break
+                            }
+                            val cellIndex = extras.int
+                            val count = extras.int
+                            if (cellIndex !in 0 until cellCount || count < 0 || extras.remaining() < count * 4) {
+                                valid = false
+                                break
+                            }
+                            val cps = IntArray(count)
+                            for (j in 0 until count) cps[j] = extras.int
+                            parsed[cellIndex] = cps
+                        }
+                        if (valid) parsed else emptyMap()
+                    }
+                } else {
+                    emptyMap()
+                }
+
+            val snapshot = TerminalSnapshot(
                 cols = cols,
                 rows = rows,
                 cursorX = cursorX,
@@ -127,8 +201,26 @@ data class TerminalSnapshot(
                 fgArgb = fgArgb,
                 bgArgb = bgArgb,
                 flags = flags,
+                graphemeExtras = graphemeExtras,
                 images = images,
             )
+
+            val elapsedNs = System.nanoTime() - t0
+            parseCalls++
+            parseTotalNs += elapsedNs
+            if (elapsedNs >= 8_000_000L) {
+                val avgMs = if (parseCalls > 0) (parseTotalNs / parseCalls) / 1_000_000.0 else 0.0
+                perfLog(
+                    "snapshot_parse SLOW total=${"%.2f".format(elapsedNs / 1_000_000.0)}ms avg=${"%.2f".format(avgMs)}ms " +
+                        "grid=${cols}x${rows} cells=$cellCount extras=${graphemeExtras.size} cap=${buffer.capacity()}",
+                )
+            }
+
+            return snapshot
+        }
+
+        private fun perfLog(message: String) {
+            runCatching { Log.w("TerminalPerf", message) }
         }
 
         fun parseImages(buffer: ByteBuffer?): List<ImagePlacement> {

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
@@ -67,7 +67,9 @@ data class TerminalSnapshot(
         result = 31 * result + fgArgb.contentHashCode()
         result = 31 * result + bgArgb.contentHashCode()
         result = 31 * result + flags.contentHashCode()
-        result = 31 * result + graphemeExtras.size
+        result = 31 * result + graphemeExtras.entries.fold(0) { acc, (key, arr) ->
+            acc + key + arr.contentHashCode()
+        }
         result = 31 * result + images.hashCode()
         return result
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -7,6 +7,8 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.os.SystemClock
+import android.util.Log
 import androidx.core.content.res.ResourcesCompat
 import android.view.ViewConfiguration
 import androidx.compose.foundation.Canvas
@@ -110,6 +112,18 @@ fun TerminalCanvas(
             typeface = symbolsTypeface
         }
     }
+    // System typeface paint used for color emoji + ZWJ/VS16 shaping. The
+    // "symbols" Nerd Font has no color emoji or ZWJ shaping, so emoji clusters
+    // (families, flags, ❤️‍🔥, 🧑‍💻, …) must go through this paint to hit
+    // Android's NotoColorEmoji fallback.
+    val emojiTextPaint = remember(fontSizePx) {
+        Paint().apply {
+            isAntiAlias = true
+            textAlign = Paint.Align.LEFT
+            textSize = fontSizePx
+            typeface = Typeface.DEFAULT
+        }
+    }
     val bgPaint = remember {
         Paint().apply {
             isAntiAlias = false
@@ -122,15 +136,18 @@ fun TerminalCanvas(
             style = Paint.Style.FILL
         }
     }
-    val glyphCache = remember {
+    val drawBuffer = remember { StringBuilder(256) }
+    val canvasPerfTracker = remember { CanvasPerfTracker() }
+    val singleGlyphCache = remember {
         HashMap<Int, String>(256).apply {
-            for (cp in 33..126) {
-                this[cp] = cp.toChar().toString()
-            }
+            for (cp in 33..126) this[cp] = cp.toChar().toString()
         }
     }
-    val drawBuffer = remember { StringBuilder(256) }
-    val symbolFallbackCache = remember(primaryTypeface, symbolsTypeface) { HashMap<Int, Boolean>(256) }
+    // Single-codepoint paint choice cache. 0 = primary (text font),
+    // 1 = symbols (Nerd Font icons / PUA), 2 = emoji (system default).
+    val singlePaintChoiceCache = remember(primaryTypeface, symbolsTypeface) { HashMap<Int, Int>(256) }
+    // Multi-codepoint grapheme cluster paint choice cache.
+    val clusterPaintChoiceCache = remember(primaryTypeface, symbolsTypeface) { HashMap<String, Int>(64) }
     val fontMetrics = primaryTextPaint.fontMetrics
     val measuredHeight = fontMetrics.descent - fontMetrics.ascent
     val cellHeightPx = if (measuredHeight > 1f) measuredHeight else 16f
@@ -383,6 +400,7 @@ fun TerminalCanvas(
         }
 
     Canvas(modifier = canvasModifier) {
+        val frameStartNs = SystemClock.elapsedRealtimeNanos()
         val cols = max(snapshot.cols, 1)
         val rows = max(snapshot.rows, 1)
         val cellWidth = cellWidthPx
@@ -456,16 +474,33 @@ fun TerminalCanvas(
                 i = rowStart
                 while (i < rowEnd) {
                     val cp = snapshot.codepoints[i]
-                    if (cp == 0 || cp == 32) { i++; continue }
+                    if (cp == 0 || cp == 32) {
+                        i++
+                        continue
+                    }
 
                     val fg = if (hasSel && i in selStart..selEnd && hasSelectionFg) {
                         selectionForegroundArgb
                     } else {
                         snapshot.fgArgb[i]
                     }
-                    val firstGlyph = glyphCache.getOrPut(cp) { String(Character.toChars(cp)) }
-                    val useSymbols = symbolFallbackCache.getOrPut(cp) {
-                        !primaryTextPaint.hasGlyph(firstGlyph) && symbolsTextPaint.hasGlyph(firstGlyph)
+                    val firstExtras = snapshot.graphemeExtras[i]
+                    val firstGlyph = if (firstExtras == null || firstExtras.isEmpty()) null else snapshot.glyphAt(i)
+                    val firstPaintChoice = if (firstGlyph == null) {
+                        pickPaintChoice(
+                            codepoint = cp,
+                            glyphCache = singleGlyphCache,
+                            cache = singlePaintChoiceCache,
+                            primaryPaint = primaryTextPaint,
+                            symbolsPaint = symbolsTextPaint,
+                        )
+                    } else {
+                        pickPaintChoice(
+                            glyph = firstGlyph,
+                            cache = clusterPaintChoiceCache,
+                            primaryPaint = primaryTextPaint,
+                            symbolsPaint = symbolsTextPaint,
+                        )
                     }
                     sb.setLength(0)
                     val startCol = i - rowStart
@@ -477,19 +512,48 @@ fun TerminalCanvas(
                         } else {
                             snapshot.fgArgb[i]
                         }
-                        if (c == 0 || c == 32 || nextFg != fg) break
+                        if (c == 0 || nextFg != fg) break
+                        if (c == 32 && !snapshot.isSpacerContinuation(i)) break
 
-                        val glyph = glyphCache.getOrPut(c) { String(Character.toChars(c)) }
-                        val nextUseSymbols = symbolFallbackCache.getOrPut(c) {
-                            !primaryTextPaint.hasGlyph(glyph) && symbolsTextPaint.hasGlyph(glyph)
+                        if (c == 32) {
+                            i++
+                            continue
                         }
-                        if (nextUseSymbols != useSymbols) break
 
-                        sb.append(glyph)
+                        val extras = snapshot.graphemeExtras[i]
+                        val glyph = if (extras == null || extras.isEmpty()) null else snapshot.glyphAt(i)
+                        val nextPaintChoice = if (glyph == null) {
+                            pickPaintChoice(
+                                codepoint = c,
+                                glyphCache = singleGlyphCache,
+                                cache = singlePaintChoiceCache,
+                                primaryPaint = primaryTextPaint,
+                                symbolsPaint = symbolsTextPaint,
+                            )
+                        } else {
+                            pickPaintChoice(
+                                glyph = glyph,
+                                cache = clusterPaintChoiceCache,
+                                primaryPaint = primaryTextPaint,
+                                symbolsPaint = symbolsTextPaint,
+                            )
+                        }
+                        if (nextPaintChoice != firstPaintChoice) break
+
+                        if (glyph == null) {
+                            sb.appendCodePoint(c)
+                        } else {
+                            sb.append(glyph)
+                        }
                         i++
                     }
 
-                    val paint = if (useSymbols) symbolsTextPaint else primaryTextPaint
+                    val paint = paintForChoice(
+                        choice = firstPaintChoice,
+                        primaryPaint = primaryTextPaint,
+                        symbolsPaint = symbolsTextPaint,
+                        emojiPaint = emojiTextPaint,
+                    )
                     paint.color = fg
                     nCanvas.drawText(sb.toString(), startCol * cellWidth, baseline, paint)
                 }
@@ -523,13 +587,34 @@ fun TerminalCanvas(
                 if (cursorTextColorArgb != null && cursorIndex in snapshot.codepoints.indices) {
                     val codepoint = snapshot.codepoints[cursorIndex]
                     if (codepoint != 0 && codepoint != 32) {
-                        val glyph = glyphCache.getOrPut(codepoint) {
-                            String(Character.toChars(codepoint))
+                        val extras = snapshot.graphemeExtras[cursorIndex]
+                        val glyph = if (extras == null || extras.isEmpty()) {
+                            singleGlyphCache.getOrPut(codepoint) { String(Character.toChars(codepoint)) }
+                        } else {
+                            snapshot.glyphAt(cursorIndex)
                         }
-                        val useSymbols = symbolFallbackCache.getOrPut(codepoint) {
-                            !primaryTextPaint.hasGlyph(glyph) && symbolsTextPaint.hasGlyph(glyph)
+                        val cursorPaintChoice = if (extras == null || extras.isEmpty()) {
+                            pickPaintChoice(
+                                codepoint = codepoint,
+                                glyphCache = singleGlyphCache,
+                                cache = singlePaintChoiceCache,
+                                primaryPaint = primaryTextPaint,
+                                symbolsPaint = symbolsTextPaint,
+                            )
+                        } else {
+                            pickPaintChoice(
+                                glyph = glyph,
+                                cache = clusterPaintChoiceCache,
+                                primaryPaint = primaryTextPaint,
+                                symbolsPaint = symbolsTextPaint,
+                            )
                         }
-                        val paint = if (useSymbols) symbolsTextPaint else primaryTextPaint
+                        val paint = paintForChoice(
+                            choice = cursorPaintChoice,
+                            primaryPaint = primaryTextPaint,
+                            symbolsPaint = symbolsTextPaint,
+                            emojiPaint = emojiTextPaint,
+                        )
                         paint.color = cursorTextColorArgb
                         nCanvas.drawText(
                             glyph,
@@ -542,6 +627,15 @@ fun TerminalCanvas(
             }
             nCanvas.restore()
         }
+        val frameEndNs = SystemClock.elapsedRealtimeNanos()
+        canvasPerfTracker.record(
+            drawNs = frameEndNs - frameStartNs,
+            cols = snapshot.cols,
+            rows = snapshot.rows,
+            extras = snapshot.graphemeExtras.size,
+            images = snapshot.images.size,
+            selectionActive = selection != null,
+        )
     }
 }
 
@@ -572,14 +666,20 @@ private fun TerminalSnapshot.wordAt(cellIndex: Int): IntRange? {
     val rowEnd = rowStart + cols - 1
 
     val cp = codepoints[cellIndex]
-    if (cp == 0 || cp == 32) return null
+    if (cp == 0 || (cp == 32 && !isSpacerContinuation(cellIndex))) return null
 
     var start = cellIndex
-    while (start > rowStart && codepoints[start - 1] != 0 && codepoints[start - 1] != 32) {
+    while (start > rowStart) {
+        val prev = start - 1
+        val prevCp = codepoints[prev]
+        if (prevCp == 0 || (prevCp == 32 && !isSpacerContinuation(prev))) break
         start--
     }
     var end = cellIndex
-    while (end < rowEnd && codepoints[end + 1] != 0 && codepoints[end + 1] != 32) {
+    while (end < rowEnd) {
+        val next = end + 1
+        val nextCp = codepoints[next]
+        if (nextCp == 0 || (nextCp == 32 && !isSpacerContinuation(next))) break
         end++
     }
     return start..end
@@ -588,29 +688,37 @@ private fun TerminalSnapshot.wordAt(cellIndex: Int): IntRange? {
 private fun extractSelectionText(snapshot: TerminalSnapshot, selection: TerminalSelection?): String? {
     if (selection == null) return null
     val range = selection.normalized(snapshot.codepoints.size) ?: return null
-    if (snapshot.cols <= 0) return null
+    return extractSelectionText(snapshot, range)
+}
 
-    val startRow = range.first / snapshot.cols
-    val endRow = range.last / snapshot.cols
-    val builder = StringBuilder(range.last - range.first + 1 + (endRow - startRow))
+internal fun extractSelectionText(snapshot: TerminalSnapshot, range: IntRange): String? {
+    if (snapshot.cols <= 0 || snapshot.codepoints.isEmpty()) return null
+
+    val normalizedRange = IntRange(
+        start = range.first.coerceIn(0, snapshot.codepoints.lastIndex),
+        endInclusive = range.last.coerceIn(0, snapshot.codepoints.lastIndex),
+    )
+    val startRow = normalizedRange.first / snapshot.cols
+    val endRow = normalizedRange.last / snapshot.cols
+    val builder = StringBuilder(normalizedRange.last - normalizedRange.first + 1 + (endRow - startRow))
 
     for (row in startRow..endRow) {
         val rowStart = row * snapshot.cols
-        val from = maxOf(range.first, rowStart)
-        val until = minOf(range.last, rowStart + snapshot.cols - 1)
+        val from = maxOf(normalizedRange.first, rowStart)
+        val until = minOf(normalizedRange.last, rowStart + snapshot.cols - 1)
         // Find last non-blank cell in this row range to trim trailing whitespace
         var lastContentIdx = until
         while (lastContentIdx >= from) {
             val cp = snapshot.codepoints[lastContentIdx]
-            if (cp != 0 && cp != 32) break
+            if (cp != 0 && (cp != 32 || snapshot.isSpacerContinuation(lastContentIdx))) break
             lastContentIdx--
         }
         for (index in from..lastContentIdx) {
             val codepoint = snapshot.codepoints[index]
-            if (codepoint == 0 || codepoint == 32) {
+            if (codepoint == 0 || (codepoint == 32 && !snapshot.isSpacerContinuation(index))) {
                 builder.append(' ')
-            } else {
-                builder.appendCodePoint(codepoint)
+            } else if (codepoint != 32) {
+                builder.append(snapshot.glyphAt(index))
             }
         }
         if (row != endRow) {
@@ -619,6 +727,122 @@ private fun extractSelectionText(snapshot: TerminalSnapshot, selection: Terminal
     }
 
     return builder.toString()
+}
+
+internal fun TerminalSnapshot.isSpacerContinuation(cellIndex: Int): Boolean {
+    return ((flags[cellIndex].toInt() and 0xFF) and TerminalSnapshot.CELL_FLAG_SPACER) != 0
+}
+
+private fun TerminalSnapshot.glyphAt(cellIndex: Int): String {
+    val codepoint = codepoints[cellIndex]
+    val extras = graphemeExtras[cellIndex]
+    if (extras == null || extras.isEmpty()) return String(Character.toChars(codepoint))
+    val builder = StringBuilder(1 + extras.size)
+    builder.appendCodePoint(codepoint)
+    for (cp in extras) builder.appendCodePoint(cp)
+    return builder.toString()
+}
+
+private const val PAINT_PRIMARY: Int = 0
+private const val PAINT_SYMBOLS: Int = 1
+private const val PAINT_EMOJI: Int = 2
+
+/**
+ * Decide which paint should render a grapheme cluster.
+ *
+ * Order of preference:
+ *  1. If the primary text font can render the cluster, use it (keeps code
+ *     glyph metrics intact).
+ *  2. Else, if the first codepoint lives in a Nerd Font private-use range
+ *     and the symbols paint has the glyph, use the symbols (Nerd Font) paint.
+ *  3. Else, use the emoji paint (system default Typeface), which routes
+ *     through Android's NotoColorEmoji + font fallback chain and is the only
+ *     paint that can shape emoji ZWJ sequences, regional-indicator flag
+ *     pairs, and VS16-promoted color emoji.
+ */
+private fun pickPaintChoice(
+    glyph: String,
+    cache: HashMap<String, Int>,
+    primaryPaint: Paint,
+    symbolsPaint: Paint,
+): Int {
+    return cache.getOrPut(glyph) {
+        if (primaryPaint.hasGlyph(glyph)) return@getOrPut PAINT_PRIMARY
+        val firstCp = glyph.codePointAt(0)
+        if (isNerdFontPrivateUse(firstCp) && symbolsPaint.hasGlyph(glyph)) {
+            return@getOrPut PAINT_SYMBOLS
+        }
+        PAINT_EMOJI
+    }
+}
+
+private fun pickPaintChoice(
+    codepoint: Int,
+    glyphCache: HashMap<Int, String>,
+    cache: HashMap<Int, Int>,
+    primaryPaint: Paint,
+    symbolsPaint: Paint,
+): Int {
+    // Fast path for the overwhelmingly common command-output ASCII glyphs.
+    if (codepoint in 0x21..0x7E) return PAINT_PRIMARY
+
+    return cache.getOrPut(codepoint) {
+        val glyph = glyphCache.getOrPut(codepoint) { String(Character.toChars(codepoint)) }
+        if (primaryPaint.hasGlyph(glyph)) return@getOrPut PAINT_PRIMARY
+        if (isNerdFontPrivateUse(codepoint) && symbolsPaint.hasGlyph(glyph)) {
+            return@getOrPut PAINT_SYMBOLS
+        }
+        PAINT_EMOJI
+    }
+}
+
+private fun paintForChoice(
+    choice: Int,
+    primaryPaint: Paint,
+    symbolsPaint: Paint,
+    emojiPaint: Paint,
+): Paint = when (choice) {
+    PAINT_SYMBOLS -> symbolsPaint
+    PAINT_EMOJI -> emojiPaint
+    else -> primaryPaint
+}
+
+/**
+ * Private Use Area ranges where Nerd Font glyphs live (devicons, powerline,
+ * weather icons, file-type icons, etc.). Everything outside these ranges that
+ * the primary font cannot render is treated as an emoji/symbol cluster.
+ */
+private fun isNerdFontPrivateUse(cp: Int): Boolean {
+    return (cp in 0xE000..0xF8FF) ||
+        (cp in 0xF0000..0xFFFFD) ||
+        (cp in 0x100000..0x10FFFD)
+}
+
+private class CanvasPerfTracker {
+    private var calls: Long = 0
+    private var totalNs: Long = 0
+
+    fun record(
+        drawNs: Long,
+        cols: Int,
+        rows: Int,
+        extras: Int,
+        images: Int,
+        selectionActive: Boolean,
+    ) {
+        calls++
+        totalNs += drawNs
+        val now = SystemClock.elapsedRealtimeNanos()
+        val slow = drawNs >= 16_000_000L
+        if (!slow) return
+
+        val avgMs = if (calls > 0) (totalNs / calls) / 1_000_000.0 else 0.0
+        Log.w(
+            "TerminalPerf",
+            "canvas_draw SLOW total=${"%.2f".format(drawNs / 1_000_000.0)}ms avg=${"%.2f".format(avgMs)}ms " +
+                "grid=${cols}x$rows extras=$extras images=$images selection=$selectionActive calls=$calls",
+        )
+    }
 }
 
 /** Tracks double-tap timing/position without triggering Compose recomposition. */

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/EmojiSnapshotRegressionTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/EmojiSnapshotRegressionTest.kt
@@ -1,0 +1,242 @@
+package com.jossephus.chuchu.ui.terminal
+
+import com.jossephus.chuchu.service.terminal.TerminalSnapshot
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmojiSnapshotRegressionTest {
+    @Test
+    fun parsesGraphemeExtrasAndSpacerFlagsForZwjBridgeCells() {
+        val cols = 4
+        val rows = 1
+        val cellCount = cols * rows
+        val headerBytes = 12 * 4
+        val gridBytes = cellCount * 11
+        val extrasOffset = headerBytes + gridBytes
+
+        val extrasRecordCount = 1
+        val extrasCodepoints = 1
+        val extrasBytes = 4 + (extrasRecordCount * 8) + (extrasCodepoints * 4)
+
+        val raw = ByteBuffer.allocate(headerBytes + gridBytes + extrasBytes).order(ByteOrder.LITTLE_ENDIAN)
+
+        // Header
+        raw.putInt(cols)
+        raw.putInt(rows)
+        raw.putInt(0) // cursor x
+        raw.putInt(0) // cursor y
+        raw.putInt(1) // cursor visible
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(255)
+        raw.putInt(255)
+        raw.putInt(255)
+        raw.putInt(extrasOffset)
+
+        fun putCell(codepoint: Int, flags: Int) {
+            raw.putInt(codepoint)
+            raw.put(255.toByte())
+            raw.put(255.toByte())
+            raw.put(255.toByte())
+            raw.put(0.toByte())
+            raw.put(0.toByte())
+            raw.put(0.toByte())
+            raw.put((flags and 0xFF).toByte())
+        }
+
+        // Cell 0: 🧑 + ZWJ (extras), Cell 1: 💻, Cell 2: spacer continuation, Cell 3: plain space
+        putCell(0x1F9D1, TerminalSnapshot.CELL_FLAG_HAS_GRAPHEME)
+        putCell(0x1F4BB, 0)
+        putCell(32, TerminalSnapshot.CELL_FLAG_SPACER)
+        putCell(32, 0)
+
+        // Extras section: one record for cell 0 with one extra codepoint U+200D
+        raw.putInt(1)
+        raw.putInt(0)
+        raw.putInt(1)
+        raw.putInt(0x200D)
+
+        raw.position(0)
+        val snapshot = TerminalSnapshot.fromByteBuffer(raw)
+
+        assertArrayEquals(intArrayOf(0x200D), snapshot.graphemeExtras[0])
+        assertTrue(snapshot.isSpacerContinuation(2))
+        assertFalse(snapshot.isSpacerContinuation(3))
+    }
+
+    @Test
+    fun selectionFallbackReconstructsZwjEmojiAcrossSpacerCells() {
+        val snapshot = snapshotOf(
+            cols = 4,
+            rows = 1,
+            cells = listOf(
+                Cell(0x1F9D1, TerminalSnapshot.CELL_FLAG_HAS_GRAPHEME),
+                Cell(0x1F4BB, 0),
+                Cell(32, TerminalSnapshot.CELL_FLAG_SPACER),
+                Cell(32, 0),
+            ),
+            extras = mapOf(0 to intArrayOf(0x200D)),
+        )
+
+        assertEquals("🧑‍💻", extractSelectionText(snapshot, 0..3))
+    }
+
+    @Test
+    fun selectionFallbackReconstructsFlagsAcrossSpacerCells() {
+        val snapshot = snapshotOf(
+            cols = 5,
+            rows = 1,
+            cells = listOf(
+                Cell(0x1F1FA, 0),
+                Cell(32, TerminalSnapshot.CELL_FLAG_SPACER),
+                Cell(0x1F1F8, 0),
+                Cell(32, TerminalSnapshot.CELL_FLAG_SPACER),
+                Cell(32, 0),
+            ),
+        )
+
+        assertEquals("🇺🇸", extractSelectionText(snapshot, 0..4))
+    }
+
+    @Test
+    fun selectionFallbackReconstructsMode2027SingleCellCoupleZwjCluster() {
+        val snapshot = snapshotOf(
+            cols = 1,
+            rows = 1,
+            cells = listOf(
+                Cell(0x1F469, TerminalSnapshot.CELL_FLAG_HAS_GRAPHEME),
+            ),
+            extras = mapOf(
+                0 to intArrayOf(
+                    0x200D, // ZWJ
+                    0x2764, // HEART
+                    0xFE0F, // VS16
+                    0x200D, // ZWJ
+                    0x1F48B, // KISS MARK
+                    0x200D, // ZWJ
+                    0x1F468, // MAN
+                ),
+            ),
+        )
+
+        assertEquals("👩‍❤️‍💋‍👨", extractSelectionText(snapshot, 0..0))
+    }
+
+    @Test
+    fun parsingMode2027ExtrasDoesNotInjectSkinToneModifiers() {
+        val cols = 3
+        val rows = 1
+        val cellCount = cols * rows
+        val headerBytes = 12 * 4
+        val gridBytes = cellCount * 11
+        val extrasOffset = headerBytes + gridBytes
+
+        // Record 0: 🧑 + ZWJ + 💻
+        // Record 1: 👩 + ZWJ + ❤️ + ZWJ + 👨
+        val extrasRecordCount = 2
+        val record0 = intArrayOf(0x200D, 0x1F4BB)
+        val record1 = intArrayOf(0x200D, 0x2764, 0xFE0F, 0x200D, 0x1F468)
+        val extrasCodepoints = record0.size + record1.size
+        val extrasBytes = 4 + (extrasRecordCount * 8) + (extrasCodepoints * 4)
+
+        val raw = ByteBuffer.allocate(headerBytes + gridBytes + extrasBytes).order(ByteOrder.LITTLE_ENDIAN)
+
+        // Header
+        raw.putInt(cols)
+        raw.putInt(rows)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(1)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(255)
+        raw.putInt(255)
+        raw.putInt(255)
+        raw.putInt(extrasOffset)
+
+        fun putCell(codepoint: Int, flags: Int) {
+            raw.putInt(codepoint)
+            raw.put(255.toByte())
+            raw.put(255.toByte())
+            raw.put(255.toByte())
+            raw.put(0.toByte())
+            raw.put(0.toByte())
+            raw.put(0.toByte())
+            raw.put((flags and 0xFF).toByte())
+        }
+
+        putCell(0x1F9D1, TerminalSnapshot.CELL_FLAG_HAS_GRAPHEME)
+        putCell(0x1F469, TerminalSnapshot.CELL_FLAG_HAS_GRAPHEME)
+        putCell(0x1F44B, 0)
+
+        raw.putInt(extrasRecordCount)
+        raw.putInt(0)
+        raw.putInt(record0.size)
+        record0.forEach { raw.putInt(it) }
+        raw.putInt(1)
+        raw.putInt(record1.size)
+        record1.forEach { raw.putInt(it) }
+
+        raw.position(0)
+        val snapshot = TerminalSnapshot.fromByteBuffer(raw)
+
+        assertArrayEquals(record0, snapshot.graphemeExtras[0])
+        assertArrayEquals(record1, snapshot.graphemeExtras[1])
+        assertEquals("🧑‍💻", extractSelectionText(snapshot, 0..0))
+        assertEquals("👩‍❤️‍👨", extractSelectionText(snapshot, 1..1))
+
+        val skinToneRange = 0x1F3FB..0x1F3FF
+        val reconstructed = buildString {
+            append(extractSelectionText(snapshot, 0..0))
+            append(extractSelectionText(snapshot, 1..1))
+        }
+        assertTrue(reconstructed.codePoints().noneMatch { cp -> cp in skinToneRange })
+    }
+
+    private data class Cell(
+        val codepoint: Int,
+        val flags: Int,
+    )
+
+    private fun snapshotOf(
+        cols: Int,
+        rows: Int,
+        cells: List<Cell>,
+        extras: Map<Int, IntArray> = emptyMap(),
+    ): TerminalSnapshot {
+        val cellCount = cols * rows
+        require(cells.size == cellCount)
+
+        val codepoints = IntArray(cellCount)
+        val fgArgb = IntArray(cellCount) { 0xFFFFFFFF.toInt() }
+        val bgArgb = IntArray(cellCount) { 0xFF000000.toInt() }
+        val flags = ByteArray(cellCount)
+
+        for ((index, cell) in cells.withIndex()) {
+            codepoints[index] = cell.codepoint
+            flags[index] = (cell.flags and 0xFF).toByte()
+        }
+
+        return TerminalSnapshot(
+            cols = cols,
+            rows = rows,
+            cursorX = 0,
+            cursorY = 0,
+            cursorVisible = false,
+            defaultBgArgb = 0xFF000000.toInt(),
+            defaultFgArgb = 0xFFFFFFFF.toInt(),
+            codepoints = codepoints,
+            fgArgb = fgArgb,
+            bgArgb = bgArgb,
+            flags = flags,
+            graphemeExtras = extras,
+        )
+    }
+}

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -11,8 +11,29 @@ const c = @cImport({
 const allocator = std.heap.c_allocator;
 const LOG_TAG = "ChuKittyNative";
 const verbose_kitty_logs = false;
-const SNAPSHOT_HEADER_I32_COUNT = 11;
+const verbose_snapshot_perf_logs = false;
+// Header layout (LE i32 fields):
+//   0  cols
+//   1  rows
+//   2  cursor_x
+//   3  cursor_y
+//   4  cursor_visible
+//   5  default_bg_r
+//   6  default_bg_g
+//   7  default_bg_b
+//   8  default_fg_r
+//   9  default_fg_g
+//  10  default_fg_b
+//  11  extras_offset (byte offset to grapheme extras section, 0 if none)
+const SNAPSHOT_HEADER_I32_COUNT = 12;
 const SNAPSHOT_CELL_SIZE_BYTES = 11;
+// Flag bit set on a cell whose codepoint has additional grapheme codepoints
+// in the extras section.
+const CELL_FLAG_HAS_GRAPHEME: u8 = 1 << 6;
+// Flag bit set on spacer cells that belong to a wide glyph cluster.
+// These are serialized with codepoint=32 but should not force a shaping
+// run break between neighboring glyph cells.
+const CELL_FLAG_SPACER: u8 = 1 << 7;
 const IMAGE_HEADER_BYTES = 44;
 const MAX_KITTY_IMAGES = 64;
 const DeviceAttributes = blk: {
@@ -83,9 +104,13 @@ const ChuchuTerminal = struct {
     pwd_dirty: bool = false,
     bell_count: u32 = 0,
     snapshot_buffer: std.ArrayListUnmanaged(u8) = .empty,
+    snapshot_extras_scratch: std.ArrayListUnmanaged(u32) = .empty,
     image_snapshot_buffer: std.ArrayListUnmanaged(u8) = .empty,
     pty_write_buffer: std.ArrayListUnmanaged(u8) = .empty,
     pty_write_len: usize = 0,
+    snapshot_perf_calls: u64 = 0,
+    snapshot_perf_total_ns: u64 = 0,
+    snapshot_perf_last_log_ns: i64 = 0,
 };
 
 fn chuchuFromHandle(handle: c.jlong) ?*ChuchuTerminal {
@@ -127,6 +152,46 @@ fn logWarn(comptime fmt: []const u8, args: anytype) void {
     var buf: [256]u8 = undefined;
     const line = std.fmt.bufPrint(&buf, fmt, args) catch return;
     logLine(c.ANDROID_LOG_WARN, line);
+}
+
+fn maybeLogSnapshotPerf(
+    terminal: *ChuchuTerminal,
+    cols: usize,
+    rows: usize,
+    extras_records: usize,
+    non_blank_cells: usize,
+    total_size: usize,
+    update_ns: i128,
+    build_ns: i128,
+    total_ns: i128,
+) void {
+    if (!verbose_snapshot_perf_logs) return;
+    if (total_ns <= 0) return;
+
+    const total_u64: u64 = @intCast(total_ns);
+    terminal.snapshot_perf_calls += 1;
+    terminal.snapshot_perf_total_ns +%= total_u64;
+
+    const now: i64 = @intCast(std.time.nanoTimestamp());
+    const slow = total_ns >= 8 * std.time.ns_per_ms or update_ns >= 4 * std.time.ns_per_ms or build_ns >= 6 * std.time.ns_per_ms;
+    const interval_elapsed = now - terminal.snapshot_perf_last_log_ns >= std.time.ns_per_s;
+    if (!slow and !interval_elapsed) return;
+
+    const avg_ns = if (terminal.snapshot_perf_calls > 0)
+        terminal.snapshot_perf_total_ns / terminal.snapshot_perf_calls
+    else
+        0;
+
+    const total_ms = @as(f64, @floatFromInt(total_u64)) / @as(f64, @floatFromInt(std.time.ns_per_ms));
+    const avg_ms = @as(f64, @floatFromInt(avg_ns)) / @as(f64, @floatFromInt(std.time.ns_per_ms));
+    const update_ms = @as(f64, @floatFromInt(@as(u64, @intCast(update_ns)))) / @as(f64, @floatFromInt(std.time.ns_per_ms));
+    const build_ms = @as(f64, @floatFromInt(@as(u64, @intCast(build_ns)))) / @as(f64, @floatFromInt(std.time.ns_per_ms));
+
+    logWarn(
+        "snapshot_perf total={d:.2}ms avg={d:.2}ms update={d:.2}ms build={d:.2}ms grid={}x{} extras={} non_blank={} bytes={} calls={}",
+        .{ total_ms, avg_ms, update_ms, build_ms, cols, rows, extras_records, non_blank_cells, total_size, terminal.snapshot_perf_calls },
+    );
+    terminal.snapshot_perf_last_log_ns = now;
 }
 
 fn logKittyState(stage: []const u8, terminal: *ChuchuTerminal) void {
@@ -220,6 +285,13 @@ fn chuchuXtversion(_: *ghostty.TerminalStream.Handler) []const u8 {
     return "ghostty 1";
 }
 
+fn enableGraphemeClusterMode(terminal: *ChuchuTerminal) void {
+    // TODO(jossephus): check if there is a better way to do this
+    // Enable DEC private mode 2027 so grapheme clusters are width-collapsed
+    // by the VT layer instead of summing per-codepoint wcwidth values.
+    terminal.stream.nextSlice("\x1b[?2027h");
+}
+
 fn appendPtyWrite(terminal: *ChuchuTerminal, bytes: []const u8) void {
     if (bytes.len == 0) return;
     if (std.math.maxInt(usize) - terminal.pty_write_len < bytes.len) return;
@@ -290,6 +362,7 @@ export fn chuchu_create_terminal(cols: c.jint, rows: c.jint, max_scrollback: c.j
         .xtversion = chuchuXtversion,
     };
     terminal.stream = ghostty.TerminalStream.initAlloc(allocator, handler);
+    enableGraphemeClusterMode(terminal);
 
     update_render_state(terminal);
     return chuchuHandleFromPtr(terminal);
@@ -298,6 +371,7 @@ export fn chuchu_create_terminal(cols: c.jint, rows: c.jint, max_scrollback: c.j
 export fn chuchu_destroy_terminal(handle: c.jlong) callconv(.c) void {
     const terminal = chuchuFromHandle(handle) orelse return;
     terminal.snapshot_buffer.deinit(allocator);
+    terminal.snapshot_extras_scratch.deinit(allocator);
     terminal.image_snapshot_buffer.deinit(allocator);
     terminal.pty_write_buffer.deinit(allocator);
     if (terminal.title) |buf| allocator.free(buf);
@@ -578,34 +652,54 @@ fn resolvedStyle(render_cell: ghostty.RenderState.Cell) ghostty.Style {
 
 fn resolvedCodepoint(render_cell: ghostty.RenderState.Cell) u32 {
     if (render_cell.raw.wide == .spacer_tail or render_cell.raw.wide == .spacer_head) return 32;
-    if (render_cell.raw.content_tag == .codepoint_grapheme and render_cell.grapheme.len > 0) return render_cell.grapheme[0];
+
+    // page.Cell.codepoint() is always the base codepoint for this cell.
+    // For .codepoint_grapheme cells, render_cell.grapheme stores only the
+    // appended codepoints, so taking grapheme[0] would drop the base
+    // character (e.g. keycaps would lose the digit and ZWJ chains could
+    // degrade to U+200D as the visible codepoint).
     const cp = render_cell.raw.codepoint();
     return if (cp == 0) 32 else cp;
+}
+
+fn cellHasExtras(render_cell: ghostty.RenderState.Cell) bool {
+    if (render_cell.raw.wide == .spacer_tail or render_cell.raw.wide == .spacer_head) return false;
+    return render_cell.raw.content_tag == .codepoint_grapheme and render_cell.grapheme.len > 0;
 }
 
 export fn chuchu_build_text_snapshot(handle: c.jlong, out_size: [*c]usize) callconv(.c) ?[*]u8 {
     const terminal = chuchuFromHandle(handle) orelse return null;
     if (out_size == null) return null;
 
+    const t_start = std.time.nanoTimestamp();
     update_render_state(terminal);
+    const t_after_update = std.time.nanoTimestamp();
 
     const cols: usize = terminal.render_state.cols;
     const rows: usize = terminal.render_state.rows;
     const header_size = SNAPSHOT_HEADER_I32_COUNT * @sizeOf(i32);
-    const total_size = header_size + (cols * rows * SNAPSHOT_CELL_SIZE_BYTES);
-    const buffer = ensureListSize(&terminal.snapshot_buffer, total_size) orelse return null;
+    const grid_size = cols * rows * SNAPSHOT_CELL_SIZE_BYTES;
+    const base_total_size = header_size + grid_size;
 
-    writeIntLe(i32, buffer[0..total_size], 0, @intCast(cols));
-    writeIntLe(i32, buffer[0..total_size], 4, @intCast(rows));
-    writeIntLe(i32, buffer[0..total_size], 8, if (terminal.render_state.cursor.viewport) |cursor| cursor.x else -1);
-    writeIntLe(i32, buffer[0..total_size], 12, if (terminal.render_state.cursor.viewport) |cursor| cursor.y else -1);
-    writeIntLe(i32, buffer[0..total_size], 16, if (terminal.render_state.cursor.visible and terminal.render_state.cursor.viewport != null) 1 else 0);
-    writeIntLe(i32, buffer[0..total_size], 20, terminal.render_state.colors.background.r);
-    writeIntLe(i32, buffer[0..total_size], 24, terminal.render_state.colors.background.g);
-    writeIntLe(i32, buffer[0..total_size], 28, terminal.render_state.colors.background.b);
-    writeIntLe(i32, buffer[0..total_size], 32, terminal.render_state.colors.foreground.r);
-    writeIntLe(i32, buffer[0..total_size], 36, terminal.render_state.colors.foreground.g);
-    writeIntLe(i32, buffer[0..total_size], 40, terminal.render_state.colors.foreground.b);
+    var buffer = ensureListSize(&terminal.snapshot_buffer, base_total_size) orelse return null;
+
+    writeIntLe(i32, buffer[0..base_total_size], 0, @intCast(cols));
+    writeIntLe(i32, buffer[0..base_total_size], 4, @intCast(rows));
+    writeIntLe(i32, buffer[0..base_total_size], 8, if (terminal.render_state.cursor.viewport) |cursor| cursor.x else -1);
+    writeIntLe(i32, buffer[0..base_total_size], 12, if (terminal.render_state.cursor.viewport) |cursor| cursor.y else -1);
+    writeIntLe(i32, buffer[0..base_total_size], 16, if (terminal.render_state.cursor.visible and terminal.render_state.cursor.viewport != null) 1 else 0);
+    writeIntLe(i32, buffer[0..base_total_size], 20, terminal.render_state.colors.background.r);
+    writeIntLe(i32, buffer[0..base_total_size], 24, terminal.render_state.colors.background.g);
+    writeIntLe(i32, buffer[0..base_total_size], 28, terminal.render_state.colors.background.b);
+    writeIntLe(i32, buffer[0..base_total_size], 32, terminal.render_state.colors.foreground.r);
+    writeIntLe(i32, buffer[0..base_total_size], 36, terminal.render_state.colors.foreground.g);
+    writeIntLe(i32, buffer[0..base_total_size], 40, terminal.render_state.colors.foreground.b);
+    // extras_offset gets patched after we know whether extras exist.
+    writeIntLe(i32, buffer[0..base_total_size], 44, 0);
+
+    terminal.snapshot_extras_scratch.clearRetainingCapacity();
+    var extras_records: usize = 0;
+    var non_blank_cells: usize = 0;
 
     const row_slice = terminal.render_state.row_data.slice();
     const row_cells = row_slice.items(.cells);
@@ -618,6 +712,7 @@ export fn chuchu_build_text_snapshot(handle: c.jlong, out_size: [*c]usize) callc
         var x: usize = 0;
         while (x < cols) : (x += 1) {
             const base = header_size + cell_index * SNAPSHOT_CELL_SIZE_BYTES;
+            const this_index = cell_index;
             cell_index += 1;
 
             const render_cell: ghostty.RenderState.Cell = .{
@@ -639,8 +734,25 @@ export fn chuchu_build_text_snapshot(handle: c.jlong, out_size: [*c]usize) callc
             if (style.flags.inverse) flags |= 1 << 3;
             if (style.flags.blink) flags |= 1 << 4;
             if (style.flags.faint) flags |= 1 << 5;
+            if (render_cell.raw.wide == .spacer_tail or render_cell.raw.wide == .spacer_head) {
+                flags |= CELL_FLAG_SPACER;
+            }
 
-            writeIntLe(i32, buffer[0..total_size], base, @intCast(resolvedCodepoint(render_cell)));
+            if (cellHasExtras(render_cell)) {
+                flags |= CELL_FLAG_HAS_GRAPHEME;
+                std.debug.assert(this_index <= std.math.maxInt(u32));
+                std.debug.assert(render_cell.grapheme.len <= std.math.maxInt(u32));
+                terminal.snapshot_extras_scratch.append(allocator, @intCast(this_index)) catch return null;
+                terminal.snapshot_extras_scratch.append(allocator, @intCast(render_cell.grapheme.len)) catch return null;
+                for (render_cell.grapheme) |cp| {
+                    terminal.snapshot_extras_scratch.append(allocator, @intCast(cp)) catch return null;
+                }
+                extras_records += 1;
+            }
+
+            const serialized_cp = resolvedCodepoint(render_cell);
+            if (serialized_cp != 0 and serialized_cp != 32) non_blank_cells += 1;
+            writeIntLe(i32, buffer[0..base_total_size], base, @intCast(serialized_cp));
             buffer[base + 4] = fg.r;
             buffer[base + 5] = fg.g;
             buffer[base + 6] = fg.b;
@@ -651,7 +763,62 @@ export fn chuchu_build_text_snapshot(handle: c.jlong, out_size: [*c]usize) callc
         }
     }
 
+    if (extras_records == 0) {
+        out_size.* = base_total_size;
+
+        const t_end = std.time.nanoTimestamp();
+        maybeLogSnapshotPerf(
+            terminal,
+            cols,
+            rows,
+            extras_records,
+            non_blank_cells,
+            base_total_size,
+            t_after_update - t_start,
+            t_end - t_after_update,
+            t_end - t_start,
+        );
+        return buffer;
+    }
+
+    // Extras section layout:
+    //   u32 record_count
+    //   For each record:
+    //     u32 cell_index
+    //     u32 count
+    //     u32[count] codepoints
+    const extras_offset: usize = base_total_size;
+    const extras_size: usize = @sizeOf(u32) + terminal.snapshot_extras_scratch.items.len * @sizeOf(u32);
+    const total_size = base_total_size + extras_size;
+
+    buffer = ensureListSize(&terminal.snapshot_buffer, total_size) orelse return null;
+    writeIntLe(i32, buffer[0..total_size], 44, @intCast(extras_offset));
+
+    var write_ptr: usize = extras_offset;
+    writeIntLe(u32, buffer[0..total_size], write_ptr, @intCast(extras_records));
+    write_ptr += @sizeOf(u32);
+
+    for (terminal.snapshot_extras_scratch.items) |word| {
+        writeIntLe(u32, buffer[0..total_size], write_ptr, word);
+        write_ptr += @sizeOf(u32);
+    }
+
+    std.debug.assert(write_ptr == total_size);
+
     out_size.* = total_size;
+
+    const t_end = std.time.nanoTimestamp();
+    maybeLogSnapshotPerf(
+        terminal,
+        cols,
+        rows,
+        extras_records,
+        non_blank_cells,
+        total_size,
+        t_after_update - t_start,
+        t_end - t_after_update,
+        t_end - t_start,
+    );
     return buffer;
 }
 
@@ -1136,8 +1303,8 @@ export fn chuchu_scroll_to_active(handle: c.jlong) callconv(.c) void {
 }
 
 const default_word_boundaries: [20]u21 = .{
-    0, ' ', '\t', '\'', '"', '│', '`', '|', ':', ';', ',',
-    '(', ')', '[', ']', '{', '}', '<', '>', '$',
+    0,   ' ', '\t', '\'', '"', '│', '`', '|', ':', ';', ',',
+    '(', ')', '[',  ']',  '{', '}',   '<', '>', '$',
 };
 
 fn viewportCellToPin(terminal: *ChuchuTerminal, vp_x: u32, vp_y: u32) ?ghostty.Pin {
@@ -1146,7 +1313,7 @@ fn viewportCellToPin(terminal: *ChuchuTerminal, vp_x: u32, vp_y: u32) ?ghostty.P
     return pages.pin(.{ .screen = .{
         .x = @as(u16, @intCast(vp_x)),
         .y = vp_top_point.screen.y + vp_y,
-    }});
+    } });
 }
 
 fn selectionTextFromPins(


### PR DESCRIPTION
fix emoji renderer in terminal canvas. 

before: 
<img width="399" height="384" alt="image" src="https://github.com/user-attachments/assets/676022b9-cb07-4e5b-afad-96980eded79e" />

after: 
<img width="794" height="714" alt="telegram-cloud-photo-size-4-5818802073670192482-x" src="https://github.com/user-attachments/assets/c6575d5f-dcd2-4d7f-9d1f-401ce3b0d03a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better rendering of complex emoji and multi-codepoint grapheme clusters with fallback glyph selection.

* **Bug Fixes**
  * Improved selection extraction to correctly reconstruct emoji and multi-character sequences across spacer cells.
  * Fixes for spacer/space handling to avoid incorrect trimming.

* **Tests**
  * Added regression tests for grapheme extras, ZWJ emoji, flags, and selection reconstruction.

* **Refactor**
  * Performance instrumentation for snapshot parsing, building, and canvas rendering.

* **Chores**
  * Updated ignore rules to exclude an internal directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jossephus/chuchu/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->