### PR TITLE
Fix crash on SSH PTY resize failure

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -317,29 +317,42 @@ class TerminalSessionEngine(
         newScreenHeight: Int,
     ) {
         scope.launch(dispatcher) {
-            if (newCols <= 0 || newRows <= 0) return@launch
-            if (newCellWidth <= 0 || newCellHeight <= 0) return@launch
-            cols = newCols
-            rows = newRows
-            cellWidth = newCellWidth
-            cellHeight = newCellHeight
-            screenWidth = newScreenWidth
-            screenHeight = newScreenHeight
-            if (handle != 0L) {
-                bridge.nativeResize(handle, cols, rows, cellWidth, cellHeight)
-                bridge.nativeSetMouseEncodingSize(
-                    handle,
-                    screenWidth,
-                    screenHeight,
-                    cellWidth,
-                    cellHeight,
-                    0,
-                    0,
-                    0,
-                    0,
-                )
-                resizeRemote(cols, rows, screenWidth, screenHeight)
-                requestSnapshot(force = true)
+            try {
+                if (newCols <= 0 || newRows <= 0) return@launch
+                if (newCellWidth <= 0 || newCellHeight <= 0) return@launch
+                cols = newCols
+                rows = newRows
+                cellWidth = newCellWidth
+                cellHeight = newCellHeight
+                screenWidth = newScreenWidth
+                screenHeight = newScreenHeight
+                if (handle != 0L) {
+                    bridge.nativeResize(handle, cols, rows, cellWidth, cellHeight)
+                    bridge.nativeSetMouseEncodingSize(
+                        handle,
+                        screenWidth,
+                        screenHeight,
+                        cellWidth,
+                        cellHeight,
+                        0,
+                        0,
+                        0,
+                        0,
+                    )
+                    resizeRemote(cols, rows, screenWidth, screenHeight)
+                    requestSnapshot(force = true)
+                }
+            } catch (e: Exception) {
+                Log.e("TerminalSession", "Resize failed", e)
+                if (!disconnectRequested && lastConnectionParams != null) {
+                    scheduleReconnect("Connection interrupted: ${e.message ?: "resize failed"}")
+                } else {
+                    _state.value =
+                        _state.value.copy(
+                            status = SessionStatus.Error,
+                            error = "Resize failed: ${e.message}",
+                        )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes an Android crash when a terminal window resize reaches a disconnected or otherwise unavailable SSH channel.

## Reproduction

Observed on an OPPO/ColorOS device, but the failure is not OPPO-specific:

1. Open Chuchu and connect to an SSH session.
2. Leave the session long enough for the remote SSH channel/process to become unavailable, or otherwise interrupt the SSH channel while the app still has a terminal session object.
3. Relaunch/resume Chuchu so Android remeasures the terminal surface and calls the terminal resize path.
4. The app can immediately close/crash.

Captured crash:

```text
FATAL EXCEPTION: terminal-session
Process: com.jossephus.chuchu
java.lang.IllegalStateException: PTY resize failed: Unable to send window-change packet
    at com.jossephus.chuchu.service.ssh.NativeSshService.resize(NativeSshService.kt:221)
    at com.jossephus.chuchu.service.terminal.TerminalSessionEngine.resizeRemote(TerminalSessionEngine.kt:838)
    at com.jossephus.chuchu.service.terminal.TerminalSessionEngine$resize$1.invokeSuspend(TerminalSessionEngine.kt:341)
```

## Cause

`TerminalSessionEngine.resize()` runs on the `terminal-session` coroutine dispatcher. It updates the local terminal dimensions and then sends the new PTY size to the remote SSH channel via `resizeRemote()`.

If the SSH channel can no longer accept a `window-change` packet, `NativeSshService.resize()` throws `IllegalStateException`. That exception was not caught inside the launched resize coroutine, so it escaped the coroutine and crashed the app process.

A PTY resize failure should be treated like a connection/session failure, not as a fatal application error.

## Fix

Wrap the resize coroutine body in error handling:

- keep ignoring invalid dimensions as before;
- keep applying local/native terminal sizing when possible;
- if remote resize fails while the session was not intentionally disconnected and reconnect information exists, route it through existing reconnect handling with `scheduleReconnect(...)`;
- otherwise surface a `SessionStatus.Error` instead of letting the exception terminate the app process.

This fixes the captured crash because `Unable to send window-change packet` is now contained inside the terminal session state machine and can no longer escape as an uncaught coroutine exception.

## Validation

- Built successfully with `./gradlew :app:assembleDebug`.
- Re-tested the relaunch/resume flow on the affected OPPO device.
- Confirmed there was no new `FATAL EXCEPTION`, no new `PTY resize failed` crash, and no Chuchu process death in logcat after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session resizing stability with enhanced error recovery capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->