### PR TITLE
fix: make SFTP directory listing wait robustly

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -22,6 +22,9 @@ import com.jossephus.chuchu.ui.terminal.TerminalSpecialKey
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -32,6 +35,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -56,8 +60,13 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     private val _connectionTabByTab = MutableStateFlow<Map<String, ConnectionTab>>(emptyMap())
     private val _fileBrowserStateByTab =
         MutableStateFlow<Map<String, FileBrowserUiState>>(emptyMap())
-    private val fileHomeByTab = mutableMapOf<String, String>()
-    private val fileBrowserRefreshJobs = mutableMapOf<String, Job>()
+    private val fileHomeByTab = ConcurrentHashMap<String, String>()
+    private val fileBrowserRefreshJobs = ConcurrentHashMap<String, Job>()
+    private val fileBrowserResolverJobs = ConcurrentHashMap<String, Job>()
+    private val fileBrowserRefreshTokens = ConcurrentHashMap<String, Long>()
+    private val fileBrowserResolverTokens = ConcurrentHashMap<String, Long>()
+    private val nextFileBrowserRefreshToken = AtomicLong(0L)
+    private val nextFileBrowserResolverToken = AtomicLong(0L)
 
     val selectedTab: StateFlow<ConnectionTab> =
         combine(activeTabId, _connectionTabByTab) { id, map ->
@@ -98,6 +107,9 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         _connectionTabByTab.value = _connectionTabByTab.value - id
         _fileBrowserStateByTab.value = _fileBrowserStateByTab.value - id
         fileHomeByTab.remove(id)
+        fileBrowserResolverTokens.remove(id)
+        fileBrowserRefreshTokens.remove(id)
+        fileBrowserResolverJobs.remove(id)?.cancel()
         fileBrowserRefreshJobs.remove(id)?.cancel()
         sessionRepository.closeTab(id)
     }
@@ -122,32 +134,64 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         id: String,
         transform: (FileBrowserUiState) -> FileBrowserUiState,
     ) {
-        val current = _fileBrowserStateByTab.value
-        val previous = current[id] ?: FileBrowserUiState()
-        _fileBrowserStateByTab.value = current + (id to transform(previous))
+        _fileBrowserStateByTab.update { current ->
+            val previous = current[id] ?: FileBrowserUiState()
+            current + (id to transform(previous))
+        }
     }
 
+    private fun tabExists(tabId: String): Boolean = sessionRepository.tabs.value.any { it.id == tabId }
+
+    private fun isCurrentRefresh(tabId: String, token: Long): Boolean =
+        tabExists(tabId) && fileBrowserRefreshTokens[tabId] == token
+
+    private fun isCurrentResolver(tabId: String, token: Long): Boolean =
+        tabExists(tabId) && fileBrowserResolverTokens[tabId] == token
+
     private fun resolveInitialFilePathAndRefresh(tabId: String) {
+        if (!tabExists(tabId)) return
         val cachedHome = fileHomeByTab[tabId]
         if (cachedHome != null) {
             updateFileBrowserState(tabId) { it.copy(currentPath = cachedHome) }
             refreshFileBrowser(tabId)
             return
         }
-        viewModelScope.launch(Dispatchers.IO) {
-            val tabState = sessionRepository.tabs.value.firstOrNull { it.id == tabId }
-            val fallback = tabState?.engine?.state?.value?.pwd?.takeIf { it.isNotBlank() } ?: "/"
-            val resolved =
-                runCatching { sessionRepository.sftpRealpath(tabId, ".") }.getOrNull()
-                    ?.takeIf { it.isNotBlank() }
-                    ?: runCatching { sessionRepository.sftpRealpath(tabId, "~") }.getOrNull()
-                        ?.takeIf { it.isNotBlank() }
-            val initial = resolved ?: fallback
-            fileHomeByTab[tabId] = initial
-            updateFileBrowserState(tabId) {
-                it.copy(currentPath = initial, resolvedHomePath = initial)
+        val resolverToken = nextFileBrowserResolverToken.incrementAndGet()
+        fileBrowserResolverTokens[tabId] = resolverToken
+        fileBrowserResolverJobs.remove(tabId)?.cancel()
+        val resolverJob =
+            viewModelScope.launch(Dispatchers.IO) {
+                val tabState = sessionRepository.tabs.value.firstOrNull { it.id == tabId }
+                val fallback = tabState?.engine?.state?.value?.pwd?.takeIf { it.isNotBlank() } ?: "/"
+                val resolvedCurrent =
+                    try {
+                        sessionRepository.sftpRealpath(tabId, ".").takeIf { it.isNotBlank() }
+                    } catch (err: CancellationException) {
+                        throw err
+                    } catch (_: Exception) {
+                        null
+                    }
+                val resolvedHome =
+                    resolvedCurrent
+                        ?: try {
+                            sessionRepository.sftpRealpath(tabId, "~").takeIf { it.isNotBlank() }
+                        } catch (err: CancellationException) {
+                            throw err
+                        } catch (_: Exception) {
+                            null
+                        }
+                if (!isCurrentResolver(tabId, resolverToken)) return@launch
+                val initial = resolvedHome ?: fallback
+                fileHomeByTab[tabId] = initial
+                updateFileBrowserState(tabId) {
+                    it.copy(currentPath = initial, resolvedHomePath = initial)
+                }
+                refreshFileBrowser(tabId)
             }
-            refreshFileBrowser(tabId)
+        fileBrowserResolverJobs[tabId] = resolverJob
+        resolverJob.invokeOnCompletion {
+            fileBrowserResolverJobs.remove(tabId, resolverJob)
+            fileBrowserResolverTokens.remove(tabId, resolverToken)
         }
     }
 
@@ -157,6 +201,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     }
 
     private fun refreshFileBrowser(tabId: String) {
+        if (!tabExists(tabId)) return
         val pwd =
             sessionRepository.tabs.value
                 .firstOrNull { it.id == tabId }
@@ -165,13 +210,17 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 ?.pwd
                 ?.takeIf { it.isNotBlank() } ?: "/"
         val targetPath = (_fileBrowserStateByTab.value[tabId]?.currentPath?.ifBlank { pwd }) ?: pwd
+        val refreshToken = nextFileBrowserRefreshToken.incrementAndGet()
+        fileBrowserRefreshTokens[tabId] = refreshToken
+        fileBrowserRefreshJobs.remove(tabId)?.cancel()
         updateFileBrowserState(tabId) {
             it.copy(currentPath = targetPath, isLoading = true, error = null)
         }
-        fileBrowserRefreshJobs.remove(tabId)?.cancel()
-        val refreshJob = viewModelScope.launch(Dispatchers.IO) {
-            runCatching { sessionRepository.sftpListDirectory(tabId, targetPath) }
-                .onSuccess { rows ->
+        val refreshJob =
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    val rows = sessionRepository.sftpListDirectory(tabId, targetPath)
+                    if (!isCurrentRefresh(tabId, refreshToken)) return@launch
                     val entries =
                         rows.map { row ->
                             val parts = row.split('\t')
@@ -205,15 +254,16 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                             FileSort.Modified ->
                                 entries.sortedByDescending { it.modifiedAtText ?: "" }
                         }
-                    if (current.currentPath == targetPath) {
+                    if (isCurrentRefresh(tabId, refreshToken) && current.currentPath == targetPath) {
                         updateFileBrowserState(tabId) {
                             it.copy(entries = sortedEntries, isLoading = false, error = null)
                         }
                     }
-                }
-                .onFailure { err ->
+                } catch (err: CancellationException) {
+                    throw err
+                } catch (err: Exception) {
                     val current = _fileBrowserStateByTab.value[tabId]
-                    if (current?.currentPath == targetPath) {
+                    if (isCurrentRefresh(tabId, refreshToken) && current?.currentPath == targetPath) {
                         updateFileBrowserState(tabId) {
                             it.copy(
                                 isLoading = false,
@@ -222,12 +272,11 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                         }
                     }
                 }
-        }
+            }
         fileBrowserRefreshJobs[tabId] = refreshJob
         refreshJob.invokeOnCompletion {
-            if (fileBrowserRefreshJobs[tabId] == refreshJob) {
-                fileBrowserRefreshJobs.remove(tabId)
-            }
+            fileBrowserRefreshJobs.remove(tabId, refreshJob)
+            fileBrowserRefreshTokens.remove(tabId, refreshToken)
         }
     }
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -23,7 +23,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,6 +35,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -61,12 +61,10 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     private val _fileBrowserStateByTab =
         MutableStateFlow<Map<String, FileBrowserUiState>>(emptyMap())
     private val fileHomeByTab = ConcurrentHashMap<String, String>()
+    // One in-flight job per tab for each operation; launching a new one cancels
+    // the previous, so stale responses can never overwrite newer state.
     private val fileBrowserRefreshJobs = ConcurrentHashMap<String, Job>()
     private val fileBrowserResolverJobs = ConcurrentHashMap<String, Job>()
-    private val fileBrowserRefreshTokens = ConcurrentHashMap<String, Long>()
-    private val fileBrowserResolverTokens = ConcurrentHashMap<String, Long>()
-    private val nextFileBrowserRefreshToken = AtomicLong(0L)
-    private val nextFileBrowserResolverToken = AtomicLong(0L)
 
     val selectedTab: StateFlow<ConnectionTab> =
         combine(activeTabId, _connectionTabByTab) { id, map ->
@@ -107,8 +105,6 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         _connectionTabByTab.value = _connectionTabByTab.value - id
         _fileBrowserStateByTab.value = _fileBrowserStateByTab.value - id
         fileHomeByTab.remove(id)
-        fileBrowserResolverTokens.remove(id)
-        fileBrowserRefreshTokens.remove(id)
         fileBrowserResolverJobs.remove(id)?.cancel()
         fileBrowserRefreshJobs.remove(id)?.cancel()
         sessionRepository.closeTab(id)
@@ -142,11 +138,14 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
 
     private fun tabExists(tabId: String): Boolean = sessionRepository.tabs.value.any { it.id == tabId }
 
-    private fun isCurrentRefresh(tabId: String, token: Long): Boolean =
-        tabExists(tabId) && fileBrowserRefreshTokens[tabId] == token
-
-    private fun isCurrentResolver(tabId: String, token: Long): Boolean =
-        tabExists(tabId) && fileBrowserResolverTokens[tabId] == token
+    private suspend fun resolveRealpath(tabId: String, path: String): String? =
+        try {
+            sessionRepository.sftpRealpath(tabId, path).takeIf { it.isNotBlank() }
+        } catch (err: CancellationException) {
+            throw err
+        } catch (_: Exception) {
+            null
+        }
 
     private fun resolveInitialFilePathAndRefresh(tabId: String) {
         if (!tabExists(tabId)) return
@@ -156,32 +155,14 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
             refreshFileBrowser(tabId)
             return
         }
-        val resolverToken = nextFileBrowserResolverToken.incrementAndGet()
-        fileBrowserResolverTokens[tabId] = resolverToken
         fileBrowserResolverJobs.remove(tabId)?.cancel()
         val resolverJob =
             viewModelScope.launch(Dispatchers.IO) {
                 val tabState = sessionRepository.tabs.value.firstOrNull { it.id == tabId }
                 val fallback = tabState?.engine?.state?.value?.pwd?.takeIf { it.isNotBlank() } ?: "/"
-                val resolvedCurrent =
-                    try {
-                        sessionRepository.sftpRealpath(tabId, ".").takeIf { it.isNotBlank() }
-                    } catch (err: CancellationException) {
-                        throw err
-                    } catch (_: Exception) {
-                        null
-                    }
-                val resolvedHome =
-                    resolvedCurrent
-                        ?: try {
-                            sessionRepository.sftpRealpath(tabId, "~").takeIf { it.isNotBlank() }
-                        } catch (err: CancellationException) {
-                            throw err
-                        } catch (_: Exception) {
-                            null
-                        }
-                if (!isCurrentResolver(tabId, resolverToken)) return@launch
-                val initial = resolvedHome ?: fallback
+                val resolved = resolveRealpath(tabId, ".") ?: resolveRealpath(tabId, "~")
+                if (!isActive || !tabExists(tabId)) return@launch
+                val initial = resolved ?: fallback
                 fileHomeByTab[tabId] = initial
                 updateFileBrowserState(tabId) {
                     it.copy(currentPath = initial, resolvedHomePath = initial)
@@ -189,10 +170,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 refreshFileBrowser(tabId)
             }
         fileBrowserResolverJobs[tabId] = resolverJob
-        resolverJob.invokeOnCompletion {
-            fileBrowserResolverJobs.remove(tabId, resolverJob)
-            fileBrowserResolverTokens.remove(tabId, resolverToken)
-        }
+        resolverJob.invokeOnCompletion { fileBrowserResolverJobs.remove(tabId, resolverJob) }
     }
 
     fun refreshFileBrowser() {
@@ -210,8 +188,6 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 ?.pwd
                 ?.takeIf { it.isNotBlank() } ?: "/"
         val targetPath = (_fileBrowserStateByTab.value[tabId]?.currentPath?.ifBlank { pwd }) ?: pwd
-        val refreshToken = nextFileBrowserRefreshToken.incrementAndGet()
-        fileBrowserRefreshTokens[tabId] = refreshToken
         fileBrowserRefreshJobs.remove(tabId)?.cancel()
         updateFileBrowserState(tabId) {
             it.copy(currentPath = targetPath, isLoading = true, error = null)
@@ -220,7 +196,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
             viewModelScope.launch(Dispatchers.IO) {
                 try {
                     val rows = sessionRepository.sftpListDirectory(tabId, targetPath)
-                    if (!isCurrentRefresh(tabId, refreshToken)) return@launch
+                    if (!isActive) return@launch
                     val entries =
                         rows.map { row ->
                             val parts = row.split('\t')
@@ -254,7 +230,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                             FileSort.Modified ->
                                 entries.sortedByDescending { it.modifiedAtText ?: "" }
                         }
-                    if (isCurrentRefresh(tabId, refreshToken) && current.currentPath == targetPath) {
+                    if (isActive && current.currentPath == targetPath) {
                         updateFileBrowserState(tabId) {
                             it.copy(entries = sortedEntries, isLoading = false, error = null)
                         }
@@ -263,7 +239,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                     throw err
                 } catch (err: Exception) {
                     val current = _fileBrowserStateByTab.value[tabId]
-                    if (isCurrentRefresh(tabId, refreshToken) && current?.currentPath == targetPath) {
+                    if (isActive && current?.currentPath == targetPath) {
                         updateFileBrowserState(tabId) {
                             it.copy(
                                 isLoading = false,
@@ -274,10 +250,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 }
             }
         fileBrowserRefreshJobs[tabId] = refreshJob
-        refreshJob.invokeOnCompletion {
-            fileBrowserRefreshJobs.remove(tabId, refreshJob)
-            fileBrowserRefreshTokens.remove(tabId, refreshToken)
-        }
+        refreshJob.invokeOnCompletion { fileBrowserRefreshJobs.remove(tabId, refreshJob) }
     }
 
     suspend fun beginUpload(fileName: String) {

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -24,6 +24,7 @@ import java.util.Date
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -56,6 +57,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     private val _fileBrowserStateByTab =
         MutableStateFlow<Map<String, FileBrowserUiState>>(emptyMap())
     private val fileHomeByTab = mutableMapOf<String, String>()
+    private val fileBrowserRefreshJobs = mutableMapOf<String, Job>()
 
     val selectedTab: StateFlow<ConnectionTab> =
         combine(activeTabId, _connectionTabByTab) { id, map ->
@@ -96,6 +98,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         _connectionTabByTab.value = _connectionTabByTab.value - id
         _fileBrowserStateByTab.value = _fileBrowserStateByTab.value - id
         fileHomeByTab.remove(id)
+        fileBrowserRefreshJobs.remove(id)?.cancel()
         sessionRepository.closeTab(id)
     }
 
@@ -134,8 +137,12 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch(Dispatchers.IO) {
             val tabState = sessionRepository.tabs.value.firstOrNull { it.id == tabId }
             val fallback = tabState?.engine?.state?.value?.pwd?.takeIf { it.isNotBlank() } ?: "/"
-            val resolved = runCatching { sessionRepository.sftpRealpath(tabId, "~") }.getOrNull()
-            val initial = resolved?.takeIf { it.isNotBlank() } ?: fallback
+            val resolved =
+                runCatching { sessionRepository.sftpRealpath(tabId, ".") }.getOrNull()
+                    ?.takeIf { it.isNotBlank() }
+                    ?: runCatching { sessionRepository.sftpRealpath(tabId, "~") }.getOrNull()
+                        ?.takeIf { it.isNotBlank() }
+            val initial = resolved ?: fallback
             fileHomeByTab[tabId] = initial
             updateFileBrowserState(tabId) {
                 it.copy(currentPath = initial, resolvedHomePath = initial)
@@ -161,7 +168,8 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         updateFileBrowserState(tabId) {
             it.copy(currentPath = targetPath, isLoading = true, error = null)
         }
-        viewModelScope.launch(Dispatchers.IO) {
+        fileBrowserRefreshJobs.remove(tabId)?.cancel()
+        val refreshJob = viewModelScope.launch(Dispatchers.IO) {
             runCatching { sessionRepository.sftpListDirectory(tabId, targetPath) }
                 .onSuccess { rows ->
                     val entries =
@@ -214,6 +222,12 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                         }
                     }
                 }
+        }
+        fileBrowserRefreshJobs[tabId] = refreshJob
+        refreshJob.invokeOnCompletion {
+            if (fileBrowserRefreshJobs[tabId] == refreshJob) {
+                fileBrowserRefreshJobs.remove(tabId)
+            }
         }
     }
 

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -242,6 +242,29 @@ fn ensureSftp(session: *NativeSshSession) ?*c.LIBSSH2_SFTP {
     }
 }
 
+/// Result of waiting for the SFTP socket after a libssh2 EAGAIN.
+const SftpProgress = enum {
+    /// Socket signalled activity, or we are still inside the idle budget; retry.
+    retry,
+    /// No progress for longer than sftp_idle_limit_ms; the peer is stalled.
+    stalled,
+    /// No socket to wait on (session torn down mid-operation).
+    no_socket,
+};
+
+/// Block briefly on the SFTP socket after an EAGAIN and decide whether the
+/// caller should retry. `idle_since_ms` is reset whenever the socket signals
+/// activity so the idle budget only measures genuinely silent periods.
+fn awaitSftpProgress(session: *NativeSshSession, idle_since_ms: *i64) SftpProgress {
+    if (session.session == null or session.socket_fd < 0) return .no_socket;
+    if (waitSocket(session, io_wait_timeout_ms)) {
+        idle_since_ms.* = nowMs();
+        return .retry;
+    }
+    if (nowMs() - idle_since_ms.* > sftp_idle_limit_ms) return .stalled;
+    return .retry;
+}
+
 fn shutdownSftp(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, reason: []const u8) bool {
     var idle_since_ms = nowMs();
     while (true) {
@@ -251,19 +274,18 @@ fn shutdownSftp(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, reason: []con
             logInfo("SFTP shutdown ended during {s} rc={}", .{ reason, rc });
             return true;
         }
-        if (session.session == null or session.socket_fd < 0) {
-            setError(session, "SFTP shutdown would block during {s} without an active socket", .{reason});
-            return false;
-        }
-        if (waitSocket(session, io_wait_timeout_ms)) {
-            idle_since_ms = nowMs();
-            continue;
-        }
-        const idle_ms = nowMs() - idle_since_ms;
-        if (idle_ms > sftp_idle_limit_ms) {
-            setError(session, "SFTP shutdown stalled during {s} (idle {d}ms)", .{ reason, idle_ms });
-            logError("SFTP shutdown stalled during {s} idle={}ms", .{ reason, idle_ms });
-            return false;
+        switch (awaitSftpProgress(session, &idle_since_ms)) {
+            .retry => {},
+            .no_socket => {
+                setError(session, "SFTP shutdown would block during {s} without an active socket", .{reason});
+                return false;
+            },
+            .stalled => {
+                const idle_ms = nowMs() - idle_since_ms;
+                setError(session, "SFTP shutdown stalled during {s} (idle {d}ms)", .{ reason, idle_ms });
+                logError("SFTP shutdown stalled during {s} idle={}ms", .{ reason, idle_ms });
+                return false;
+            },
         }
     }
 }
@@ -277,19 +299,18 @@ fn closeSftpHandle(session: *NativeSshSession, handle: *c.LIBSSH2_SFTP_HANDLE, r
             setLibssh2Error(session, reason, @intCast(rc));
             return false;
         }
-        if (session.session == null or session.socket_fd < 0) {
-            setError(session, "{s} would block without an active socket", .{reason});
-            return false;
-        }
-        if (waitSocket(session, io_wait_timeout_ms)) {
-            idle_since_ms = nowMs();
-            continue;
-        }
-        const idle_ms = nowMs() - idle_since_ms;
-        if (idle_ms > sftp_idle_limit_ms) {
-            setError(session, "{s} stalled (idle {d}ms)", .{ reason, idle_ms });
-            logError("{s} stalled idle={}ms", .{ reason, idle_ms });
-            return false;
+        switch (awaitSftpProgress(session, &idle_since_ms)) {
+            .retry => {},
+            .no_socket => {
+                setError(session, "{s} would block without an active socket", .{reason});
+                return false;
+            },
+            .stalled => {
+                const idle_ms = nowMs() - idle_since_ms;
+                setError(session, "{s} stalled (idle {d}ms)", .{ reason, idle_ms });
+                logError("{s} stalled idle={}ms", .{ reason, idle_ms });
+                return false;
+            },
         }
     }
 }
@@ -322,25 +343,21 @@ fn sftpOpenDir(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, path_z: [:0]u8
         }
 
         eagain_count +%= 1;
-        if (waitSocket(session, io_wait_timeout_ms)) {
-            idle_since_ms = nowMs();
-            continue;
-        }
-
-        const now = nowMs();
-        const idle_ms = now - idle_since_ms;
-        if (idle_ms > sftp_idle_limit_ms) {
-            const elapsed_ms = now - started_ms;
-            setError(
-                session,
-                "SFTP opendir timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d})",
-                .{ path_z, elapsed_ms, idle_ms, eagain_count },
-            );
-            logError(
-                "SFTP opendir timeout path={s} elapsed={}ms idle={}ms eagain={}",
-                .{ path_z, elapsed_ms, idle_ms, eagain_count },
-            );
-            return null;
+        switch (awaitSftpProgress(session, &idle_since_ms)) {
+            .retry => {},
+            .no_socket, .stalled => {
+                const now = nowMs();
+                setError(
+                    session,
+                    "SFTP opendir timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d})",
+                    .{ path_z, now - started_ms, now - idle_since_ms, eagain_count },
+                );
+                logError(
+                    "SFTP opendir timeout path={s} elapsed={}ms idle={}ms eagain={}",
+                    .{ path_z, now - started_ms, now - idle_since_ms, eagain_count },
+                );
+                return null;
+            },
         }
     }
 }
@@ -1077,12 +1094,15 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeClose(env:
     _ = env;
     _ = thiz;
     const session = sessionFromHandle(handle) orelse return;
+    // Best-effort SFTP teardown: even if it stalls (e.g. the peer is gone), we
+    // must still free the channel, session, and socket below. libssh2_session_free
+    // releases any remaining SFTP state, so a stalled shutdown is not fatal here.
     if (session.upload_handle) |upload_handle| {
-        if (!closeSftpHandle(session, upload_handle, "native close upload handle")) return;
+        _ = closeSftpHandle(session, upload_handle, "native close upload handle");
         session.upload_handle = null;
     }
     if (session.sftp) |sftp| {
-        if (!shutdownSftp(session, sftp, "native close")) return;
+        _ = shutdownSftp(session, sftp, "native close");
         session.sftp = null;
     }
     if (session.channel) |channel| {
@@ -1168,27 +1188,23 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpListDi
         if (rc == 0) break;
         if (rc == c.LIBSSH2_ERROR_EAGAIN) {
             eagain_count +%= 1;
-            if (waitSocket(session, io_wait_timeout_ms)) {
-                idle_since_ms = nowMs();
-                continue;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => continue,
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    setError(
+                        session,
+                        "SFTP readdir timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d}, entries={d})",
+                        .{ path_z, now - started_ms, now - idle_since_ms, eagain_count, names.items.len },
+                    );
+                    logError(
+                        "SFTP readdir timeout path={s} elapsed={}ms idle={}ms eagain={} entries={}",
+                        .{ path_z, now - started_ms, now - idle_since_ms, eagain_count, names.items.len },
+                    );
+                    read_failed = true;
+                    break;
+                },
             }
-            const now = nowMs();
-            const idle_ms = now - idle_since_ms;
-            if (idle_ms > sftp_idle_limit_ms) {
-                const elapsed_ms = now - started_ms;
-                setError(
-                    session,
-                    "SFTP readdir timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d}, entries={d})",
-                    .{ path_z, elapsed_ms, idle_ms, eagain_count, names.items.len },
-                );
-                logError(
-                    "SFTP readdir timeout path={s} elapsed={}ms idle={}ms eagain={} entries={}",
-                    .{ path_z, elapsed_ms, idle_ms, eagain_count, names.items.len },
-                );
-                read_failed = true;
-                break;
-            }
-            continue;
         }
         setSftpError(session, sftp, "SFTP readdir failed", @intCast(rc));
         read_failed = true;
@@ -1238,26 +1254,22 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpRealpa
         }
 
         eagain_count +%= 1;
-        if (waitSocket(session, io_wait_timeout_ms)) {
-            idle_since_ms = nowMs();
-            continue;
-        }
-
-        const now = nowMs();
-        const idle_ms = now - idle_since_ms;
-        if (idle_ms > sftp_idle_limit_ms) {
-            const elapsed_ms = now - started_ms;
-            setError(
-                session,
-                "SFTP realpath timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d})",
-                .{ path_z, elapsed_ms, idle_ms, eagain_count },
-            );
-            logError(
-                "SFTP realpath timeout path={s} elapsed={}ms idle={}ms eagain={}",
-                .{ path_z, elapsed_ms, idle_ms, eagain_count },
-            );
-            resetSftpAfterFailure(session, "realpath timeout");
-            return null;
+        switch (awaitSftpProgress(session, &idle_since_ms)) {
+            .retry => {},
+            .no_socket, .stalled => {
+                const now = nowMs();
+                setError(
+                    session,
+                    "SFTP realpath timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d})",
+                    .{ path_z, now - started_ms, now - idle_since_ms, eagain_count },
+                );
+                logError(
+                    "SFTP realpath timeout path={s} elapsed={}ms idle={}ms eagain={}",
+                    .{ path_z, now - started_ms, now - idle_since_ms, eagain_count },
+                );
+                resetSftpAfterFailure(session, "realpath timeout");
+                return null;
+            },
         }
     }
 }

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -35,6 +35,8 @@ fn logError(comptime fmt: []const u8, args: anytype) void {
 }
 const setup_wait_timeout_ms = 10_000;
 const io_wait_timeout_ms = 120;
+// SFTP servers may make progress between short 120ms socket waits; use a
+// longer idle cap before failing directory listing/realpath as truly stalled.
 const sftp_idle_limit_ms: i64 = 15_000;
 
 const NativeSshSession = struct {
@@ -194,11 +196,11 @@ fn nowMs() i64 {
 
 fn destroyNativeSshSession(session: *NativeSshSession) void {
     if (session.upload_handle) |uh| {
-        _ = c.libssh2_sftp_close_handle(uh);
+        _ = closeSftpHandle(session, uh, "destroy upload handle");
         session.upload_handle = null;
     }
     if (session.sftp) |sftp| {
-        _ = c.libssh2_sftp_shutdown(sftp);
+        _ = shutdownSftp(session, sftp, "destroy session");
         session.sftp = null;
     }
     if (session.channel) |channel| {
@@ -240,6 +242,58 @@ fn ensureSftp(session: *NativeSshSession) ?*c.LIBSSH2_SFTP {
     }
 }
 
+fn shutdownSftp(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, reason: []const u8) bool {
+    var idle_since_ms = nowMs();
+    while (true) {
+        const rc = c.libssh2_sftp_shutdown(sftp);
+        if (rc == 0) return true;
+        if (rc != c.LIBSSH2_ERROR_EAGAIN) {
+            logInfo("SFTP shutdown ended during {s} rc={}", .{ reason, rc });
+            return true;
+        }
+        if (session.session == null or session.socket_fd < 0) {
+            setError(session, "SFTP shutdown would block during {s} without an active socket", .{reason});
+            return false;
+        }
+        if (waitSocket(session, io_wait_timeout_ms)) {
+            idle_since_ms = nowMs();
+            continue;
+        }
+        const idle_ms = nowMs() - idle_since_ms;
+        if (idle_ms > sftp_idle_limit_ms) {
+            setError(session, "SFTP shutdown stalled during {s} (idle {d}ms)", .{ reason, idle_ms });
+            logError("SFTP shutdown stalled during {s} idle={}ms", .{ reason, idle_ms });
+            return false;
+        }
+    }
+}
+
+fn closeSftpHandle(session: *NativeSshSession, handle: *c.LIBSSH2_SFTP_HANDLE, reason: []const u8) bool {
+    var idle_since_ms = nowMs();
+    while (true) {
+        const rc = c.libssh2_sftp_close_handle(handle);
+        if (rc == 0) return true;
+        if (rc != c.LIBSSH2_ERROR_EAGAIN) {
+            setLibssh2Error(session, reason, @intCast(rc));
+            return false;
+        }
+        if (session.session == null or session.socket_fd < 0) {
+            setError(session, "{s} would block without an active socket", .{reason});
+            return false;
+        }
+        if (waitSocket(session, io_wait_timeout_ms)) {
+            idle_since_ms = nowMs();
+            continue;
+        }
+        const idle_ms = nowMs() - idle_since_ms;
+        if (idle_ms > sftp_idle_limit_ms) {
+            setError(session, "{s} stalled (idle {d}ms)", .{ reason, idle_ms });
+            logError("{s} stalled idle={}ms", .{ reason, idle_ms });
+            return false;
+        }
+    }
+}
+
 fn resetSftpAfterFailure(session: *NativeSshSession, reason: []const u8) void {
     if (session.sftp == null) return;
     if (session.upload_handle != null) {
@@ -248,8 +302,9 @@ fn resetSftpAfterFailure(session: *NativeSshSession, reason: []const u8) void {
     }
     logError("Resetting SFTP subsystem after {s}", .{reason});
     if (session.sftp) |sftp| {
-        _ = c.libssh2_sftp_shutdown(sftp);
-        session.sftp = null;
+        if (shutdownSftp(session, sftp, reason)) {
+            session.sftp = null;
+        }
     }
 }
 
@@ -1022,6 +1077,14 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeClose(env:
     _ = env;
     _ = thiz;
     const session = sessionFromHandle(handle) orelse return;
+    if (session.upload_handle) |upload_handle| {
+        if (!closeSftpHandle(session, upload_handle, "native close upload handle")) return;
+        session.upload_handle = null;
+    }
+    if (session.sftp) |sftp| {
+        if (!shutdownSftp(session, sftp, "native close")) return;
+        session.sftp = null;
+    }
     if (session.channel) |channel| {
         _ = c.libssh2_channel_close(channel);
         _ = c.libssh2_channel_free(channel);
@@ -1133,12 +1196,15 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpListDi
     }
 
     if (read_failed) {
-        _ = c.libssh2_sftp_closedir(dir);
+        _ = closeSftpHandle(session, dir, "SFTP closedir after readdir failure");
         resetSftpAfterFailure(session, "readdir failure");
         return null;
     }
 
-    _ = c.libssh2_sftp_closedir(dir);
+    if (!closeSftpHandle(session, dir, "SFTP closedir after list")) {
+        resetSftpAfterFailure(session, "closedir failure");
+        return null;
+    }
 
     const string_class = env.*.*.FindClass.?(env, "java/lang/String") orelse return null;
     const result = env.*.*.NewObjectArray.?(env, @intCast(names.items.len), string_class, null) orelse return null;

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -35,6 +35,7 @@ fn logError(comptime fmt: []const u8, args: anytype) void {
 }
 const setup_wait_timeout_ms = 10_000;
 const io_wait_timeout_ms = 120;
+const sftp_idle_limit_ms: i64 = 15_000;
 
 const NativeSshSession = struct {
     socket_fd: c_int = -1,
@@ -78,6 +79,45 @@ fn setLibssh2Error(session: *NativeSshSession, prefix: []const u8, rc: c_int) vo
     } else {
         setError(session, "{s}: rc={}", .{ prefix, rc });
     }
+}
+
+fn sftpStatusName(code: c_ulong) []const u8 {
+    return switch (code) {
+        c.LIBSSH2_FX_OK => "ok",
+        c.LIBSSH2_FX_EOF => "eof",
+        c.LIBSSH2_FX_NO_SUCH_FILE => "no such file",
+        c.LIBSSH2_FX_PERMISSION_DENIED => "permission denied",
+        c.LIBSSH2_FX_FAILURE => "failure",
+        c.LIBSSH2_FX_BAD_MESSAGE => "bad message",
+        c.LIBSSH2_FX_NO_CONNECTION => "no connection",
+        c.LIBSSH2_FX_CONNECTION_LOST => "connection lost",
+        c.LIBSSH2_FX_OP_UNSUPPORTED => "operation unsupported",
+        c.LIBSSH2_FX_INVALID_HANDLE => "invalid handle",
+        c.LIBSSH2_FX_NO_SUCH_PATH => "no such path",
+        c.LIBSSH2_FX_FILE_ALREADY_EXISTS => "file already exists",
+        c.LIBSSH2_FX_WRITE_PROTECT => "write protected",
+        c.LIBSSH2_FX_NO_MEDIA => "no media",
+        c.LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM => "no space on filesystem",
+        c.LIBSSH2_FX_QUOTA_EXCEEDED => "quota exceeded",
+        c.LIBSSH2_FX_UNKNOWN_PRINCIPAL => "unknown principal",
+        c.LIBSSH2_FX_LOCK_CONFLICT => "lock conflict",
+        c.LIBSSH2_FX_DIR_NOT_EMPTY => "directory not empty",
+        c.LIBSSH2_FX_NOT_A_DIRECTORY => "not a directory",
+        c.LIBSSH2_FX_INVALID_FILENAME => "invalid filename",
+        c.LIBSSH2_FX_LINK_LOOP => "link loop",
+        else => "unknown status",
+    };
+}
+
+fn setSftpError(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, prefix: []const u8, rc: c_int) void {
+    var errmsg_ptr: [*c]const u8 = null;
+    var errmsg_len: c_int = 0;
+    if (session.session) |ssh_session| {
+        _ = c.libssh2_session_last_error(ssh_session, @ptrCast(&errmsg_ptr), &errmsg_len, 0);
+    }
+    const status = c.libssh2_sftp_last_error(sftp);
+    const detail = if (errmsg_ptr != null and errmsg_len > 0) errmsg_ptr[0..@intCast(errmsg_len)] else "libssh2 SFTP error";
+    setError(session, "{s}: {s} (SFTP status {d}: {s}, rc={d})", .{ prefix, detail, status, sftpStatusName(status), rc });
 }
 
 fn closeSocket(fd: c_int) void {
@@ -159,6 +199,7 @@ fn destroyNativeSshSession(session: *NativeSshSession) void {
     }
     if (session.sftp) |sftp| {
         _ = c.libssh2_sftp_shutdown(sftp);
+        session.sftp = null;
     }
     if (session.channel) |channel| {
         _ = c.libssh2_channel_close(channel);
@@ -199,17 +240,51 @@ fn ensureSftp(session: *NativeSshSession) ?*c.LIBSSH2_SFTP {
     }
 }
 
+fn resetSftpAfterFailure(session: *NativeSshSession, reason: []const u8) void {
+    if (session.sftp == null) return;
+    if (session.upload_handle != null) {
+        logError("Skipping SFTP reset after {s}: upload active", .{reason});
+        return;
+    }
+    logError("Resetting SFTP subsystem after {s}", .{reason});
+    if (session.sftp) |sftp| {
+        _ = c.libssh2_sftp_shutdown(sftp);
+        session.sftp = null;
+    }
+}
+
 fn sftpOpenDir(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, path_z: [:0]u8) ?*c.LIBSSH2_SFTP_HANDLE {
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u32 = 0;
     while (true) {
         const dir = c.libssh2_sftp_opendir(sftp, path_z.ptr);
         if (dir != null) return dir;
         const rc = c.libssh2_session_last_errno(session.session.?);
         if (rc != c.LIBSSH2_ERROR_EAGAIN) {
-            setLibssh2Error(session, "SFTP opendir failed", rc);
+            setSftpError(session, sftp, "SFTP opendir failed", rc);
             return null;
         }
-        if (!waitSocket(session, io_wait_timeout_ms)) {
-            setError(session, "SFTP opendir timed out", .{});
+
+        eagain_count +%= 1;
+        if (waitSocket(session, io_wait_timeout_ms)) {
+            idle_since_ms = nowMs();
+            continue;
+        }
+
+        const now = nowMs();
+        const idle_ms = now - idle_since_ms;
+        if (idle_ms > sftp_idle_limit_ms) {
+            const elapsed_ms = now - started_ms;
+            setError(
+                session,
+                "SFTP opendir timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d})",
+                .{ path_z, elapsed_ms, idle_ms, eagain_count },
+            );
+            logError(
+                "SFTP opendir timeout path={s} elapsed={}ms idle={}ms eagain={}",
+                .{ path_z, elapsed_ms, idle_ms, eagain_count },
+            );
             return null;
         }
     }
@@ -977,8 +1052,10 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpListDi
     const path_z = dupSentinel(path_bytes) orelse return null;
     defer allocator.free(path_z);
 
-    const dir = sftpOpenDir(session, sftp, path_z) orelse return null;
-    defer _ = c.libssh2_sftp_closedir(dir);
+    const dir = sftpOpenDir(session, sftp, path_z) orelse {
+        resetSftpAfterFailure(session, "opendir failure");
+        return null;
+    };
 
     var names: std.ArrayList([]u8) = .empty;
     defer {
@@ -988,6 +1065,10 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpListDi
 
     var entry_buf: [1024]u8 = undefined;
     var attrs: c.LIBSSH2_SFTP_ATTRIBUTES = undefined;
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u32 = 0;
+    var read_failed = false;
     while (true) {
         const rc = c.libssh2_sftp_readdir_ex(dir, &entry_buf, @intCast(entry_buf.len), null, 0, &attrs);
         if (rc > 0) {
@@ -1006,21 +1087,58 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpListDi
             const size: u64 = if ((attrs.flags & c.LIBSSH2_SFTP_ATTR_SIZE) != 0) @intCast(attrs.filesize) else 0;
             const mtime: u64 = if ((attrs.flags & c.LIBSSH2_SFTP_ATTR_ACMODTIME) != 0) @intCast(attrs.mtime) else 0;
             const perms: u64 = if ((attrs.flags & c.LIBSSH2_SFTP_ATTR_PERMISSIONS) != 0) @intCast(attrs.permissions) else 0;
-            const line = std.fmt.allocPrint(allocator, "{s}\t{s}\t{}\t{}\t{}", .{ name, kind, size, mtime, perms }) catch break;
+            const line = std.fmt.allocPrint(allocator, "{s}\t{s}\t{}\t{}\t{}", .{ name, kind, size, mtime, perms }) catch {
+                setError(session, "SFTP list allocation failed after {} entries", .{names.items.len});
+                read_failed = true;
+                break;
+            };
             const copy = line;
             names.append(allocator, copy) catch {
                 allocator.free(copy);
+                setError(session, "SFTP list allocation failed after {} entries", .{names.items.len});
+                read_failed = true;
                 break;
             };
+            idle_since_ms = nowMs();
             continue;
         }
         if (rc == 0) break;
         if (rc == c.LIBSSH2_ERROR_EAGAIN) {
-            if (!waitSocket(session, io_wait_timeout_ms)) break;
+            eagain_count +%= 1;
+            if (waitSocket(session, io_wait_timeout_ms)) {
+                idle_since_ms = nowMs();
+                continue;
+            }
+            const now = nowMs();
+            const idle_ms = now - idle_since_ms;
+            if (idle_ms > sftp_idle_limit_ms) {
+                const elapsed_ms = now - started_ms;
+                setError(
+                    session,
+                    "SFTP readdir timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d}, entries={d})",
+                    .{ path_z, elapsed_ms, idle_ms, eagain_count, names.items.len },
+                );
+                logError(
+                    "SFTP readdir timeout path={s} elapsed={}ms idle={}ms eagain={} entries={}",
+                    .{ path_z, elapsed_ms, idle_ms, eagain_count, names.items.len },
+                );
+                read_failed = true;
+                break;
+            }
             continue;
         }
+        setSftpError(session, sftp, "SFTP readdir failed", @intCast(rc));
+        read_failed = true;
         break;
     }
+
+    if (read_failed) {
+        _ = c.libssh2_sftp_closedir(dir);
+        resetSftpAfterFailure(session, "readdir failure");
+        return null;
+    }
+
+    _ = c.libssh2_sftp_closedir(dir);
 
     const string_class = env.*.*.FindClass.?(env, "java/lang/String") orelse return null;
     const result = env.*.*.NewObjectArray.?(env, @intCast(names.items.len), string_class, null) orelse return null;
@@ -1041,12 +1159,41 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpRealpa
     defer allocator.free(path_z);
 
     var out_buf: [2048]u8 = undefined;
-    const rc = c.libssh2_sftp_realpath(sftp, path_z.ptr, &out_buf, @as(c_int, @intCast(out_buf.len)));
-    if (rc <= 0) {
-        setLibssh2Error(session, "SFTP realpath failed", c.libssh2_session_last_errno(session.session.?));
-        return null;
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u32 = 0;
+    while (true) {
+        const rc = c.libssh2_sftp_realpath(sftp, path_z.ptr, &out_buf, @as(c_int, @intCast(out_buf.len)));
+        if (rc > 0) return jniNewStringOrNull(env, out_buf[0..@intCast(rc)]);
+        const last_rc = c.libssh2_session_last_errno(session.session.?);
+        if (last_rc != c.LIBSSH2_ERROR_EAGAIN) {
+            setSftpError(session, sftp, "SFTP realpath failed", last_rc);
+            return null;
+        }
+
+        eagain_count +%= 1;
+        if (waitSocket(session, io_wait_timeout_ms)) {
+            idle_since_ms = nowMs();
+            continue;
+        }
+
+        const now = nowMs();
+        const idle_ms = now - idle_since_ms;
+        if (idle_ms > sftp_idle_limit_ms) {
+            const elapsed_ms = now - started_ms;
+            setError(
+                session,
+                "SFTP realpath timed out for {s} after {d}ms (idle {d}ms, EAGAIN={d})",
+                .{ path_z, elapsed_ms, idle_ms, eagain_count },
+            );
+            logError(
+                "SFTP realpath timeout path={s} elapsed={}ms idle={}ms eagain={}",
+                .{ path_z, elapsed_ms, idle_ms, eagain_count },
+            );
+            resetSftpAfterFailure(session, "realpath timeout");
+            return null;
+        }
     }
-    return jniNewStringOrNull(env, out_buf[0..@intCast(rc)]);
 }
 
 export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpOpenWrite(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong, path: c.jstring) callconv(.c) c.jboolean {


### PR DESCRIPTION
## Summary

Fixes SFTP file-browser directory listing failures caused by treating a single short nonblocking wait as a fatal timeout.

What changed:
- Keep polling SFTP `opendir`, `readdir`, and `realpath` while libssh2 reports `EAGAIN`, using a longer idle deadline instead of a single 120ms wait.
- Reset the cached SFTP subsystem after failed directory/realpath operations so later attempts do not reuse stale state.
- Include SFTP server status codes/names in native error messages for clearer diagnosis.
- Resolve the file browser start path with `realpath(".")` before falling back to `realpath("~")`.
- Cancel stale per-tab file-browser refresh jobs before starting a new refresh.

## Testing

Validation performed locally:
- `zig fmt --check src/bridge/chuchu_ssh.zig` ✅
- `zig build -Doptimize=ReleaseSmall jni` ✅
- `./gradlew :app:compileDebugKotlin :app:assembleDebug` ✅

User testing:
- User installed a debug APK built from this fix and confirmed the SFTP file browser works on the VPS that previously failed with `SFTP opendir timed out` / `SFTP opendir failed`.

## AI disclosure

This PR was fully implemented by AI at the request of the user. The user tested the resulting APK on-device and requested that this be clearly disclosed to the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal tab file browsing reliability by properly cancelling in-flight resolver/refresh work when switching or closing tabs, preventing stale updates.
  * More robust initial path resolution now attempts common home/dir targets first and falls back to a safe working directory.
  * Strengthened SFTP behavior with idle-timeout detection, clearer error reporting, and safer recovery/cleanup after failures (including better handling during directory listing, realpath lookups, and shutdown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->