### PR TITLE
feat: add encrypted SSH backup import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Chuchu is a native Android SSH client powered by libghostty, a terminal-first Co
 - more than 400 themes from the official ghostty repository
 - configurable accessory keys and custom terminal actions
 - per-host post-connect actions that autorun a selected custom action after SSH/Mosh connects or reconnects
+- encrypted local import/export backups for SSH keys and server profiles
 - beautiful and working terminal renderer with fully working resize, scrollback, focus, modifier keys, mouse actions 
 
 ## Status

--- a/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupCodec.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupCodec.kt
@@ -1,0 +1,309 @@
+package com.jossephus.chuchu.data.backup
+
+import com.jossephus.chuchu.model.AuthMethod
+import com.jossephus.chuchu.model.Transport
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.EOFException
+import java.security.SecureRandom
+import javax.crypto.AEADBadTagException
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+object ChuchuBackupCodec {
+    const val FORMAT_VERSION: Int = 1
+    const val PAYLOAD_VERSION: Int = 1
+    const val KDF_ID_PBKDF2_HMAC_SHA1: Int = 1
+    const val CIPHER_ID_AES_256_GCM: Int = 1
+    const val KDF_ALGORITHM: String = "PBKDF2WithHmacSHA1"
+    const val CIPHER_ALGORITHM: String = "AES/GCM/NoPadding"
+    const val KDF_ITERATIONS: Int = 210_000
+    const val KEY_SIZE_BITS: Int = 256
+    const val SALT_SIZE_BYTES: Int = 16
+    const val IV_SIZE_BYTES: Int = 12
+    const val GCM_TAG_SIZE_BITS: Int = 128
+    const val MAX_BACKUP_SIZE_BYTES: Int = 32 * 1024 * 1024
+
+    private const val CONTAINER_MAGIC: Int = 0x4348424b // CHBK
+    private const val PAYLOAD_MAGIC: Int = 0x4348504c // CHPL
+    private const val MAX_ITEMS: Int = 100_000
+    private const val MAX_STRING_BYTES: Int = 4 * 1024 * 1024
+
+    fun encrypt(
+        payload: BackupPayload,
+        passphrase: CharArray,
+        random: SecureRandom = SecureRandom(),
+    ): ByteArray {
+        require(passphrase.isNotEmpty()) { "Backup passphrase must not be empty" }
+        val plaintext = encodePayload(payload)
+        return try {
+            val salt = ByteArray(SALT_SIZE_BYTES).also(random::nextBytes)
+            val iv = ByteArray(IV_SIZE_BYTES).also(random::nextBytes)
+            val metadata = encodeMetadata(salt = salt, iv = iv)
+            val key = deriveKey(passphrase, salt)
+            val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+            cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_SIZE_BITS, iv))
+            cipher.updateAAD(metadata)
+            val ciphertext = cipher.doFinal(plaintext)
+            ByteArrayOutputStream().use { output ->
+                DataOutputStream(output).use { data ->
+                    data.write(metadata)
+                    data.writeInt(ciphertext.size)
+                    data.write(ciphertext)
+                }
+                output.toByteArray()
+            }
+        } finally {
+            plaintext.fill(0)
+        }
+    }
+
+    @Throws(BackupFormatException::class, InvalidBackupPassphraseException::class)
+    fun decrypt(bytes: ByteArray, passphrase: CharArray): BackupPayload {
+        require(passphrase.isNotEmpty()) { "Backup passphrase must not be empty" }
+        return try {
+            if (bytes.size > MAX_BACKUP_SIZE_BYTES) throw BackupFormatException("Backup file is too large")
+            DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+                val metadata = readMetadata(input)
+                val ciphertextSize = input.readPositiveInt("ciphertext size")
+                if (ciphertextSize > MAX_BACKUP_SIZE_BYTES) {
+                    throw BackupFormatException("Backup file is too large")
+                }
+                val ciphertext = input.readExactBytes(ciphertextSize, "ciphertext")
+                if (input.read() != -1) throw BackupFormatException("Unexpected trailing backup data")
+                val key = deriveKey(passphrase, metadata.salt)
+                val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+                cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_SIZE_BITS, metadata.iv))
+                cipher.updateAAD(metadata.encoded)
+                val plaintext = try {
+                    cipher.doFinal(ciphertext)
+                } catch (_: AEADBadTagException) {
+                    throw InvalidBackupPassphraseException()
+                }
+                try {
+                    decodePayload(plaintext)
+                } finally {
+                    plaintext.fill(0)
+                }
+            }
+        } catch (e: InvalidBackupPassphraseException) {
+            throw e
+        } catch (e: BackupFormatException) {
+            throw e
+        } catch (e: EOFException) {
+            throw BackupFormatException("Truncated backup file")
+        } catch (e: IllegalArgumentException) {
+            throw BackupFormatException(e.message ?: "Invalid backup file")
+        }
+    }
+
+    fun encodePayload(payload: BackupPayload): ByteArray = ByteArrayOutputStream().use { output ->
+        DataOutputStream(output).use { data ->
+            data.writeInt(PAYLOAD_MAGIC)
+            data.writeInt(PAYLOAD_VERSION)
+            data.writeInt(payload.keys.size)
+            payload.keys.forEach { key ->
+                data.writeLong(key.id)
+                data.writeString(key.name)
+                data.writeString(key.algorithm)
+                data.writeString(key.privateKeyPem)
+                data.writeString(key.publicKeyOpenSsh)
+                data.writeLong(key.createdAtEpochMs)
+            }
+            data.writeInt(payload.hosts.size)
+            payload.hosts.forEach { host ->
+                data.writeLong(host.id)
+                data.writeString(host.name)
+                data.writeString(host.host)
+                data.writeInt(host.port)
+                data.writeString(host.username)
+                data.writeString(host.password)
+                data.writeNullableLong(host.keyId)
+                data.writeString(host.keyPassphrase)
+                data.writeString(host.transport.name)
+                data.writeString(host.authMethod.name)
+                data.writeBoolean(host.requireAuthOnConnect)
+                data.writeNullableString(host.postConnectCommand)
+            }
+        }
+        output.toByteArray()
+    }
+
+    @Throws(BackupFormatException::class)
+    fun decodePayload(bytes: ByteArray): BackupPayload = try {
+        DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+            if (input.readInt() != PAYLOAD_MAGIC) throw BackupFormatException("Invalid backup payload")
+            val version = input.readInt()
+            if (version != PAYLOAD_VERSION) throw BackupFormatException("Unsupported backup payload version")
+            val keyCount = input.readItemCount("key count")
+            val keys = buildList(keyCount) {
+                repeat(keyCount) {
+                    add(
+                        BackupSshKey(
+                            id = input.readLong(),
+                            name = input.readString("key name"),
+                            algorithm = input.readString("key algorithm"),
+                            privateKeyPem = input.readString("private key"),
+                            publicKeyOpenSsh = input.readString("public key"),
+                            createdAtEpochMs = input.readLong(),
+                        ),
+                    )
+                }
+            }
+            val hostCount = input.readItemCount("host count")
+            val hosts = buildList(hostCount) {
+                repeat(hostCount) {
+                    add(
+                        BackupHostProfile(
+                            id = input.readLong(),
+                            name = input.readString("host name"),
+                            host = input.readString("host"),
+                            port = input.readInt(),
+                            username = input.readString("username"),
+                            password = input.readString("password"),
+                            keyId = input.readNullableLong(),
+                            keyPassphrase = input.readString("key passphrase"),
+                            transport = input.readEnum<Transport>("transport"),
+                            authMethod = input.readEnum<AuthMethod>("auth method"),
+                            requireAuthOnConnect = input.readBoolean(),
+                            postConnectCommand = input.readNullableString("post-connect command"),
+                        ),
+                    )
+                }
+            }
+            if (input.read() != -1) throw BackupFormatException("Unexpected trailing payload data")
+            BackupPayload(keys = keys, hosts = hosts)
+        }
+    } catch (e: BackupFormatException) {
+        throw e
+    } catch (e: EOFException) {
+        throw BackupFormatException("Truncated backup payload")
+    }
+
+    private fun encodeMetadata(salt: ByteArray, iv: ByteArray): ByteArray = ByteArrayOutputStream().use { output ->
+        DataOutputStream(output).use { data ->
+            data.writeInt(CONTAINER_MAGIC)
+            data.writeInt(FORMAT_VERSION)
+            data.writeInt(KDF_ID_PBKDF2_HMAC_SHA1)
+            data.writeInt(KDF_ITERATIONS)
+            data.writeInt(CIPHER_ID_AES_256_GCM)
+            data.writeBytesWithLength(salt)
+            data.writeBytesWithLength(iv)
+        }
+        output.toByteArray()
+    }
+
+    private fun readMetadata(input: DataInputStream): BackupMetadata {
+        val bytes = ByteArrayOutputStream()
+        fun writeInt(value: Int) {
+            DataOutputStream(bytes).use { it.writeInt(value) }
+        }
+        val magic = input.readInt().also(::writeInt)
+        if (magic != CONTAINER_MAGIC) throw BackupFormatException("Invalid backup file")
+        val version = input.readInt().also(::writeInt)
+        if (version != FORMAT_VERSION) throw BackupFormatException("Unsupported backup version")
+        val kdfId = input.readInt().also(::writeInt)
+        if (kdfId != KDF_ID_PBKDF2_HMAC_SHA1) throw BackupFormatException("Unsupported backup KDF")
+        val iterations = input.readInt().also(::writeInt)
+        if (iterations != KDF_ITERATIONS) throw BackupFormatException("Unsupported backup KDF parameters")
+        val cipherId = input.readInt().also(::writeInt)
+        if (cipherId != CIPHER_ID_AES_256_GCM) throw BackupFormatException("Unsupported backup cipher")
+        val salt = input.readBytesWithLength("salt", SALT_SIZE_BYTES).also { bytes.writeIntAndBytes(it) }
+        val iv = input.readBytesWithLength("iv", IV_SIZE_BYTES).also { bytes.writeIntAndBytes(it) }
+        return BackupMetadata(salt = salt, iv = iv, encoded = bytes.toByteArray())
+    }
+
+    private fun deriveKey(passphrase: CharArray, salt: ByteArray): SecretKeySpec {
+        val spec = PBEKeySpec(passphrase, salt, KDF_ITERATIONS, KEY_SIZE_BITS)
+        return try {
+            val keyBytes = SecretKeyFactory.getInstance(KDF_ALGORITHM).generateSecret(spec).encoded
+            try {
+                SecretKeySpec(keyBytes, "AES")
+            } finally {
+                keyBytes.fill(0)
+            }
+        } finally {
+            spec.clearPassword()
+        }
+    }
+
+    private data class BackupMetadata(
+        val salt: ByteArray,
+        val iv: ByteArray,
+        val encoded: ByteArray,
+    )
+
+    private fun DataOutputStream.writeString(value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        writeBytesWithLength(bytes)
+    }
+
+    private fun DataOutputStream.writeNullableString(value: String?) {
+        writeBoolean(value != null)
+        if (value != null) writeString(value)
+    }
+
+    private fun DataOutputStream.writeNullableLong(value: Long?) {
+        writeBoolean(value != null)
+        if (value != null) writeLong(value)
+    }
+
+    private fun DataOutputStream.writeBytesWithLength(bytes: ByteArray) {
+        writeInt(bytes.size)
+        write(bytes)
+    }
+
+    private fun ByteArrayOutputStream.writeIntAndBytes(bytes: ByteArray) {
+        DataOutputStream(this).use { data ->
+            data.writeInt(bytes.size)
+            data.write(bytes)
+        }
+    }
+
+    private fun DataInputStream.readString(label: String): String {
+        val size = readPositiveInt("$label length")
+        if (size > MAX_STRING_BYTES) throw BackupFormatException("$label is too large")
+        return String(readExactBytes(size, label), Charsets.UTF_8)
+    }
+
+    private fun DataInputStream.readNullableString(label: String): String? =
+        if (readBoolean()) readString(label) else null
+
+    private fun DataInputStream.readNullableLong(): Long? =
+        if (readBoolean()) readLong() else null
+
+    private inline fun <reified T : Enum<T>> DataInputStream.readEnum(label: String): T {
+        val value = readString(label)
+        return enumValues<T>().firstOrNull { it.name == value }
+            ?: throw BackupFormatException("Unknown $label")
+    }
+
+    private fun DataInputStream.readItemCount(label: String): Int {
+        val count = readPositiveInt(label)
+        if (count > MAX_ITEMS) throw BackupFormatException("$label is too large")
+        return count
+    }
+
+    private fun DataInputStream.readPositiveInt(label: String): Int {
+        val value = readInt()
+        if (value < 0) throw BackupFormatException("Invalid $label")
+        return value
+    }
+
+    private fun DataInputStream.readBytesWithLength(label: String, expectedSize: Int): ByteArray {
+        val size = readPositiveInt("$label length")
+        if (size != expectedSize) throw BackupFormatException("Invalid $label length")
+        return readExactBytes(size, label)
+    }
+
+    private fun DataInputStream.readExactBytes(size: Int, label: String): ByteArray {
+        val bytes = ByteArray(size)
+        readFully(bytes)
+        return bytes
+    }
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupCodec.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupCodec.kt
@@ -50,7 +50,7 @@ object ChuchuBackupCodec {
             cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_SIZE_BITS, iv))
             cipher.updateAAD(metadata)
             val ciphertext = cipher.doFinal(plaintext)
-            ByteArrayOutputStream().use { output ->
+            val encrypted = ByteArrayOutputStream().use { output ->
                 DataOutputStream(output).use { data ->
                     data.write(metadata)
                     data.writeInt(ciphertext.size)
@@ -58,6 +58,8 @@ object ChuchuBackupCodec {
                 }
                 output.toByteArray()
             }
+            if (encrypted.size > MAX_BACKUP_SIZE_BYTES) throw BackupFormatException("Backup file is too large")
+            encrypted
         } finally {
             plaintext.fill(0)
         }
@@ -102,36 +104,43 @@ object ChuchuBackupCodec {
         }
     }
 
-    fun encodePayload(payload: BackupPayload): ByteArray = ByteArrayOutputStream().use { output ->
-        DataOutputStream(output).use { data ->
-            data.writeInt(PAYLOAD_MAGIC)
-            data.writeInt(PAYLOAD_VERSION)
-            data.writeInt(payload.keys.size)
-            payload.keys.forEach { key ->
-                data.writeLong(key.id)
-                data.writeString(key.name)
-                data.writeString(key.algorithm)
-                data.writeString(key.privateKeyPem)
-                data.writeString(key.publicKeyOpenSsh)
-                data.writeLong(key.createdAtEpochMs)
+    @Throws(BackupFormatException::class)
+    fun encodePayload(payload: BackupPayload): ByteArray {
+        validateItemCount(payload.keys.size, "key count")
+        validateItemCount(payload.hosts.size, "host count")
+        val encoded = ByteArrayOutputStream().use { output ->
+            DataOutputStream(output).use { data ->
+                data.writeInt(PAYLOAD_MAGIC)
+                data.writeInt(PAYLOAD_VERSION)
+                data.writeInt(payload.keys.size)
+                payload.keys.forEach { key ->
+                    data.writeLong(key.id)
+                    data.writeString(key.name, "key name")
+                    data.writeString(key.algorithm, "key algorithm")
+                    data.writeString(key.privateKeyPem, "private key")
+                    data.writeString(key.publicKeyOpenSsh, "public key")
+                    data.writeLong(key.createdAtEpochMs)
+                }
+                data.writeInt(payload.hosts.size)
+                payload.hosts.forEach { host ->
+                    data.writeLong(host.id)
+                    data.writeString(host.name, "host name")
+                    data.writeString(host.host, "host")
+                    data.writeInt(host.port)
+                    data.writeString(host.username, "username")
+                    data.writeString(host.password, "password")
+                    data.writeNullableLong(host.keyId)
+                    data.writeString(host.keyPassphrase, "key passphrase")
+                    data.writeString(host.transport.name, "transport")
+                    data.writeString(host.authMethod.name, "auth method")
+                    data.writeBoolean(host.requireAuthOnConnect)
+                    data.writeNullableString(host.postConnectCommand, "post-connect command")
+                }
             }
-            data.writeInt(payload.hosts.size)
-            payload.hosts.forEach { host ->
-                data.writeLong(host.id)
-                data.writeString(host.name)
-                data.writeString(host.host)
-                data.writeInt(host.port)
-                data.writeString(host.username)
-                data.writeString(host.password)
-                data.writeNullableLong(host.keyId)
-                data.writeString(host.keyPassphrase)
-                data.writeString(host.transport.name)
-                data.writeString(host.authMethod.name)
-                data.writeBoolean(host.requireAuthOnConnect)
-                data.writeNullableString(host.postConnectCommand)
-            }
+            output.toByteArray()
         }
-        output.toByteArray()
+        if (encoded.size > MAX_BACKUP_SIZE_BYTES) throw BackupFormatException("Backup payload is too large")
+        return encoded
     }
 
     @Throws(BackupFormatException::class)
@@ -238,14 +247,15 @@ object ChuchuBackupCodec {
         val encoded: ByteArray,
     )
 
-    private fun DataOutputStream.writeString(value: String) {
+    private fun DataOutputStream.writeString(value: String, label: String) {
         val bytes = value.toByteArray(Charsets.UTF_8)
+        if (bytes.size > MAX_STRING_BYTES) throw BackupFormatException("$label is too large")
         writeBytesWithLength(bytes)
     }
 
-    private fun DataOutputStream.writeNullableString(value: String?) {
+    private fun DataOutputStream.writeNullableString(value: String?, label: String) {
         writeBoolean(value != null)
-        if (value != null) writeString(value)
+        if (value != null) writeString(value, label)
     }
 
     private fun DataOutputStream.writeNullableLong(value: Long?) {
@@ -285,8 +295,12 @@ object ChuchuBackupCodec {
 
     private fun DataInputStream.readItemCount(label: String): Int {
         val count = readPositiveInt(label)
-        if (count > MAX_ITEMS) throw BackupFormatException("$label is too large")
+        validateItemCount(count, label)
         return count
+    }
+
+    private fun validateItemCount(count: Int, label: String) {
+        if (count > MAX_ITEMS) throw BackupFormatException("$label is too large")
     }
 
     private fun DataInputStream.readPositiveInt(label: String): Int {

--- a/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupImportPlanner.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupImportPlanner.kt
@@ -1,0 +1,155 @@
+package com.jossephus.chuchu.data.backup
+
+import com.jossephus.chuchu.model.AuthMethod
+import com.jossephus.chuchu.model.HostProfile
+import com.jossephus.chuchu.model.SshKey
+
+object ChuchuBackupImportPlanner {
+    @Throws(BackupFormatException::class)
+    fun planImport(
+        payload: BackupPayload,
+        existingKeys: List<SshKey>,
+        existingHosts: List<HostProfile>,
+    ): BackupImportPlan {
+        validatePayload(payload)
+
+        val usedKeyNames = existingKeys.map { it.name }.toMutableSet()
+        val keyActions = mutableListOf<KeyImportAction>()
+        val keyRefs = mutableMapOf<Long, KeyReference>()
+
+        payload.keys.forEach { backupKey ->
+            val exactExisting = existingKeys.firstOrNull { it.sameContentAs(backupKey) }
+            if (exactExisting != null) {
+                keyActions += KeyImportAction.Reuse(
+                    exportedId = backupKey.id,
+                    localId = exactExisting.id,
+                    name = exactExisting.name,
+                )
+                keyRefs[backupKey.id] = KeyReference.Existing(exactExisting.id)
+            } else {
+                val importName = uniqueName(backupKey.name, usedKeyNames)
+                val importKey = backupKey.toEntity(idOverride = 0L).copy(name = importName)
+                keyActions += KeyImportAction.Insert(
+                    exportedId = backupKey.id,
+                    key = importKey,
+                    renamed = importName != backupKey.name,
+                )
+                keyRefs[backupKey.id] = KeyReference.Insert(keyActions.lastIndex)
+            }
+        }
+
+        val usedHostNames = existingHosts.map { it.name }.toMutableSet()
+        val hostActions = payload.hosts.map { backupHost ->
+            val localKeyId = backupHost.keyId?.let { exportedKeyId ->
+                when (val ref = keyRefs[exportedKeyId]) {
+                    is KeyReference.Existing -> ref.localId
+                    is KeyReference.Insert -> null
+                    null -> throw BackupFormatException("Host references a missing SSH key")
+                }
+            }
+            val importName = uniqueName(backupHost.name, usedHostNames)
+            val importHost = backupHost.toEntity(
+                idOverride = 0L,
+                keyIdOverride = localKeyId,
+            ).copy(name = importName)
+            HostImportAction(
+                exportedId = backupHost.id,
+                host = importHost,
+                keyActionIndex = backupHost.keyId?.let { (keyRefs[it] as? KeyReference.Insert)?.actionIndex },
+                renamed = importName != backupHost.name,
+            )
+        }
+
+        return BackupImportPlan(
+            keyActions = keyActions,
+            hostActions = hostActions,
+        )
+    }
+
+    @Throws(BackupFormatException::class)
+    private fun validatePayload(payload: BackupPayload) {
+        val keyIds = mutableSetOf<Long>()
+        payload.keys.forEach { key ->
+            if (key.id <= 0L) throw BackupFormatException("Invalid SSH key id")
+            if (!keyIds.add(key.id)) throw BackupFormatException("Duplicate SSH key id")
+            if (key.name.isBlank()) throw BackupFormatException("SSH key name is required")
+            if (key.privateKeyPem.isBlank()) throw BackupFormatException("SSH private key is required")
+            if (key.publicKeyOpenSsh.isBlank()) throw BackupFormatException("SSH public key is required")
+        }
+
+        val hostIds = mutableSetOf<Long>()
+        payload.hosts.forEach { host ->
+            if (host.id <= 0L) throw BackupFormatException("Invalid host id")
+            if (!hostIds.add(host.id)) throw BackupFormatException("Duplicate host id")
+            if (host.name.isBlank()) throw BackupFormatException("Host name is required")
+            if (host.host.isBlank()) throw BackupFormatException("Host address is required")
+            if (host.username.isBlank()) throw BackupFormatException("Host username is required")
+            if (host.port !in 1..65535) throw BackupFormatException("Invalid host port")
+            if (host.keyId != null && host.keyId !in keyIds) {
+                throw BackupFormatException("Host references a missing SSH key")
+            }
+            if (host.authMethod.requiresKey() && host.keyId == null) {
+                throw BackupFormatException("Key authentication host is missing an SSH key")
+            }
+        }
+    }
+
+    private fun uniqueName(baseName: String, usedNames: MutableSet<String>): String {
+        val trimmed = baseName.trim().ifBlank { "imported" }
+        if (usedNames.add(trimmed)) return trimmed
+        var index = 2
+        while (true) {
+            val candidate = "$trimmed-$index"
+            if (usedNames.add(candidate)) return candidate
+            index += 1
+        }
+    }
+
+    private fun SshKey.sameContentAs(backupKey: BackupSshKey): Boolean =
+        name == backupKey.name &&
+            algorithm == backupKey.algorithm &&
+            privateKeyPem == backupKey.privateKeyPem &&
+            publicKeyOpenSsh == backupKey.publicKeyOpenSsh &&
+            createdAtEpochMs == backupKey.createdAtEpochMs
+
+    private fun AuthMethod.requiresKey(): Boolean =
+        this == AuthMethod.Key || this == AuthMethod.KeyWithPassphrase
+}
+
+data class BackupImportPlan(
+    val keyActions: List<KeyImportAction>,
+    val hostActions: List<HostImportAction>,
+) {
+    val keyInsertCount: Int get() = keyActions.count { it is KeyImportAction.Insert }
+    val keyReuseCount: Int get() = keyActions.count { it is KeyImportAction.Reuse }
+    val renamedKeyCount: Int get() = keyActions.count { it is KeyImportAction.Insert && it.renamed }
+    val renamedHostCount: Int get() = hostActions.count { it.renamed }
+}
+
+sealed interface KeyImportAction {
+    val exportedId: Long
+
+    data class Reuse(
+        override val exportedId: Long,
+        val localId: Long,
+        val name: String,
+    ) : KeyImportAction
+
+    data class Insert(
+        override val exportedId: Long,
+        val key: SshKey,
+        val renamed: Boolean,
+    ) : KeyImportAction
+}
+
+data class HostImportAction(
+    val exportedId: Long,
+    val host: HostProfile,
+    val keyActionIndex: Int?,
+    val renamed: Boolean,
+)
+
+private sealed interface KeyReference {
+    data class Existing(val localId: Long) : KeyReference
+    data class Insert(val actionIndex: Int) : KeyReference
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupModels.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupModels.kt
@@ -1,0 +1,100 @@
+package com.jossephus.chuchu.data.backup
+
+import com.jossephus.chuchu.model.AuthMethod
+import com.jossephus.chuchu.model.HostProfile
+import com.jossephus.chuchu.model.SshKey
+import com.jossephus.chuchu.model.Transport
+
+const val CHUCHU_BACKUP_EXTENSION = "chuchu-backup"
+const val CHUCHU_BACKUP_MIME_TYPE = "application/octet-stream"
+
+class BackupFormatException(message: String) : Exception(message)
+
+class InvalidBackupPassphraseException : Exception("Invalid backup passphrase")
+
+data class BackupPayload(
+    val keys: List<BackupSshKey>,
+    val hosts: List<BackupHostProfile>,
+) {
+    fun toEntities(): Pair<List<SshKey>, List<HostProfile>> =
+        keys.map { it.toEntity() } to hosts.map { it.toEntity() }
+}
+
+data class BackupSshKey(
+    val id: Long,
+    val name: String,
+    val algorithm: String,
+    val privateKeyPem: String,
+    val publicKeyOpenSsh: String,
+    val createdAtEpochMs: Long,
+) {
+    fun toEntity(idOverride: Long = id): SshKey = SshKey(
+        id = idOverride,
+        name = name,
+        algorithm = algorithm,
+        privateKeyPem = privateKeyPem,
+        publicKeyOpenSsh = publicKeyOpenSsh,
+        createdAtEpochMs = createdAtEpochMs,
+    )
+
+    companion object {
+        fun fromEntity(key: SshKey): BackupSshKey = BackupSshKey(
+            id = key.id,
+            name = key.name,
+            algorithm = key.algorithm,
+            privateKeyPem = key.privateKeyPem,
+            publicKeyOpenSsh = key.publicKeyOpenSsh,
+            createdAtEpochMs = key.createdAtEpochMs,
+        )
+    }
+}
+
+data class BackupHostProfile(
+    val id: Long,
+    val name: String,
+    val host: String,
+    val port: Int,
+    val username: String,
+    val password: String,
+    val keyId: Long?,
+    val keyPassphrase: String,
+    val transport: Transport,
+    val authMethod: AuthMethod,
+    val requireAuthOnConnect: Boolean,
+    val postConnectCommand: String?,
+) {
+    fun toEntity(
+        idOverride: Long = id,
+        keyIdOverride: Long? = keyId,
+    ): HostProfile = HostProfile(
+        id = idOverride,
+        name = name,
+        host = host,
+        port = port,
+        username = username,
+        password = password,
+        keyId = keyIdOverride,
+        keyPassphrase = keyPassphrase,
+        transport = transport,
+        authMethod = authMethod,
+        requireAuthOnConnect = requireAuthOnConnect,
+        postConnectCommand = postConnectCommand,
+    )
+
+    companion object {
+        fun fromEntity(host: HostProfile): BackupHostProfile = BackupHostProfile(
+            id = host.id,
+            name = host.name,
+            host = host.host,
+            port = host.port,
+            username = host.username,
+            password = host.password,
+            keyId = host.keyId,
+            keyPassphrase = host.keyPassphrase,
+            transport = host.transport,
+            authMethod = host.authMethod,
+            requireAuthOnConnect = host.requireAuthOnConnect,
+            postConnectCommand = host.postConnectCommand,
+        )
+    }
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupRepository.kt
@@ -9,10 +9,12 @@ class ChuchuBackupRepository(
     private val db: AppDatabase,
 ) {
     suspend fun createEncryptedBackup(passphrase: CharArray): ByteArray {
-        val payload = BackupPayload(
-            keys = db.sshKeyDao().getAll().map(BackupSshKey::fromEntity),
-            hosts = db.hostProfileDao().getAll().map(BackupHostProfile::fromEntity),
-        )
+        val payload = db.withTransaction {
+            BackupPayload(
+                keys = db.sshKeyDao().getAll().map(BackupSshKey::fromEntity),
+                hosts = db.hostProfileDao().getAll().map(BackupHostProfile::fromEntity),
+            )
+        }
         return ChuchuBackupCodec.encrypt(payload, passphrase)
     }
 

--- a/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/backup/ChuchuBackupRepository.kt
@@ -1,0 +1,95 @@
+package com.jossephus.chuchu.data.backup
+
+import androidx.room.withTransaction
+import com.jossephus.chuchu.data.db.AppDatabase
+import com.jossephus.chuchu.model.HostProfile
+import com.jossephus.chuchu.model.SshKey
+
+class ChuchuBackupRepository(
+    private val db: AppDatabase,
+) {
+    suspend fun createEncryptedBackup(passphrase: CharArray): ByteArray {
+        val payload = BackupPayload(
+            keys = db.sshKeyDao().getAll().map(BackupSshKey::fromEntity),
+            hosts = db.hostProfileDao().getAll().map(BackupHostProfile::fromEntity),
+        )
+        return ChuchuBackupCodec.encrypt(payload, passphrase)
+    }
+
+    fun readEncryptedBackup(
+        bytes: ByteArray,
+        passphrase: CharArray,
+    ): BackupPayload = ChuchuBackupCodec.decrypt(bytes, passphrase)
+
+    suspend fun planImport(payload: BackupPayload): BackupImportPlan {
+        return ChuchuBackupImportPlanner.planImport(
+            payload = payload,
+            existingKeys = db.sshKeyDao().getAll(),
+            existingHosts = db.hostProfileDao().getAll(),
+        )
+    }
+
+    suspend fun importPayload(payload: BackupPayload): BackupImportResult {
+        return db.withTransaction {
+            val plan = ChuchuBackupImportPlanner.planImport(
+                payload = payload,
+                existingKeys = db.sshKeyDao().getAll(),
+                existingHosts = db.hostProfileDao().getAll(),
+            )
+            applyImportPlan(plan)
+        }
+    }
+
+    suspend fun importEncryptedBackup(
+        bytes: ByteArray,
+        passphrase: CharArray,
+    ): BackupImportResult {
+        val payload = readEncryptedBackup(bytes, passphrase)
+        return importPayload(payload)
+    }
+
+    private suspend fun applyImportPlan(plan: BackupImportPlan): BackupImportResult {
+        val insertedKeyIdsByActionIndex = mutableMapOf<Int, Long>()
+        plan.keyActions.forEachIndexed { index, action ->
+            if (action is KeyImportAction.Insert) {
+                check(action.key.id == 0L) { "Imported SSH keys must not preserve exported ids" }
+                val localId = db.sshKeyDao().insertForImport(action.key)
+                insertedKeyIdsByActionIndex[index] = localId
+            }
+        }
+
+        var importedHosts = 0
+        plan.hostActions.forEach { action ->
+            check(action.host.id == 0L) { "Imported hosts must not preserve exported ids" }
+            val localKeyId = action.keyActionIndex?.let { insertedKeyIdsByActionIndex[it] }
+                ?: action.host.keyId
+            val host = action.host.copy(keyId = localKeyId)
+            db.hostProfileDao().insertForImport(host)
+            importedHosts += 1
+        }
+
+        return BackupImportResult(
+            importedKeys = plan.keyInsertCount,
+            reusedKeys = plan.keyReuseCount,
+            importedHosts = importedHosts,
+            renamedKeys = plan.renamedKeyCount,
+            renamedHosts = plan.renamedHostCount,
+        )
+    }
+}
+
+data class BackupImportResult(
+    val importedKeys: Int,
+    val reusedKeys: Int,
+    val importedHosts: Int,
+    val renamedKeys: Int,
+    val renamedHosts: Int,
+)
+
+fun buildBackupPayload(
+    keys: List<SshKey>,
+    hosts: List<HostProfile>,
+): BackupPayload = BackupPayload(
+    keys = keys.map(BackupSshKey::fromEntity),
+    hosts = hosts.map(BackupHostProfile::fromEntity),
+)

--- a/android/app/src/main/java/com/jossephus/chuchu/data/db/HostProfileDao.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/db/HostProfileDao.kt
@@ -17,8 +17,14 @@ interface HostProfileDao {
     @Query("SELECT * FROM host_profiles WHERE id = :id")
     suspend fun getById(id: Long): HostProfile?
 
+    @Query("SELECT * FROM host_profiles ORDER BY name")
+    suspend fun getAll(): List<HostProfile>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(profile: HostProfile): Long
+
+    @Insert
+    suspend fun insertForImport(profile: HostProfile): Long
 
     @Update
     suspend fun update(profile: HostProfile)

--- a/android/app/src/main/java/com/jossephus/chuchu/data/db/SshKeyDao.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/db/SshKeyDao.kt
@@ -15,8 +15,14 @@ interface SshKeyDao {
     @Query("SELECT * FROM ssh_keys WHERE id = :id")
     suspend fun getById(id: Long): SshKey?
 
+    @Query("SELECT * FROM ssh_keys ORDER BY name")
+    suspend fun getAll(): List<SshKey>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(key: SshKey): Long
+
+    @Insert
+    suspend fun insertForImport(key: SshKey): Long
 
     @Query("DELETE FROM ssh_keys WHERE id = :id")
     suspend fun deleteById(id: Long)

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -24,6 +24,7 @@ import com.jossephus.chuchu.ui.screens.AddServer.AddServerScreen
 import com.jossephus.chuchu.ui.screens.AddServer.AddServerViewModel
 import com.jossephus.chuchu.ui.screens.ServerList.ServerListScreen
 import com.jossephus.chuchu.ui.screens.ServerList.ServerListViewModel
+import com.jossephus.chuchu.ui.screens.Settings.SettingsBackupViewModel
 import com.jossephus.chuchu.ui.screens.Settings.SettingsScreen
 import com.jossephus.chuchu.ui.screens.Terminal.TerminalScreen
 import com.jossephus.chuchu.ui.screens.Terminal.TerminalViewModel
@@ -89,6 +90,9 @@ fun ApplicationNavController() {
         }
         composable("settings") {
             val settingsRepo = SettingsRepository.getInstance(application)
+            val backupViewModel: SettingsBackupViewModel = viewModel(
+                factory = SettingsBackupViewModel.factory(application),
+            )
             val themeName by settingsRepo.themeName.collectAsStateWithLifecycle()
             val fontName by settingsRepo.fontName.collectAsStateWithLifecycle()
             val appLockEnabled by settingsRepo.appLockEnabled.collectAsStateWithLifecycle()
@@ -117,6 +121,7 @@ fun ApplicationNavController() {
                 onAccessoryLayoutChanged = settingsRepo::setAccessoryLayoutIds,
                 onAccessoryBarSingleRowChanged = settingsRepo::setAccessoryBarSingleRow,
                 onTerminalCustomActionsChanged = settingsRepo::setTerminalCustomKeyGroups,
+                backupViewModel = backupViewModel,
                 onBack = {
                     val currentRoute = navController.currentBackStackEntry?.destination?.route
                     if (currentRoute == "settings") {

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsBackupViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsBackupViewModel.kt
@@ -1,0 +1,284 @@
+package com.jossephus.chuchu.ui.screens.Settings
+
+import android.app.Application
+import android.net.Uri
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.jossephus.chuchu.data.backup.BackupFormatException
+import com.jossephus.chuchu.data.backup.BackupImportPlan
+import com.jossephus.chuchu.data.backup.BackupPayload
+import com.jossephus.chuchu.data.backup.ChuchuBackupCodec
+import com.jossephus.chuchu.data.backup.ChuchuBackupRepository
+import com.jossephus.chuchu.data.backup.InvalidBackupPassphraseException
+import com.jossephus.chuchu.data.db.AppDatabase
+import com.jossephus.chuchu.model.HostProfile
+import com.jossephus.chuchu.model.SshKey
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal const val BACKUP_MIN_PASSPHRASE_LENGTH = 8
+
+class SettingsBackupViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+    companion object {
+        fun factory(application: Application): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    if (modelClass.isAssignableFrom(SettingsBackupViewModel::class.java)) {
+                        @Suppress("UNCHECKED_CAST")
+                        return SettingsBackupViewModel(application) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+                }
+            }
+    }
+
+    private val db = AppDatabase.getInstance(application)
+    private val backupRepo = ChuchuBackupRepository(db)
+
+    private val _keys = MutableStateFlow<List<SshKey>>(emptyList())
+    val keys: StateFlow<List<SshKey>> = _keys.asStateFlow()
+
+    private val _hosts = MutableStateFlow<List<HostProfile>>(emptyList())
+    val hosts: StateFlow<List<HostProfile>> = _hosts.asStateFlow()
+
+    private val _isBusy = MutableStateFlow(false)
+    val isBusy: StateFlow<Boolean> = _isBusy.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _success = MutableStateFlow<String?>(null)
+    val success: StateFlow<String?> = _success.asStateFlow()
+
+    // Passphrase fields
+    private val _exportPassphrase = MutableStateFlow("")
+    val exportPassphrase: StateFlow<String> = _exportPassphrase.asStateFlow()
+
+    private val _exportPassphraseConfirm = MutableStateFlow("")
+    val exportPassphraseConfirm: StateFlow<String> = _exportPassphraseConfirm.asStateFlow()
+
+    private val _importPassphrase = MutableStateFlow("")
+    val importPassphrase: StateFlow<String> = _importPassphrase.asStateFlow()
+
+    // Import preview state
+    private val _importPlan = MutableStateFlow<BackupImportPlan?>(null)
+    val importPlan: StateFlow<BackupImportPlan?> = _importPlan.asStateFlow()
+
+    // Decrypted payload cached during import flow
+    private var cachedPayload: BackupPayload? = null
+
+    init {
+        viewModelScope.launch {
+            db.sshKeyDao().observeAll().collect { _keys.value = it }
+        }
+        viewModelScope.launch {
+            db.hostProfileDao().observeAll().collect { _hosts.value = it }
+        }
+    }
+
+    // ── Passphrase state setters ──────────────────────────────────────────────
+
+    fun updateExportPassphrase(value: String) {
+        _exportPassphrase.value = value
+    }
+
+    fun updateExportPassphraseConfirm(value: String) {
+        _exportPassphraseConfirm.value = value
+    }
+
+    fun updateImportPassphrase(value: String) {
+        _importPassphrase.value = value
+    }
+
+    fun exportPassphraseValid(): Boolean {
+        val p = _exportPassphrase.value
+        return p.length >= BACKUP_MIN_PASSPHRASE_LENGTH && p == _exportPassphraseConfirm.value
+    }
+
+    fun importPassphraseValid(): Boolean {
+        return _importPassphrase.value.length >= 1
+    }
+
+    // ── Export ────────────────────────────────────────────────────────────────
+
+    /**
+     * Called from the Sheet composable after device auth succeeds and SAF returns
+     * a writeable URI. Encrypts the backup in memory and writes to the URI.
+     */
+    fun performExport(uri: Uri) {
+        if (_isBusy.value || !exportPassphraseValid()) return
+        _isBusy.value = true
+        viewModelScope.launch {
+            _error.value = null
+            _success.value = null
+            val passphrase = _exportPassphrase.value.toCharArray()
+            try {
+                val encryptedBytes = withContext(Dispatchers.IO) {
+                    backupRepo.createEncryptedBackup(passphrase)
+                }
+                withContext(Dispatchers.IO) {
+                    val context = getApplication<Application>()
+                    context.contentResolver.openOutputStream(uri)?.use { output ->
+                        output.write(encryptedBytes)
+                    } ?: throw BackupFormatException("Could not open backup destination")
+                }
+                _success.value = "Backup exported successfully"
+            } catch (_: Exception) {
+                _error.value = "Export failed. Please choose another location and try again."
+            } finally {
+                passphrase.fill('\u0000')
+                _isBusy.value = false
+                clearExportPassphrase()
+            }
+        }
+    }
+
+    // ── Import ────────────────────────────────────────────────────────────────
+
+    /**
+     * Called from the Sheet composable after device auth succeeds and SAF returns
+     * a readable URI. Reads bytes, decrypts, and plans the import.
+     */
+    fun performImport(uri: Uri) {
+        if (_isBusy.value || !importPassphraseValid()) return
+        _isBusy.value = true
+        viewModelScope.launch {
+            _error.value = null
+            _success.value = null
+            _importPlan.value = null
+            cachedPayload = null
+            val passphrase = _importPassphrase.value.toCharArray()
+            try {
+                val bytes = withContext(Dispatchers.IO) {
+                    readBackupBytes(uri)
+                }
+                val payload = withContext(Dispatchers.IO) {
+                    backupRepo.readEncryptedBackup(bytes, passphrase)
+                }
+                cachedPayload = payload
+                val plan = withContext(Dispatchers.IO) {
+                    backupRepo.planImport(payload)
+                }
+                _importPassphrase.value = ""
+                _importPlan.value = plan
+            } catch (_: InvalidBackupPassphraseException) {
+                _error.value = "Wrong passphrase. Could not decrypt backup."
+                clearImportPassphrase()
+            } catch (_: BackupFormatException) {
+                _error.value = "Import failed. Choose a valid Chuchu backup file."
+                clearImportPassphrase()
+            } catch (_: Exception) {
+                _error.value = "Import failed. Could not read the selected backup file."
+                clearImportPassphrase()
+            } finally {
+                passphrase.fill('\u0000')
+                _isBusy.value = false
+            }
+        }
+    }
+
+    /** Proceed with the cached import after user confirms the preview. */
+    fun confirmImport() {
+        if (_isBusy.value) return
+        val payload = cachedPayload ?: return
+        _isBusy.value = true
+        viewModelScope.launch {
+            _error.value = null
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    backupRepo.importPayload(payload)
+                }
+                val parts = mutableListOf<String>()
+                if (result.importedKeys > 0) parts += "${result.importedKeys} key(s)"
+                if (result.reusedKeys > 0) parts += "${result.reusedKeys} reused"
+                if (result.renamedKeys > 0) parts += "${result.renamedKeys} key(s) renamed"
+                if (result.importedHosts > 0) parts += "${result.importedHosts} host(s)"
+                if (result.renamedHosts > 0) parts += "${result.renamedHosts} host(s) renamed"
+                _success.value = "Import complete: ${parts.joinToString(", ")}"
+                clearImportState()
+            } catch (_: Exception) {
+                _error.value = "Import failed. Nothing was changed."
+                clearImportState()
+            } finally {
+                _isBusy.value = false
+            }
+        }
+    }
+
+    /** Dismiss the import preview and clear cached data. */
+    fun cancelImport() {
+        clearImportState()
+    }
+
+    // ── Dismiss / clear ───────────────────────────────────────────────────────
+
+    /** Clear everything when the sheet is dismissed or back is pressed. */
+    fun dismissSheet() {
+        clearAllState()
+    }
+
+    fun clearMessages() {
+        _error.value = null
+        _success.value = null
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private fun readBackupBytes(uri: Uri): ByteArray {
+        val context = getApplication<Application>()
+        return context.contentResolver.openInputStream(uri)?.use { input ->
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var totalBytes = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                totalBytes += read
+                if (totalBytes > ChuchuBackupCodec.MAX_BACKUP_SIZE_BYTES) {
+                    throw BackupFormatException("Backup file is too large")
+                }
+                output.write(buffer, 0, read)
+            }
+            output.toByteArray()
+        } ?: throw BackupFormatException("Could not open backup file")
+    }
+
+    private fun clearExportPassphrase() {
+        _exportPassphrase.value = ""
+        _exportPassphraseConfirm.value = ""
+    }
+
+    private fun clearImportPassphrase() {
+        _importPassphrase.value = ""
+    }
+
+    private fun clearImportState() {
+        _importPassphrase.value = ""
+        _importPlan.value = null
+        cachedPayload = null
+    }
+
+    private fun clearAllState() {
+        _exportPassphrase.value = ""
+        _exportPassphraseConfirm.value = ""
+        _importPassphrase.value = ""
+        _importPlan.value = null
+        cachedPayload = null
+        _error.value = null
+        _success.value = null
+    }
+
+    override fun onCleared() {
+        clearAllState()
+        super.onCleared()
+    }
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsBackupViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsBackupViewModel.kt
@@ -16,6 +16,7 @@ import com.jossephus.chuchu.data.db.AppDatabase
 import com.jossephus.chuchu.model.HostProfile
 import com.jossephus.chuchu.model.SshKey
 import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -132,6 +133,8 @@ class SettingsBackupViewModel(
                     } ?: throw BackupFormatException("Could not open backup destination")
                 }
                 _success.value = "Backup exported successfully"
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 _error.value = "Export failed. Please choose another location and try again."
             } finally {
@@ -176,6 +179,8 @@ class SettingsBackupViewModel(
             } catch (_: BackupFormatException) {
                 _error.value = "Import failed. Choose a valid Chuchu backup file."
                 clearImportPassphrase()
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 _error.value = "Import failed. Could not read the selected backup file."
                 clearImportPassphrase()
@@ -205,6 +210,8 @@ class SettingsBackupViewModel(
                 if (result.renamedHosts > 0) parts += "${result.renamedHosts} host(s) renamed"
                 _success.value = "Import complete: ${parts.joinToString(", ")}"
                 clearImportState()
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 _error.value = "Import failed. Nothing was changed."
                 clearImportState()

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ fun SettingsScreen(
     onAccessoryLayoutChanged: (List<String>) -> Unit,
     onAccessoryBarSingleRowChanged: (Boolean) -> Unit,
     onTerminalCustomActionsChanged: (List<TerminalCustomKeyGroup>) -> Unit,
+    backupViewModel: SettingsBackupViewModel? = null,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -66,9 +67,14 @@ fun SettingsScreen(
     var selectedCategory by remember { mutableStateOf(SettingsCategory.General) }
     var showAccessoryEditor by remember { mutableStateOf(false) }
     var showCustomActionEditor by remember { mutableStateOf(false) }
+    var showBackupSheet by remember { mutableStateOf(false) }
 
     BackHandler(enabled = true) {
         when {
+            showBackupSheet -> {
+                backupViewModel?.dismissSheet()
+                showBackupSheet = false
+            }
             showCustomActionEditor -> showCustomActionEditor = false
             showAccessoryEditor -> showAccessoryEditor = false
             else -> onBack()
@@ -149,6 +155,7 @@ fun SettingsScreen(
                         requireAuthOnConnect = requireAuthOnConnect,
                         onAppLockEnabledChanged = onAppLockEnabledChanged,
                         onRequireAuthOnConnectChanged = onRequireAuthOnConnectChanged,
+                        onOpenBackup = { showBackupSheet = true },
                     )
                     SettingsCategory.Terminal -> TerminalSettings(
                         currentAccessoryLayoutIds = currentAccessoryLayoutIds,
@@ -178,6 +185,14 @@ fun SettingsScreen(
             onSave = onTerminalCustomActionsChanged,
             onDismiss = { showCustomActionEditor = false },
         )
+
+        if (backupViewModel != null) {
+            SshBackupSheet(
+                visible = showBackupSheet,
+                viewModel = backupViewModel,
+                onDismiss = { showBackupSheet = false },
+            )
+        }
     }
 }
 
@@ -195,6 +210,7 @@ private fun GeneralSettings(
     requireAuthOnConnect: Boolean,
     onAppLockEnabledChanged: (Boolean) -> Unit,
     onRequireAuthOnConnectChanged: (Boolean) -> Unit,
+    onOpenBackup: () -> Unit = {},
 ) {
     val typography = ChuTypography.current
     val colors = ChuColors.current
@@ -238,4 +254,22 @@ private fun GeneralSettings(
     }
     Spacer(modifier = Modifier.height(4.dp))
     ChuText("use biometrics or device PIN/pattern.", style = typography.bodySmall, color = colors.textMuted)
+    Spacer(modifier = Modifier.height(16.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ChuText("ssh keys & backups", style = typography.label)
+        ChuButton(
+            onClick = onOpenBackup,
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+        ) {
+            ChuText("manage", style = typography.label)
+        }
+    }
+    Spacer(modifier = Modifier.height(4.dp))
+    ChuText("encrypted export/import.", style = typography.bodySmall, color = colors.textMuted)
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SshBackupSheet.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SshBackupSheet.kt
@@ -1,0 +1,764 @@
+package com.jossephus.chuchu.ui.screens.Settings
+
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import com.jossephus.chuchu.data.backup.BackupImportPlan
+import com.jossephus.chuchu.data.backup.CHUCHU_BACKUP_MIME_TYPE
+import com.jossephus.chuchu.data.backup.KeyImportAction
+import com.jossephus.chuchu.model.SshKey
+import com.jossephus.chuchu.ui.components.ChuButton
+import com.jossephus.chuchu.ui.components.ChuButtonVariant
+import com.jossephus.chuchu.ui.components.ChuCard
+import com.jossephus.chuchu.ui.components.ChuText
+import com.jossephus.chuchu.ui.components.ChuTextField
+import com.jossephus.chuchu.ui.security.VerificationResult
+import com.jossephus.chuchu.ui.security.requireUserVerification
+import com.jossephus.chuchu.ui.theme.ChuColors
+import com.jossephus.chuchu.ui.theme.ChuTypography
+
+/** Internal step tracking for the backup sheet flow. */
+private sealed interface SheetStep {
+    /** Default view: key list, counts, export/import buttons. */
+    data object Overview : SheetStep
+
+    /** Show export passphrase fields. */
+    data object ExportPassphrase : SheetStep
+
+    /** Show import passphrase field. */
+    data object ImportPassphrase : SheetStep
+
+    /** Show import preview summary before confirming. */
+    data class ImportPreview(val plan: BackupImportPlan) : SheetStep
+}
+
+@Composable
+internal fun SshBackupSheet(
+    visible: Boolean,
+    viewModel: SettingsBackupViewModel,
+    onDismiss: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    val context = LocalContext.current
+
+    // VM state
+    val keys by viewModel.keys.collectAsStateWithLifecycle()
+    val hosts by viewModel.hosts.collectAsStateWithLifecycle()
+    val isBusy by viewModel.isBusy.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+    val success by viewModel.success.collectAsStateWithLifecycle()
+    val importPlan by viewModel.importPlan.collectAsStateWithLifecycle()
+    val exportPassphrase by viewModel.exportPassphrase.collectAsStateWithLifecycle()
+    val exportPassphraseConfirm by viewModel.exportPassphraseConfirm.collectAsStateWithLifecycle()
+    val importPassphrase by viewModel.importPassphrase.collectAsStateWithLifecycle()
+
+    // Sheet step – derived from VM state so they stay in sync
+    val step = when {
+        importPlan != null -> SheetStep.ImportPreview(importPlan!!)
+        else -> {
+            // Local-only steps managed inside the sheet
+            null
+        }
+    }
+    var localStep by remember { mutableStateOf<SheetStep>(SheetStep.Overview) }
+    val effectiveStep: SheetStep = step ?: localStep
+
+    // SAF launchers – stay at composable scope
+    val exportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument(CHUCHU_BACKUP_MIME_TYPE),
+    ) { uri ->
+        if (uri != null) {
+            viewModel.performExport(uri)
+        } else {
+            // User cancelled SAF picker – clear export passphrase
+            viewModel.updateExportPassphrase("")
+            viewModel.updateExportPassphraseConfirm("")
+        }
+        localStep = SheetStep.Overview
+    }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri != null) {
+            viewModel.performImport(uri)
+        } else {
+            // User cancelled SAF picker – clear import passphrase
+            viewModel.updateImportPassphrase("")
+        }
+        localStep = SheetStep.Overview
+    }
+
+    // ── Dismiss handler ────────────────────────────────────────────────────
+    fun handleDismiss() {
+        viewModel.dismissSheet()
+        localStep = SheetStep.Overview
+        onDismiss()
+    }
+
+    BackHandler(enabled = visible) {
+        handleDismiss()
+    }
+
+    // ── Scrim + Sheet ──────────────────────────────────────────────────────
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Scrim overlay
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(colors.background.copy(alpha = 0.72f))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = { handleDismiss() },
+                    ),
+            )
+        }
+
+        // Sheet panel
+        AnimatedVisibility(
+            visible = visible,
+            enter = slideInVertically { it },
+            exit = slideOutVertically { it },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.82f)
+                    .background(colors.surfaceVariant)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {},
+                    )
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                // ── Header ────────────────────────────────────────────────
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        ChuText("ssh keys & backups", style = typography.headline)
+                        ChuText(
+                            text = when (effectiveStep) {
+                                is SheetStep.Overview -> "Backup your SSH keys and server profiles."
+                                is SheetStep.ExportPassphrase -> "Create an encrypted backup file."
+                                is SheetStep.ImportPassphrase -> "Restore from an encrypted backup file."
+                                is SheetStep.ImportPreview -> "Review what will be imported."
+                            },
+                            style = typography.body,
+                            color = colors.textSecondary,
+                        )
+                    }
+
+                    ChuButton(
+                        onClick = { handleDismiss() },
+                        variant = ChuButtonVariant.Ghost,
+                        bracketed = true,
+                        borderColor = colors.textMuted,
+                        contentPadding = PaddingValues(6.dp),
+                    ) {
+                        ChuText("x", style = typography.label, color = colors.textMuted)
+                    }
+                }
+
+                // ── Scrollable content ─────────────────────────────────────
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    when (effectiveStep) {
+                        is SheetStep.Overview -> OverviewContent(
+                            keys = keys,
+                            hostCount = hosts.size,
+                            busy = isBusy,
+                            onExport = { localStep = SheetStep.ExportPassphrase },
+                            onImport = { localStep = SheetStep.ImportPassphrase },
+                        )
+
+                        is SheetStep.ExportPassphrase -> ExportPassphraseContent(
+                            passphrase = exportPassphrase,
+                            passphraseConfirm = exportPassphraseConfirm,
+                            onPassphraseChange = viewModel::updateExportPassphrase,
+                            onPassphraseConfirmChange = viewModel::updateExportPassphraseConfirm,
+                            valid = viewModel.exportPassphraseValid(),
+                            busy = isBusy,
+                            onExport = {
+                                requireUserVerification(
+                                    context = context,
+                                    title = "Export SSH backup",
+                                    subtitle = "Authenticate to create an encrypted backup",
+                                ) { result ->
+                                    if (result == VerificationResult.Success || result == VerificationResult.Unavailable) {
+                                        exportLauncher.launch(defaultBackupFileName())
+                                    }
+                                    // On Failed, stay on the same step
+                                }
+                            },
+                            onCancel = {
+                                viewModel.updateExportPassphrase("")
+                                viewModel.updateExportPassphraseConfirm("")
+                                localStep = SheetStep.Overview
+                            },
+                        )
+
+                        is SheetStep.ImportPassphrase -> ImportPassphraseContent(
+                            passphrase = importPassphrase,
+                            onPassphraseChange = viewModel::updateImportPassphrase,
+                            valid = viewModel.importPassphraseValid(),
+                            busy = isBusy,
+                            onImport = {
+                                requireUserVerification(
+                                    context = context,
+                                    title = "Import SSH backup",
+                                    subtitle = "Authenticate to restore an encrypted backup",
+                                ) { result ->
+                                    if (result == VerificationResult.Success || result == VerificationResult.Unavailable) {
+                                        importLauncher.launch(arrayOf(CHUCHU_BACKUP_MIME_TYPE, "*/*"))
+                                    }
+                                    // On Failed, stay on the same step
+                                }
+                            },
+                            onCancel = {
+                                viewModel.updateImportPassphrase("")
+                                localStep = SheetStep.Overview
+                            },
+                        )
+
+                        is SheetStep.ImportPreview -> ImportPreviewContent(
+                            plan = effectiveStep.plan,
+                            busy = isBusy,
+                            onConfirm = viewModel::confirmImport,
+                            onCancel = {
+                                viewModel.cancelImport()
+                                localStep = SheetStep.Overview
+                            },
+                        )
+                    }
+
+                    // ── Status messages ────────────────────────────────────
+                    if (isBusy) {
+                        ChuCard(modifier = Modifier.fillMaxWidth()) {
+                            ChuText(
+                                text = "Working…",
+                                style = typography.body,
+                                color = colors.textMuted,
+                                modifier = Modifier.padding(12.dp),
+                            )
+                        }
+                    }
+
+                    error?.let { msg ->
+                        ChuCard(modifier = Modifier.fillMaxWidth(), background = colors.error.copy(alpha = 0.12f)) {
+                            ChuText(
+                                text = msg,
+                                style = typography.body,
+                                color = colors.error,
+                                modifier = Modifier.padding(12.dp),
+                            )
+                        }
+                    }
+
+                    success?.let { msg ->
+                        ChuCard(modifier = Modifier.fillMaxWidth(), background = colors.accent.copy(alpha = 0.12f)) {
+                            ChuText(
+                                text = msg,
+                                style = typography.body,
+                                color = colors.accent,
+                                modifier = Modifier.padding(12.dp),
+                            )
+                        }
+                    }
+                }
+
+                // ── Bottom action (only for overview) ──────────────────────
+                if (effectiveStep is SheetStep.Overview && (error != null || success != null)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        ChuButton(
+                            onClick = {
+                                viewModel.clearMessages()
+                            },
+                            variant = ChuButtonVariant.Outlined,
+                            bracketed = true,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            ChuText("dismiss", style = typography.label)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Overview content ───────────────────────────────────────────────────────────
+
+@Composable
+private fun OverviewContent(
+    keys: List<SshKey>,
+    hostCount: Int,
+    busy: Boolean,
+    onExport: () -> Unit,
+    onImport: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+
+    ChuCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            // Summary row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    ChuText("ssh keys", style = typography.label)
+                    ChuText(
+                        text = if (keys.isEmpty()) "none" else "${keys.size} key(s)",
+                        style = typography.body,
+                        color = colors.textMuted,
+                    )
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    ChuText("host profiles", style = typography.label)
+                    ChuText(
+                        text = if (hostCount == 0) "none" else "$hostCount host(s)",
+                        style = typography.body,
+                        color = colors.textMuted,
+                    )
+                }
+            }
+
+            // Key list (safe metadata only)
+            if (keys.isNotEmpty()) {
+                ChuText(
+                    text = "configured keys:",
+                    style = typography.labelSmall,
+                    color = colors.textSecondary,
+                )
+                keys.forEach { key ->
+                    KeyInfoRow(key = key)
+                }
+            } else {
+                ChuText(
+                    text = "No SSH keys configured yet. Add keys in a server profile.",
+                    style = typography.body,
+                    color = colors.textSecondary,
+                )
+            }
+
+            // Warning about encrypted secrets
+            ChuText(
+                text = "Backups include all private keys, passwords, and passphrases inside an encrypted file.",
+                style = typography.bodySmall,
+                color = colors.textMuted,
+            )
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ChuButton(
+            onClick = onExport,
+            enabled = !busy,
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("export", style = typography.label, color = colors.accent)
+        }
+        ChuButton(
+            onClick = onImport,
+            enabled = !busy,
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("import", style = typography.label, color = colors.accent)
+        }
+    }
+}
+
+// ── Key info row (safe metadata only) ──────────────────────────────────────────
+
+@Composable
+private fun KeyInfoRow(key: SshKey) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    val shortPublic = publicKeyShortPrefix(key)
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            ChuText(text = key.name, style = typography.label)
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                ChuText(
+                    text = key.algorithm,
+                    style = typography.bodySmall,
+                    color = colors.textMuted,
+                )
+                if (shortPublic.isNotBlank()) {
+                    ChuText(
+                        text = shortPublic,
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Extracts a short public key prefix for safe display (never shows full PEM). */
+private fun publicKeyShortPrefix(key: SshKey): String {
+    val pk = key.publicKeyOpenSsh.trim()
+    if (pk.isEmpty()) return ""
+    // Show first line break or first 32 chars, whichever is shorter
+    val firstLine = pk.substringBefore('\n').trim()
+    return if (firstLine.length <= 36) firstLine else firstLine.take(32) + "…"
+}
+
+// ── Export passphrase content ───────────────────────────────────────────────────
+
+@Composable
+private fun ExportPassphraseContent(
+    passphrase: String,
+    passphraseConfirm: String,
+    onPassphraseChange: (String) -> Unit,
+    onPassphraseConfirmChange: (String) -> Unit,
+    valid: Boolean,
+    busy: Boolean,
+    onExport: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+
+    ChuCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            ChuTextField(
+                value = passphrase,
+                onValueChange = onPassphraseChange,
+                label = "encryption passphrase",
+                placeholder = "at least $BACKUP_MIN_PASSPHRASE_LENGTH characters",
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                autoFocus = true,
+            )
+            ChuTextField(
+                value = passphraseConfirm,
+                onValueChange = onPassphraseConfirmChange,
+                label = "confirm passphrase",
+                placeholder = "re-enter passphrase",
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                autoFocus = false,
+            )
+            if (passphrase.length in 1 until BACKUP_MIN_PASSPHRASE_LENGTH) {
+                ChuText(
+                    text = "Passphrase must be at least $BACKUP_MIN_PASSPHRASE_LENGTH characters.",
+                    style = typography.bodySmall,
+                    color = colors.textMuted,
+                )
+            } else if (passphrase.length >= BACKUP_MIN_PASSPHRASE_LENGTH && !valid) {
+                ChuText(
+                    text = "Passphrases do not match.",
+                    style = typography.bodySmall,
+                    color = colors.error,
+                )
+            }
+            ChuText(
+                text = "You will be prompted to choose a save location and verify your identity.",
+                style = typography.bodySmall,
+                color = colors.textMuted,
+            )
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ChuButton(
+            onClick = onCancel,
+            variant = ChuButtonVariant.Ghost,
+            bracketed = true,
+            borderColor = colors.textMuted,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("cancel", style = typography.label, color = colors.textMuted)
+        }
+        ChuButton(
+            onClick = onExport,
+            enabled = !busy && valid,
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            borderColor = colors.accent,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("export", style = typography.label, color = colors.accent)
+        }
+    }
+}
+
+// ── Import passphrase content ───────────────────────────────────────────────────
+
+@Composable
+private fun ImportPassphraseContent(
+    passphrase: String,
+    onPassphraseChange: (String) -> Unit,
+    valid: Boolean,
+    busy: Boolean,
+    onImport: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+
+    ChuCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            ChuTextField(
+                value = passphrase,
+                onValueChange = onPassphraseChange,
+                label = "backup passphrase",
+                placeholder = "passphrase used during export",
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                autoFocus = true,
+            )
+            ChuText(
+                text = "You will be prompted to select a backup file and verify your identity.",
+                style = typography.bodySmall,
+                color = colors.textMuted,
+            )
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ChuButton(
+            onClick = onCancel,
+            variant = ChuButtonVariant.Ghost,
+            bracketed = true,
+            borderColor = colors.textMuted,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("cancel", style = typography.label, color = colors.textMuted)
+        }
+        ChuButton(
+            onClick = onImport,
+            enabled = !busy && valid,
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            borderColor = colors.accent,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("import", style = typography.label, color = colors.accent)
+        }
+    }
+}
+
+// ── Import preview content ─────────────────────────────────────────────────────
+
+@Composable
+private fun ImportPreviewContent(
+    plan: BackupImportPlan,
+    busy: Boolean,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+
+    ChuCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            ChuText("import summary", style = typography.label)
+
+            val summaryParts = mutableListOf<String>()
+            val keyInsert = plan.keyInsertCount
+            val keyReuse = plan.keyReuseCount
+            val keyRenamed = plan.renamedKeyCount
+            val hostImported = plan.hostActions.size
+            val hostRenamed = plan.renamedHostCount
+
+            if (keyInsert > 0) summaryParts += "$keyInsert new key(s)"
+            if (keyReuse > 0) summaryParts += "$keyReuse existing key(s) reused"
+            if (keyRenamed > 0) summaryParts += "$keyRenamed key(s) renamed"
+            if (hostImported > 0) summaryParts += "$hostImported host(s)"
+            if (hostRenamed > 0) summaryParts += "$hostRenamed host(s) renamed"
+
+            ChuText(
+                text = summaryParts.joinToString(", ").ifEmpty { "Nothing to import" },
+                style = typography.body,
+                color = colors.textSecondary,
+            )
+
+            // Show which keys will be reused
+            val reusedKeys = plan.keyActions.filterIsInstance<KeyImportAction.Reuse>()
+            if (reusedKeys.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                ChuText("reused keys:", style = typography.labelSmall, color = colors.textMuted)
+                reusedKeys.forEach { action ->
+                    ChuText(
+                        text = "  • ${action.name}",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+            }
+
+            // Show which keys will be inserted
+            val insertedKeys = plan.keyActions.filterIsInstance<KeyImportAction.Insert>()
+            if (insertedKeys.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                ChuText("new keys:", style = typography.labelSmall, color = colors.textMuted)
+                insertedKeys.forEach { action ->
+                    val note = if (action.renamed) " (renamed)" else ""
+                    ChuText(
+                        text = "  • ${action.key.name}$note",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+            }
+
+            // Show which hosts will be imported
+            val renamedHosts = plan.hostActions.filter { it.renamed }
+            val normalHosts = plan.hostActions.filter { !it.renamed }
+            if (normalHosts.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                ChuText("hosts to add:", style = typography.labelSmall, color = colors.textMuted)
+                normalHosts.forEach { action ->
+                    ChuText(
+                        text = "  • ${action.host.name} → ${action.host.host}",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+            }
+            if (renamedHosts.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                ChuText("renamed hosts:", style = typography.labelSmall, color = colors.textMuted)
+                renamedHosts.forEach { action ->
+                    ChuText(
+                        text = "  • ${action.host.name} (conflict resolved)",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+            }
+
+            ChuText(
+                text = "Existing data will not be overwritten. Conflicting names will be auto-renamed.",
+                style = typography.bodySmall,
+                color = colors.textMuted,
+            )
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ChuButton(
+            onClick = onCancel,
+            variant = ChuButtonVariant.Ghost,
+            bracketed = true,
+            borderColor = colors.textMuted,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("cancel", style = typography.label, color = colors.textMuted)
+        }
+        ChuButton(
+            onClick = onConfirm,
+            enabled = !busy && (plan.keyInsertCount > 0 || plan.hostActions.isNotEmpty()),
+            variant = ChuButtonVariant.Outlined,
+            bracketed = true,
+            borderColor = colors.accent,
+            modifier = Modifier.weight(1f),
+        ) {
+            ChuText("confirm import", style = typography.label, color = colors.accent)
+        }
+    }
+}
+
+private fun defaultBackupFileName(): String {
+    val date = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
+    return "chuchu-ssh-hosts-backup-$date.chuchu-backup"
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SshBackupSheet.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SshBackupSheet.kt
@@ -136,8 +136,27 @@ internal fun SshBackupSheet(
         onDismiss()
     }
 
+    fun handleBack() {
+        when (effectiveStep) {
+            SheetStep.Overview -> handleDismiss()
+            SheetStep.ExportPassphrase -> {
+                viewModel.updateExportPassphrase("")
+                viewModel.updateExportPassphraseConfirm("")
+                localStep = SheetStep.Overview
+            }
+            SheetStep.ImportPassphrase -> {
+                viewModel.updateImportPassphrase("")
+                localStep = SheetStep.Overview
+            }
+            is SheetStep.ImportPreview -> {
+                viewModel.cancelImport()
+                localStep = SheetStep.Overview
+            }
+        }
+    }
+
     BackHandler(enabled = visible) {
-        handleDismiss()
+        handleBack()
     }
 
     // ── Scrim + Sheet ──────────────────────────────────────────────────────

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- SSH private keys, host passwords, passphrases, and trusted host keys are backed up only through Chuchu's encrypted local export flow. -->
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
 </full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- SSH private keys, host passwords, passphrases, and trusted host keys are backed up only through Chuchu's encrypted local export flow. -->
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <!-- Device-to-device transfer must not move plaintext local secrets outside the encrypted export flow. -->
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/android/app/src/test/java/com/jossephus/chuchu/data/backup/ChuchuBackupCoreTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/data/backup/ChuchuBackupCoreTest.kt
@@ -53,11 +53,22 @@ class ChuchuBackupCoreTest {
         val encrypted = ChuchuBackupCodec.encrypt(samplePayload(), "right".toCharArray())
         writeIntAt(
             encrypted,
-            offset = 56,
+            offset = ciphertextSizeOffset(encrypted),
             value = ChuchuBackupCodec.MAX_BACKUP_SIZE_BYTES + 1,
         )
 
         ChuchuBackupCodec.decrypt(encrypted, "right".toCharArray())
+    }
+
+    @Test(expected = BackupFormatException::class)
+    fun payloadEncodeRejectsOversizedStrings() {
+        val oversizedName = "x".repeat((4 * 1024 * 1024) + 1)
+
+        ChuchuBackupCodec.encodePayload(
+            samplePayload().copy(
+                keys = listOf(BackupSshKey.fromEntity(sampleKey(name = oversizedName))),
+            ),
+        )
     }
 
     @Test
@@ -207,6 +218,22 @@ class ChuchuBackupCoreTest {
         requireAuthOnConnect = true,
         postConnectCommand = "echo hello",
     )
+
+    private fun ciphertextSizeOffset(bytes: ByteArray): Int {
+        var offset = Int.SIZE_BYTES * 5
+        val saltSize = readIntAt(bytes, offset)
+        offset += Int.SIZE_BYTES + saltSize
+        val ivSize = readIntAt(bytes, offset)
+        offset += Int.SIZE_BYTES + ivSize
+        return offset
+    }
+
+    private fun readIntAt(bytes: ByteArray, offset: Int): Int {
+        return ((bytes[offset].toInt() and 0xff) shl 24) or
+            ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+            ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+            (bytes[offset + 3].toInt() and 0xff)
+    }
 
     private fun writeIntAt(bytes: ByteArray, offset: Int, value: Int) {
         bytes[offset] = (value ushr 24).toByte()

--- a/android/app/src/test/java/com/jossephus/chuchu/data/backup/ChuchuBackupCoreTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/data/backup/ChuchuBackupCoreTest.kt
@@ -1,0 +1,231 @@
+package com.jossephus.chuchu.data.backup
+
+import com.jossephus.chuchu.model.AuthMethod
+import com.jossephus.chuchu.model.HostProfile
+import com.jossephus.chuchu.model.SshKey
+import com.jossephus.chuchu.model.Transport
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChuchuBackupCoreTest {
+    @Test
+    fun encryptedBackupRoundTripPreservesAllCurrentFields() {
+        val payload = samplePayload()
+
+        val encrypted = ChuchuBackupCodec.encrypt(payload, "correct horse".toCharArray())
+        val decrypted = ChuchuBackupCodec.decrypt(encrypted, "correct horse".toCharArray())
+
+        assertEquals(payload, decrypted)
+        assertEquals("echo hello", decrypted.hosts.single().postConnectCommand)
+        assertFalse(String(encrypted, Charsets.ISO_8859_1).contains("PRIVATE KEY"))
+    }
+
+    @Test(expected = InvalidBackupPassphraseException::class)
+    fun wrongPassphraseFailsWithoutPayload() {
+        val encrypted = ChuchuBackupCodec.encrypt(samplePayload(), "right".toCharArray())
+
+        ChuchuBackupCodec.decrypt(encrypted, "wrong".toCharArray())
+    }
+
+    @Test
+    fun encryptedBackupsUseFreshSaltAndIv() {
+        val payload = samplePayload()
+
+        val first = ChuchuBackupCodec.encrypt(payload, "same passphrase".toCharArray())
+        val second = ChuchuBackupCodec.encrypt(payload, "same passphrase".toCharArray())
+
+        assertFalse(first.contentEquals(second))
+    }
+
+    @Test(expected = InvalidBackupPassphraseException::class)
+    fun encryptedBackupRejectsCiphertextTampering() {
+        val encrypted = ChuchuBackupCodec.encrypt(samplePayload(), "right".toCharArray())
+        encrypted[encrypted.lastIndex] = (encrypted[encrypted.lastIndex].toInt() xor 0x01).toByte()
+
+        ChuchuBackupCodec.decrypt(encrypted, "right".toCharArray())
+    }
+
+    @Test(expected = BackupFormatException::class)
+    fun encryptedBackupRejectsOversizedCiphertextBeforeAllocation() {
+        val encrypted = ChuchuBackupCodec.encrypt(samplePayload(), "right".toCharArray())
+        writeIntAt(
+            encrypted,
+            offset = 56,
+            value = ChuchuBackupCodec.MAX_BACKUP_SIZE_BYTES + 1,
+        )
+
+        ChuchuBackupCodec.decrypt(encrypted, "right".toCharArray())
+    }
+
+    @Test
+    fun importPlanReusesIdenticalKeysAndRenamesConflictingKeys() {
+        val existing = sampleKey(id = 50L, name = "main")
+        val conflicting = sampleKey(id = 1L, name = "main", privateKeyPem = "DIFFERENT")
+        val identical = BackupSshKey.fromEntity(existing.copy(id = 2L))
+        val payload = BackupPayload(
+            keys = listOf(identical, BackupSshKey.fromEntity(conflicting)),
+            hosts = emptyList(),
+        )
+
+        val plan = ChuchuBackupImportPlanner.planImport(
+            payload = payload,
+            existingKeys = listOf(existing),
+            existingHosts = emptyList(),
+        )
+
+        assertEquals(1, plan.keyReuseCount)
+        assertEquals(1, plan.keyInsertCount)
+        val insert = plan.keyActions.filterIsInstance<KeyImportAction.Insert>().single()
+        assertEquals("main-2", insert.key.name)
+        assertEquals(0L, insert.key.id)
+        assertTrue(insert.renamed)
+    }
+
+    @Test
+    fun importPlanNeverPreservesExportedPrimaryKeys() {
+        val payload = BackupPayload(
+            keys = listOf(BackupSshKey.fromEntity(sampleKey(id = 10L, name = "new"))),
+            hosts = listOf(BackupHostProfile.fromEntity(sampleHost(id = 10L, keyId = 10L))),
+        )
+
+        val plan = ChuchuBackupImportPlanner.planImport(
+            payload = payload,
+            existingKeys = listOf(sampleKey(id = 10L, name = "local")),
+            existingHosts = listOf(sampleHost(id = 10L, name = "local-host", keyId = null)),
+        )
+
+        val insertKey = plan.keyActions.filterIsInstance<KeyImportAction.Insert>().single()
+        val insertHost = plan.hostActions.single()
+        assertEquals(0L, insertKey.key.id)
+        assertEquals(0L, insertHost.host.id)
+        assertEquals("new", insertKey.key.name)
+        assertEquals("server", insertHost.host.name)
+    }
+
+    @Test
+    fun importPlanRemapsHostsToReusedLocalKeyIds() {
+        val existing = sampleKey(id = 77L, name = "main")
+        val payload = BackupPayload(
+            keys = listOf(BackupSshKey.fromEntity(existing.copy(id = 1L))),
+            hosts = listOf(BackupHostProfile.fromEntity(sampleHost(id = 2L, keyId = 1L))),
+        )
+
+        val plan = ChuchuBackupImportPlanner.planImport(
+            payload = payload,
+            existingKeys = listOf(existing),
+            existingHosts = emptyList(),
+        )
+
+        assertEquals(77L, plan.hostActions.single().host.keyId)
+        assertNull(plan.hostActions.single().keyActionIndex)
+    }
+
+    @Test
+    fun importPlanTracksInsertedKeyForDeferredHostRemap() {
+        val payload = BackupPayload(
+            keys = listOf(BackupSshKey.fromEntity(sampleKey(id = 1L, name = "main"))),
+            hosts = listOf(BackupHostProfile.fromEntity(sampleHost(id = 2L, keyId = 1L))),
+        )
+
+        val plan = ChuchuBackupImportPlanner.planImport(
+            payload = payload,
+            existingKeys = emptyList(),
+            existingHosts = emptyList(),
+        )
+
+        assertNull(plan.hostActions.single().host.keyId)
+        assertEquals(0, plan.hostActions.single().keyActionIndex)
+    }
+
+    @Test(expected = BackupFormatException::class)
+    fun importPlanRejectsMissingKeyReferences() {
+        val payload = BackupPayload(
+            keys = emptyList(),
+            hosts = listOf(BackupHostProfile.fromEntity(sampleHost(id = 2L, keyId = 1L))),
+        )
+
+        ChuchuBackupImportPlanner.planImport(
+            payload = payload,
+            existingKeys = emptyList(),
+            existingHosts = emptyList(),
+        )
+    }
+
+    @Test(expected = BackupFormatException::class)
+    fun payloadDecodeRejectsUnknownEnums() {
+        val payload = samplePayload().copy(
+            hosts = listOf(BackupHostProfile.fromEntity(sampleHost(authMethod = AuthMethod.Key))),
+        )
+        val encoded = ChuchuBackupCodec.encodePayload(payload)
+        replaceLastAscii(encoded, "Key", "Bog")
+
+        ChuchuBackupCodec.decodePayload(encoded)
+    }
+
+    @Test(expected = BackupFormatException::class)
+    fun payloadDecodeRejectsMalformedBytes() {
+        ChuchuBackupCodec.decodePayload(byteArrayOf(1, 2, 3))
+    }
+
+    private fun samplePayload(): BackupPayload = BackupPayload(
+        keys = listOf(BackupSshKey.fromEntity(sampleKey())),
+        hosts = listOf(BackupHostProfile.fromEntity(sampleHost())),
+    )
+
+    private fun sampleKey(
+        id: Long = 1L,
+        name: String = "main",
+        privateKeyPem: String = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+    ): SshKey = SshKey(
+        id = id,
+        name = name,
+        algorithm = "ED25519",
+        privateKeyPem = privateKeyPem,
+        publicKeyOpenSsh = "ssh-ed25519 AAAA test",
+        createdAtEpochMs = 1234L,
+    )
+
+    private fun sampleHost(
+        id: Long = 2L,
+        name: String = "server",
+        keyId: Long? = 1L,
+        authMethod: AuthMethod = AuthMethod.KeyWithPassphrase,
+    ): HostProfile = HostProfile(
+        id = id,
+        name = name,
+        host = "example.com",
+        port = 2222,
+        username = "salem",
+        password = "saved-password",
+        keyId = keyId,
+        keyPassphrase = "key-passphrase",
+        transport = Transport.Mosh,
+        authMethod = authMethod,
+        requireAuthOnConnect = true,
+        postConnectCommand = "echo hello",
+    )
+
+    private fun writeIntAt(bytes: ByteArray, offset: Int, value: Int) {
+        bytes[offset] = (value ushr 24).toByte()
+        bytes[offset + 1] = (value ushr 16).toByte()
+        bytes[offset + 2] = (value ushr 8).toByte()
+        bytes[offset + 3] = value.toByte()
+    }
+
+    private fun replaceLastAscii(bytes: ByteArray, oldValue: String, newValue: String) {
+        val oldBytes = oldValue.toByteArray(Charsets.UTF_8)
+        val newBytes = newValue.toByteArray(Charsets.UTF_8)
+        require(oldBytes.size == newBytes.size)
+        var matchIndex = -1
+        for (index in 0..bytes.size - oldBytes.size) {
+            if (oldBytes.indices.all { offset -> bytes[index + offset] == oldBytes[offset] }) {
+                matchIndex = index
+            }
+        }
+        require(matchIndex >= 0)
+        newBytes.copyInto(bytes, destinationOffset = matchIndex)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a local-first encrypted backup flow for SSH keys and server profiles.

- Adds a Settings bottom sheet that lists configured SSH keys and exposes import/export actions.
- Exports/imports `.chuchu-backup` files through Android's file picker, with no cloud sync or storage permissions.
- Encrypts backups with a user passphrase and prompts for device auth when available.
- Includes SSH keys and full host profiles, including saved credentials and post-connect commands.
- Imports with a non-destructive merge: reuses identical keys, renames conflicts, and remaps host key references.
- Excludes Room/shared preference secrets from Android platform backup paths.

## Testing

Validation performed locally:

- `git diff --check`
- `cd android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest`
- Native JNI + debug APK build:
  - `PATH=/home/salem/.cache/chuchu-tools/zig-x86_64-linux-0.15.2:$PATH ANDROID_NDK_HOME=/home/salem/Android/Sdk/ndk/27.1.12297006 ANDROID_NDK_ROOT=/home/salem/Android/Sdk/ndk/27.1.12297006 make build`
  - `cd android && ./gradlew assembleDebug`
- Verified debug APK contains `lib/arm64-v8a/libchuchu_jni.so`.

User testing:

- A debug APK was sent for on-device testing.
- User checked the Settings backup sheet in a light theme and confirmed the final button styling looked good.

## AI disclosure

This PR was implemented by AI at the user's request. The user tested the debug APK on-device and requested that AI involvement be disclosed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted local export/import for SSH keys and host profiles with passphrase protection and import preview.
  * UI: settings sheet for managing SSH keys & backups with export/import flows and confirmation.

* **Data / Storage**
  * Repository and import planner to create, read, plan, and apply encrypted backups; DB insert/query paths added for import semantics.

* **Tests**
  * Added tests for encryption/decryption, tamper/passphrase handling, payload formatting, and import planning.

* **Documentation**
  * README updated to mention encrypted backup support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jossephus/chuchu/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->