### PR TITLE
feat: improve terminal accessory bar

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuButton.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuButton.kt
@@ -34,6 +34,55 @@ enum class ChuButtonVariant {
     Ghost,
 }
 
+/**
+ * Reusable non-clickable button surface: background, border, shape, press alpha,
+ * min-height, and content padding.  Used by [ChuButton] for clickable buttons
+ * and by [RepeatableAccessoryButton][com.jossephus.chuchu.ui.terminal.RepeatableAccessoryButton]
+ * for repeat-touch buttons so both share consistent visual styling.
+ */
+@Composable
+fun ChuButtonSurface(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    pressed: Boolean = false,
+    variant: ChuButtonVariant = ChuButtonVariant.Filled,
+    backgroundColor: Color? = null,
+    borderColor: Color? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
+    content: @Composable () -> Unit,
+) {
+    val colors = ChuColors.current
+    val shape = RectangleShape
+
+    val background: Color = when {
+        !enabled -> colors.disabledSurface
+        variant == ChuButtonVariant.Filled -> colors.accent
+        backgroundColor != null -> backgroundColor
+        else -> Color.Transparent
+    }
+
+    val effectiveBorderColor: Color = borderColor ?: colors.border
+
+    val border: BorderStroke? = when {
+        !enabled && variant != ChuButtonVariant.Ghost -> BorderStroke(1.dp, colors.border)
+        variant == ChuButtonVariant.Outlined -> BorderStroke(1.dp, effectiveBorderColor)
+        else -> null
+    }
+
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(background, shape)
+            .then(if (border != null) Modifier.border(border, shape) else Modifier)
+            .defaultMinSize(minHeight = 36.dp)
+            .alpha(if (pressed && enabled) 0.7f else 1f)
+            .padding(contentPadding),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
 @Composable
 fun ChuButton(
     onClick: () -> Unit,
@@ -52,22 +101,6 @@ fun ChuButton(
     val typography = ChuTypography.current
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
-    val shape = RectangleShape
-
-    val background: Color = when {
-        !enabled -> colors.disabledSurface
-        variant == ChuButtonVariant.Filled -> colors.accent
-        backgroundColor != null -> backgroundColor
-        else -> Color.Transparent
-    }
-
-    val effectiveBorderColor: Color = borderColor ?: colors.border
-
-    val border: BorderStroke? = when {
-        !enabled && variant != ChuButtonVariant.Ghost -> BorderStroke(1.dp, colors.border)
-        variant == ChuButtonVariant.Outlined -> BorderStroke(1.dp, effectiveBorderColor)
-        else -> null
-    }
 
     val bracketColor: Color = when {
         !enabled -> colors.disabledText
@@ -85,22 +118,21 @@ fun ChuButton(
         }
     }
 
-    Box(
+    ChuButtonSurface(
         modifier = modifier
             .then(semanticsModifier)
-            .clip(shape)
-            .background(background, shape)
-            .then(if (border != null) Modifier.border(border, shape) else Modifier)
-            .defaultMinSize(minHeight = 36.dp)
-            .alpha(if (pressed && enabled) 0.7f else 1f)
             .clickable(
                 enabled = enabled,
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClick,
-            )
-            .padding(contentPadding),
-        contentAlignment = Alignment.Center,
+            ),
+        enabled = enabled,
+        pressed = pressed,
+        variant = variant,
+        backgroundColor = backgroundColor,
+        borderColor = borderColor,
+        contentPadding = contentPadding,
     ) {
         if (bracketed) {
             Row(

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
@@ -55,6 +55,7 @@ fun CommandPalette(
     focusedTabIndex: Int,
     onFocusedTabIndexChange: (Int) -> Unit,
     accessoryItems: List<AccessoryKeyItem>,
+    accessoryModifierState: ModifierState,
     onAccessoryAction: (AccessoryAction) -> Unit,
     onChuchuKey: () -> Unit,
     chuchuKeyActive: Boolean,
@@ -220,7 +221,7 @@ fun CommandPalette(
       }
       KeyboardAccessoryBar(
           items = accessoryItems,
-          modifierState = ModifierState(),
+          modifierState = accessoryModifierState,
           onAction = onAccessoryAction,
           onSettings = onOpenSettings,
           onChuchuKey = onChuchuKey,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -1193,8 +1193,9 @@ fun TerminalScreen(
                             if (chuchuKeys.isPrefixActive) {
                                 chuchuKeys.reset()
                             }
+                            val preDispatchModifierState = modifierState
                             val result =
-                                TerminalAccessoryDispatcher.dispatch(action, modifierState)
+                                TerminalAccessoryDispatcher.dispatch(action, preDispatchModifierState)
                             modifierState = result.modifierState
 
                             // Mirror main-handler IME suppression
@@ -1226,7 +1227,10 @@ fun TerminalScreen(
                                 }
                                 else -> {
                                     result.specialKey?.let { key ->
-                                        vm.onSpecialKeyInput(key, modifierState.terminalMods())
+                                        vm.onSpecialKeyInput(
+                                            key,
+                                            preDispatchModifierState.terminalMods(),
+                                        )
                                     }
                                     result.text?.let { text ->
                                         if (!chuchuKeys.handleText(text)) {

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -476,6 +476,29 @@ fun TerminalScreen(
             val isReconnecting = sessionState.status == SessionStatus.Reconnecting
             val snapshot = sessionState.snapshot
             if (snapshot != null) {
+                var modifierState by remember { mutableStateOf(ModifierState()) }
+                val inputViewRef = remember { mutableStateOf<TerminalInputView?>(null) }
+                val clipboard = remember {
+                    context.getSystemService(ClipboardManager::class.java)
+                }
+
+                fun pasteClipboard(): Boolean {
+                    val clip = clipboard?.primaryClip
+                    if (clip == null || clip.itemCount == 0) {
+                        return false
+                    }
+                    val text = clip.getItemAt(0).coerceToText(context).toString()
+                    if (text.isNotEmpty()) {
+                        vm.onPasteText(modifierState.applyToText(text))
+                        selectedText = null
+                        hasSelectionActive = false
+                        selectionAnchorOffset = Offset.Zero
+                        selectionResetKey += 1
+                        return true
+                    }
+                    return false
+                }
+
                 Box(modifier = screenInsetsModifier.fillMaxSize()) {
                     LaunchedEffect(ghosttyTheme, colors, isDarkTheme) {
                         vm.onColorSchemeChanged(isDarkTheme)
@@ -499,7 +522,6 @@ fun TerminalScreen(
                         }
                     }
 
-                    val inputViewRef = remember { mutableStateOf<TerminalInputView?>(null) }
                     val titleText = sessionState.title?.takeIf { it.isNotBlank() }
                     val pwdText = sessionState.pwd?.takeIf { it.isNotBlank() }
                     val inputMethodManager = remember {
@@ -513,9 +535,6 @@ fun TerminalScreen(
                         if (view != null) {
                             inputMethodManager?.hideSoftInputFromWindow(view.windowToken, 0)
                         }
-                    }
-                    val clipboard = remember {
-                        context.getSystemService(ClipboardManager::class.java)
                     }
                     var hasClipboardText by remember { mutableStateOf(false) }
                     val scope = rememberCoroutineScope()
@@ -539,31 +558,7 @@ fun TerminalScreen(
                             clipboard?.removePrimaryClipChangedListener(listener)
                         }
                     }
-                    var modifierState by remember { mutableStateOf(ModifierState()) }
 
-                    fun resetModifiers() {
-                        modifierState = modifierState.reset()
-                    }
-
-                    fun pasteClipboard(): Boolean {
-                        val clip = clipboard?.primaryClip
-                        if (clip == null || clip.itemCount == 0) {
-                            resetModifiers()
-                            return false
-                        }
-                        val text = clip.getItemAt(0).coerceToText(context).toString()
-                        if (text.isNotEmpty()) {
-                            vm.onPasteText(modifierState.applyToText(text))
-                            resetModifiers()
-                            selectedText = null
-                            hasSelectionActive = false
-                            selectionAnchorOffset = Offset.Zero
-                            selectionResetKey += 1
-                            return true
-                        }
-                        resetModifiers()
-                        return false
-                    }
 
                     fun dispatchAccessoryAction(action: AccessoryAction) {
                         if (
@@ -1012,7 +1007,6 @@ fun TerminalScreen(
                                                             text,
                                                             modifierState,
                                                         )
-                                                        resetModifiers()
                                                     }
                                                 }
                                                 onTerminalKey = { key, codepoint, mods, action, charCode ->
@@ -1090,9 +1084,6 @@ fun TerminalScreen(
                                                             action,
                                                             charCode,
                                                         )
-                                                        if (modifierState.hasActiveModifiers()) {
-                                                            resetModifiers()
-                                                        }
                                                     }
                                                 }
                                                 setOnFocusChangeListener { _, hasFocus ->
@@ -1130,7 +1121,6 @@ fun TerminalScreen(
                                                 rawText,
                                                 actionModifierState,
                                             )
-                                            resetModifiers()
                                             requestInputFocus()
                                         },
                                         modifier =
@@ -1204,7 +1194,14 @@ fun TerminalScreen(
                                 chuchuKeys.reset()
                             }
                             val result =
-                                TerminalAccessoryDispatcher.dispatch(action, ModifierState())
+                                TerminalAccessoryDispatcher.dispatch(action, modifierState)
+                            modifierState = result.modifierState
+
+                            // Mirror main-handler IME suppression
+                            if (result.suppressImeInput) {
+                                inputViewRef.value?.armInputSuppression(action.toString())
+                            }
+
                             when (result.specialKey) {
                                 TerminalSpecialKey.Left,
                                 TerminalSpecialKey.Up -> {
@@ -1228,12 +1225,21 @@ fun TerminalScreen(
                                     showTabSheet = false
                                 }
                                 else -> {
+                                    result.specialKey?.let { key ->
+                                        vm.onSpecialKeyInput(key, modifierState.terminalMods())
+                                    }
                                     result.text?.let { text ->
                                         if (!chuchuKeys.handleText(text)) {
                                             vm.onTextInput(text)
                                         }
                                     }
                                 }
+                            }
+
+                            // Preserve sticky modifiers: paste applies active modifiers
+                            // but does not clear them.
+                            if (result.shouldPaste) {
+                                pasteClipboard()
                             }
                         }
                     }
@@ -1243,6 +1249,7 @@ fun TerminalScreen(
                         focusedTabIndex = focusedTabIndex,
                         onFocusedTabIndexChange = { focusedTabIndex = it },
                         accessoryItems = accessoryLayout,
+                        accessoryModifierState = modifierState,
                         onAccessoryAction = paletteAccessoryAction,
                         onChuchuKey = { chuchuKeys.togglePrefix() },
                         chuchuKeyActive = chuchuKeys.isPrefixActive,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,7 +41,10 @@ import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuSymbolsFontFamily
 import com.jossephus.chuchu.ui.theme.ChuTypography
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val INITIAL_REPEAT_DELAY_MS = 400L
+private const val REPEAT_INTERVAL_MS = 50L
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -243,20 +245,6 @@ private fun RepeatableAccessoryButton(
     var pressed by remember { mutableStateOf(false) }
     val currentOnAction by rememberUpdatedState(onAction)
 
-    // After the pointer handler sends the initial press, repeat after
-    // a 400ms initial delay at 50ms intervals until released.
-    // Emit one haptic tick when the delayed repeat begins.
-    LaunchedEffect(pressed, item.action) {
-        if (!pressed) return@LaunchedEffect
-        delay(400L)
-        if (!pressed) return@LaunchedEffect
-        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-        while (true) {
-            currentOnAction(item.action)
-            delay(50L)
-        }
-    }
-
     Box(
         modifier = Modifier
             .height(buttonHeight)
@@ -265,8 +253,22 @@ private fun RepeatableAccessoryButton(
                     awaitFirstDown().consume()
                     pressed = true
                     currentOnAction(item.action)
+
                     try {
-                        waitForUpOrCancellation()?.consume()
+                        val releasedDuringDelay = withTimeoutOrNull(INITIAL_REPEAT_DELAY_MS) {
+                            waitForUpOrCancellation()
+                        }
+
+                        if (releasedDuringDelay == null) {
+                            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            while (true) {
+                                currentOnAction(item.action)
+                                val released = withTimeoutOrNull(REPEAT_INTERVAL_MS) {
+                                    waitForUpOrCancellation()
+                                }
+                                if (released != null) break
+                            }
+                        }
                     } finally {
                         pressed = false
                     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
@@ -1,7 +1,11 @@
 package com.jossephus.chuchu.ui.terminal
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
@@ -9,20 +13,36 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.jossephus.chuchu.ui.components.ChuButton
+import com.jossephus.chuchu.ui.components.ChuButtonSurface
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
 import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuSymbolsFontFamily
 import com.jossephus.chuchu.ui.theme.ChuTypography
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -127,13 +147,23 @@ private fun AccessoryButton(
             contentPadding = buttonPadding,
         )
     } else {
-        ChuButton(
-            onClick = { onAction(item.action) },
-            variant = ChuButtonVariant.Outlined,
-            modifier = Modifier.height(buttonHeight),
-            contentPadding = buttonPadding,
-        ) {
-            ChuText(item.label, style = typography.label)
+        val specialKey = (item.action as? AccessoryAction.SendSpecialKey)?.key
+        if (specialKey != null && specialKey.isRepeatable) {
+            RepeatableAccessoryButton(
+                item = item,
+                onAction = onAction,
+                buttonHeight = buttonHeight,
+                buttonPadding = buttonPadding,
+            )
+        } else {
+            ChuButton(
+                onClick = { onAction(item.action) },
+                variant = ChuButtonVariant.Outlined,
+                modifier = Modifier.height(buttonHeight),
+                contentPadding = buttonPadding,
+            ) {
+                ChuText(item.label, style = typography.label)
+            }
         }
     }
 }
@@ -202,6 +232,67 @@ private fun SettingsButton(
 }
 
 @Composable
+private fun RepeatableAccessoryButton(
+    item: AccessoryKeyItem,
+    onAction: (AccessoryAction) -> Unit,
+    buttonHeight: Dp,
+    buttonPadding: PaddingValues,
+) {
+    val typography = ChuTypography.current
+    val haptics = LocalHapticFeedback.current
+    var pressed by remember { mutableStateOf(false) }
+    val currentOnAction by rememberUpdatedState(onAction)
+
+    // After the pointer handler sends the initial press, repeat after
+    // a 400ms initial delay at 50ms intervals until released.
+    // Emit one haptic tick when the delayed repeat begins.
+    LaunchedEffect(pressed, item.action) {
+        if (!pressed) return@LaunchedEffect
+        delay(400L)
+        if (!pressed) return@LaunchedEffect
+        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        while (true) {
+            currentOnAction(item.action)
+            delay(50L)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .height(buttonHeight)
+            .pointerInput(item.action) {
+                awaitEachGesture {
+                    awaitFirstDown().consume()
+                    pressed = true
+                    currentOnAction(item.action)
+                    try {
+                        waitForUpOrCancellation()?.consume()
+                    } finally {
+                        pressed = false
+                    }
+                }
+            }
+            .semantics {
+                role = Role.Button
+                contentDescription = item.label
+                onClick(label = item.label) {
+                    currentOnAction(item.action)
+                    true
+                }
+            },
+    ) {
+        ChuButtonSurface(
+            modifier = Modifier.height(buttonHeight),
+            pressed = pressed,
+            variant = ChuButtonVariant.Outlined,
+            contentPadding = buttonPadding,
+        ) {
+            ChuText(item.label, style = typography.label)
+        }
+    }
+}
+
+@Composable
 private fun ToggleButton(
     label: String,
     enabled: Boolean,
@@ -220,7 +311,7 @@ private fun ToggleButton(
     ) {
         ChuText(
             activeLabel,
-            style = typography.labelSmall,
+            style = typography.label,
             color = if (enabled) colors.onAccent else colors.textSecondary,
         )
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalAccessory.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalAccessory.kt
@@ -27,9 +27,19 @@ data class ModifierState(
         TerminalModifier.Cmd -> cmd
     }
 
+    /** Returns true when any sticky modifier is active. */
     fun hasActiveModifiers(): Boolean = ctrl || alt || shift || cmd
 
-    fun reset(): ModifierState = ModifierState()
+    /**
+     * Returns display labels for all currently active modifiers,
+     * in a consistent order. Used by the persistent indicator.
+     */
+    fun activeModifierLabels(): List<String> = buildList {
+        if (ctrl) add("Ctrl")
+        if (alt) add("Alt")
+        if (shift) add("Shift")
+        if (cmd) add("Cmd")
+    }
 
     fun terminalMods(): Int {
         var mods = 0
@@ -67,20 +77,22 @@ data class ModifierState(
 enum class TerminalSpecialKey(
     val label: String,
     val engineKey: Int,
+    val isRepeatable: Boolean = false,
 ) {
     Escape("Esc", GhosttyKey.escape),
     Tab("Tab", GhosttyKey.tab),
     Enter("Enter", GhosttyKey.enter),
-    Up("↑", GhosttyKey.arrowUp),
-    Down("↓", GhosttyKey.arrowDown),
-    Left("←", GhosttyKey.arrowLeft),
-    Right("→", GhosttyKey.arrowRight),
-    Home("Home", GhosttyKey.home),
-    End("End", GhosttyKey.end),
-    PageUp("PgUp", GhosttyKey.pageUp),
-    PageDown("PgDn", GhosttyKey.pageDown),
+    Up("↑", GhosttyKey.arrowUp, isRepeatable = true),
+    Down("↓", GhosttyKey.arrowDown, isRepeatable = true),
+    Left("←", GhosttyKey.arrowLeft, isRepeatable = true),
+    Right("→", GhosttyKey.arrowRight, isRepeatable = true),
+    Home("Home", GhosttyKey.home, isRepeatable = true),
+    End("End", GhosttyKey.end, isRepeatable = true),
+    PageUp("PgUp", GhosttyKey.pageUp, isRepeatable = true),
+    PageDown("PgDn", GhosttyKey.pageDown, isRepeatable = true),
     Insert("Ins", GhosttyKey.insert),
-    Delete("Del", GhosttyKey.delete),
+    Delete("Del", GhosttyKey.delete, isRepeatable = true),
+    Backspace("⌫", GhosttyKey.backspace, isRepeatable = true),
     F1("F1", GhosttyKey.f1),
     F2("F2", GhosttyKey.f2),
     F3("F3", GhosttyKey.f3),
@@ -129,13 +141,13 @@ object TerminalAccessoryDispatcher {
         )
 
         is AccessoryAction.SendSpecialKey -> AccessoryDispatchResult(
-            modifierState = modifierState.reset(),
+            modifierState = modifierState,
             specialKey = action.key,
             suppressImeInput = true,
         )
 
         is AccessoryAction.SendText -> AccessoryDispatchResult(
-            modifierState = modifierState.reset(),
+            modifierState = modifierState,
             text = modifierState.applyToText(action.text),
         )
 
@@ -166,6 +178,9 @@ object TerminalAccessoryLayoutStore {
         AccessoryKeyItem("page_down", TerminalSpecialKey.PageDown.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.PageDown)),
         AccessoryKeyItem("insert", TerminalSpecialKey.Insert.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.Insert)),
         AccessoryKeyItem("delete", TerminalSpecialKey.Delete.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.Delete)),
+        AccessoryKeyItem("backspace", TerminalSpecialKey.Backspace.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.Backspace)),
+        AccessoryKeyItem("minus", "-", AccessoryAction.SendText("-")),
+        AccessoryKeyItem("slash", "/", AccessoryAction.SendText("/")),
         AccessoryKeyItem("f1", TerminalSpecialKey.F1.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.F1)),
         AccessoryKeyItem("f2", TerminalSpecialKey.F2.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.F2)),
         AccessoryKeyItem("f3", TerminalSpecialKey.F3.label, AccessoryAction.SendSpecialKey(TerminalSpecialKey.F3)),

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalAccessory.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalAccessory.kt
@@ -27,19 +27,7 @@ data class ModifierState(
         TerminalModifier.Cmd -> cmd
     }
 
-    /** Returns true when any sticky modifier is active. */
     fun hasActiveModifiers(): Boolean = ctrl || alt || shift || cmd
-
-    /**
-     * Returns display labels for all currently active modifiers,
-     * in a consistent order. Used by the persistent indicator.
-     */
-    fun activeModifierLabels(): List<String> = buildList {
-        if (ctrl) add("Ctrl")
-        if (alt) add("Alt")
-        if (shift) add("Shift")
-        if (cmd) add("Cmd")
-    }
 
     fun terminalMods(): Int {
         var mods = 0

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/AccessoryLogicTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/AccessoryLogicTest.kt
@@ -1,0 +1,268 @@
+package com.jossephus.chuchu.ui.terminal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Focused tests for pure accessory-bar logic:
+ * sticky modifier persistence, catalog entries, and dispatch behavior.
+ *
+ * These test only Kotlin/non-Android APIs so they run as plain JUnit.
+ */
+class AccessoryLogicTest {
+
+    // ── ModifierState ──────────────────────────────────────────────────────
+
+    @Test
+    fun `toggle each modifier independently`() {
+        val s0 = ModifierState()
+        assertFalse(s0.hasActiveModifiers())
+
+        val s1 = s0.toggle(TerminalModifier.Ctrl)
+        assertTrue(s1.ctrl)
+        assertFalse(s1.alt)
+        assertFalse(s1.shift)
+        assertFalse(s1.cmd)
+        assertTrue(s1.hasActiveModifiers())
+
+        val s2 = s1.toggle(TerminalModifier.Ctrl)
+        assertFalse(s2.ctrl)
+        assertFalse(s2.hasActiveModifiers())
+
+        val s3 = s2.toggle(TerminalModifier.Alt).toggle(TerminalModifier.Shift)
+        assertTrue(s3.alt)
+        assertTrue(s3.shift)
+        assertFalse(s3.ctrl)
+        assertFalse(s3.cmd)
+    }
+
+    @Test
+    fun `activeModifierLabels returns only active labels in order`() {
+        assertEquals(emptyList<String>(), ModifierState().activeModifierLabels())
+
+        val s = ModifierState(ctrl = true, shift = true, cmd = true)
+        assertEquals(listOf("Ctrl", "Shift", "Cmd"), s.activeModifierLabels())
+    }
+
+    @Test
+    fun `isEnabled returns correct values`() {
+        val s = ModifierState(ctrl = true, alt = false, shift = true, cmd = false)
+        assertTrue(s.isEnabled(TerminalModifier.Ctrl))
+        assertFalse(s.isEnabled(TerminalModifier.Alt))
+        assertTrue(s.isEnabled(TerminalModifier.Shift))
+        assertFalse(s.isEnabled(TerminalModifier.Cmd))
+    }
+
+    @Test
+    fun `terminalMods encodes bits correctly`() {
+        assertEquals(0, ModifierState().terminalMods())
+        assertEquals(1, ModifierState(shift = true).terminalMods())   // bit 0
+        assertEquals(2, ModifierState(ctrl = true).terminalMods())    // bit 1
+        assertEquals(4, ModifierState(alt = true).terminalMods())    // bit 2
+        assertEquals(8, ModifierState(cmd = true).terminalMods())    // bit 3
+        assertEquals(15, ModifierState(ctrl = true, alt = true, shift = true, cmd = true).terminalMods())
+    }
+
+    @Test
+    fun `applyToText returns original for empty or no modifiers`() {
+        assertEquals("", ModifierState().applyToText(""))
+        assertEquals("hello", ModifierState().applyToText("hello"))
+    }
+
+    @Test
+    fun `applyToText ctrl-modifies first char lower case`() {
+        // ctrl+a -> SOH (0x01)
+        val result = ModifierState(ctrl = true).applyToText("ab")
+        assertEquals(0x01.toChar().toString() + "b", result)
+    }
+
+    @Test
+    fun `applyToText ctrl-modifies first char upper case`() {
+        // ctrl+A -> SOH (0x01)
+        val result = ModifierState(ctrl = true).applyToText("Ab")
+        assertEquals(0x01.toChar().toString() + "b", result)
+    }
+
+    @Test
+    fun `applyToText ctrl C is ETX`() {
+        assertEquals(0x03.toChar().toString(), ModifierState(ctrl = true).applyToText("c"))
+    }
+
+    @Test
+    fun `applyToText alt wraps in escape prefix`() {
+        val result = ModifierState(alt = true).applyToText("xy")
+        assertEquals("\u001bxy", result)
+    }
+
+    @Test
+    fun `applyToText ctrl+alt combines both`() {
+        val result = ModifierState(ctrl = true, alt = true).applyToText("a")
+        assertEquals("\u001b${0x01.toChar()}", result)
+    }
+
+    // ── TerminalAccessoryDispatcher ───────────────────────────────────────
+
+    @Test
+    fun `dispatch ToggleModifier toggles and preserves other modifiers`() {
+        val s0 = ModifierState(ctrl = true)
+        val r = TerminalAccessoryDispatcher.dispatch(
+            AccessoryAction.ToggleModifier(TerminalModifier.Alt),
+            s0,
+        )
+        assertTrue(r.modifierState.ctrl)   // preserved
+        assertTrue(r.modifierState.alt)    // toggled on
+        assertNull(r.specialKey)
+        assertNull(r.text)
+        assertFalse(r.shouldPaste)
+        assertFalse(r.suppressImeInput)
+    }
+
+    @Test
+    fun `dispatch SendSpecialKey preserves modifiers and sets suppressImeInput`() {
+        val s = ModifierState(shift = true)
+        val r = TerminalAccessoryDispatcher.dispatch(
+            AccessoryAction.SendSpecialKey(TerminalSpecialKey.Tab),
+            s,
+        )
+        assertTrue(r.modifierState.shift)   // sticky — preserved
+        assertEquals(TerminalSpecialKey.Tab, r.specialKey)
+        assertTrue(r.suppressImeInput)
+        assertNull(r.text)
+        assertFalse(r.shouldPaste)
+    }
+
+    @Test
+    fun `dispatch SendText applies modifier to text`() {
+        val s = ModifierState(ctrl = true)
+        val r = TerminalAccessoryDispatcher.dispatch(
+            AccessoryAction.SendText("a"),
+            s,
+        )
+        assertTrue(r.modifierState.ctrl)   // sticky — preserved
+        assertEquals(0x01.toChar().toString(), r.text)
+        assertNull(r.specialKey)
+        assertFalse(r.shouldPaste)
+    }
+
+    @Test
+    fun `dispatch Paste returns shouldPaste and preserves modifiers`() {
+        val s = ModifierState(alt = true)
+        val r = TerminalAccessoryDispatcher.dispatch(
+            AccessoryAction.Paste,
+            s,
+        )
+        assertTrue(r.modifierState.alt)   // sticky — preserved
+        assertTrue(r.shouldPaste)
+        assertNull(r.specialKey)
+        assertNull(r.text)
+        assertFalse(r.suppressImeInput)
+    }
+
+    // ── Catalog entries ───────────────────────────────────────────────────
+
+    @Test
+    fun `catalog contains backspace`() {
+        val ids = TerminalAccessoryLayoutStore.catalog().map { it.id }
+        assertTrue("catalog must contain backspace", "backspace" in ids)
+    }
+
+    @Test
+    fun `catalog contains minus`() {
+        val ids = TerminalAccessoryLayoutStore.catalog().map { it.id }
+        assertTrue("catalog must contain minus", "minus" in ids)
+    }
+
+    @Test
+    fun `catalog contains slash`() {
+        val ids = TerminalAccessoryLayoutStore.catalog().map { it.id }
+        assertTrue("catalog must contain slash", "slash" in ids)
+    }
+
+    @Test
+    fun `backspace key has repeatable flag`() {
+        val item = TerminalAccessoryLayoutStore.catalog().first { it.id == "backspace" }
+        val key = (item.action as? AccessoryAction.SendSpecialKey)?.key
+        assertNotNull(key)
+        assertTrue("Backspace must be repeatable", key!!.isRepeatable)
+    }
+
+    @Test
+    fun `arrow keys have repeatable flag`() {
+        for (id in listOf("up", "down", "left", "right")) {
+            val item = TerminalAccessoryLayoutStore.catalog().first { it.id == id }
+            val key = (item.action as? AccessoryAction.SendSpecialKey)?.key
+            assertNotNull("$id must be a special key", key)
+            assertTrue("$id must be repeatable", key!!.isRepeatable)
+        }
+    }
+
+    @Test
+    fun `function keys are not repeatable`() {
+        for (id in (1..12).map { "f$it" }) {
+            val item = TerminalAccessoryLayoutStore.catalog().first { it.id == id }
+            val key = (item.action as? AccessoryAction.SendSpecialKey)?.key
+            assertNotNull("$id must be a special key", key)
+            assertFalse("$id must not be repeatable", key!!.isRepeatable)
+        }
+    }
+
+    @Test
+    fun `tab and enter are not repeatable`() {
+        for (id in listOf("tab", "enter")) {
+            val item = TerminalAccessoryLayoutStore.catalog().first { it.id == id }
+            val key = (item.action as? AccessoryAction.SendSpecialKey)?.key
+            assertNotNull("$id must be a special key", key)
+            assertFalse("$id must not be repeatable", key!!.isRepeatable)
+        }
+    }
+
+    // ── Layout store ──────────────────────────────────────────────────────
+
+    @Test
+    fun `defaultLayout includes expected keys`() {
+        val layout = TerminalAccessoryLayoutStore.defaultLayout()
+        val ids = layout.map { it.id }
+        assertTrue("escape" in ids)
+        assertTrue("up" in ids)
+        assertTrue("down" in ids)
+        assertTrue("ctrl" in ids)
+        assertTrue("cmd" in ids)
+    }
+
+    @Test
+    fun `normalizeIds removes unknown ids and deduplicates`() {
+        val result = TerminalAccessoryLayoutStore.normalizeIds(
+            listOf("escape", "unknown", "tab", "escape", "nope"),
+        )
+        assertEquals(listOf("escape", "tab"), result)
+    }
+
+    @Test
+    fun `resolveSelectedLayout returns items for valid ids`() {
+        val items = TerminalAccessoryLayoutStore.resolveSelectedLayout(
+            listOf("escape", "ctrl", "up"),
+        )
+        assertEquals(3, items.size)
+        assertEquals("escape", items[0].id)
+        assertEquals("ctrl", items[1].id)
+        assertEquals("up", items[2].id)
+    }
+
+    @Test
+    fun `resolveSelectedLayout with empty list returns empty`() {
+        val items = TerminalAccessoryLayoutStore.resolveSelectedLayout(emptyList())
+        assertTrue(items.isEmpty())
+    }
+
+    // ── Paste action convenience ──────────────────────────────────────────
+
+    @Test
+    fun `catalog paste item is Paste action`() {
+        val item = TerminalAccessoryLayoutStore.catalog().first { it.id == "paste" }
+        assertTrue(item.action is AccessoryAction.Paste)
+    }
+}

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/AccessoryLogicTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/AccessoryLogicTest.kt
@@ -41,14 +41,6 @@ class AccessoryLogicTest {
     }
 
     @Test
-    fun `activeModifierLabels returns only active labels in order`() {
-        assertEquals(emptyList<String>(), ModifierState().activeModifierLabels())
-
-        val s = ModifierState(ctrl = true, shift = true, cmd = true)
-        assertEquals(listOf("Ctrl", "Shift", "Cmd"), s.activeModifierLabels())
-    }
-
-    @Test
     fun `isEnabled returns correct values`() {
         val s = ModifierState(ctrl = true, alt = false, shift = true, cmd = false)
         assertTrue(s.isEnabled(TerminalModifier.Ctrl))


### PR DESCRIPTION
## Summary

Improves the terminal accessory bar for faster command-line editing.

What changed:
- Makes accessory modifiers sticky until tapped again.
- Adds hold-to-repeat for navigation/editing keys, with a light haptic tick when repeat starts.
- Adds opt-in configurable keys for Backspace, `-`, and `/`; the default layout is unchanged.
- Shares modifier state with the command palette, including paste and IME-suppression handling.
- Refactors repeatable buttons to reuse the shared `ChuButton` surface without adding a separate sticky-key strip.
- Adds focused accessory logic tests for modifier state, dispatch behavior, catalog entries, and repeatable flags.

Notes:
- No new production `java.io` or Java crypto/security APIs were added.

## Testing

Validation performed locally:

- `git diff --check`
- `cd android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:assembleDebug`

User testing:

- Built and sent a debug APK for on-device testing.
- User confirmed the updated sticky-key UI looks good.

## AI disclosure

This PR was implemented by AI at the user's request and tested manually by the user with a debug APK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press-and-hold repetition for accessory keys (arrows, Home/End, PageUp/PageDown, Backspace/Delete, etc.).
  * Command palette and accessory bar now accept and use the current modifier state.

* **Improvements**
  * Clipboard paste preserves sticky modifier state for consistent pastes.
  * Button visuals refined (centralized surface styling) and toggle button label sizing adjusted.

* **Tests**
  * Added comprehensive tests for accessory-bar and modifier logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->