### PR TITLE
Throttle terminal foreground notifications

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -78,7 +78,7 @@ class TerminalSessionRepository private constructor(application: Application) {
 
     init {
         scope.launch {
-            _tabs
+            combine(_tabs, _activeTabId) { tabs, _ -> tabs }
                 .flatMapLatest { tabs ->
                     if (tabs.isEmpty()) {
                         flowOf(emptyList())
@@ -120,7 +120,7 @@ class TerminalSessionRepository private constructor(application: Application) {
     private fun currentNotificationLabel(): String {
         val tabs = _tabs.value
         if (tabs.isEmpty()) return "Active session"
-        val active = activeTab.value ?: tabs.first()
+        val active = tabs.firstOrNull { it.id == _activeTabId.value } ?: tabs.first()
         if (tabs.size == 1) return active.spec.notificationLabel
         return "${tabs.size} sessions  ·  ${active.spec.notificationLabel}"
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -73,6 +73,8 @@ class TerminalSessionRepository private constructor(application: Application) {
             .stateIn(scope, SharingStarted.Eagerly, emptySet())
 
     private var attachedClients = 0
+    private var foregroundServiceRunning = false
+    private var foregroundNotificationLabel: String? = null
 
     init {
         scope.launch {
@@ -93,10 +95,15 @@ class TerminalSessionRepository private constructor(application: Application) {
                                 state.status == SessionStatus.Connected ||
                                 state.status == SessionStatus.Reconnecting
                         }
-                    if (anyAlive) {
-                        SessionForegroundService.start(appContext, currentNotificationLabel())
-                    } else {
+                    val label = if (anyAlive) currentNotificationLabel() else null
+                    if (anyAlive && (!foregroundServiceRunning || foregroundNotificationLabel != label)) {
+                        SessionForegroundService.start(appContext, label ?: "Active session")
+                        foregroundServiceRunning = true
+                        foregroundNotificationLabel = label
+                    } else if (!anyAlive && foregroundServiceRunning) {
                         SessionForegroundService.stop(appContext)
+                        foregroundServiceRunning = false
+                        foregroundNotificationLabel = null
                     }
                 }
         }


### PR DESCRIPTION
## Summary

Throttle terminal foreground-service notification updates so Chuchu only starts/updates the foreground service when the session alive state changes or the visible notification label changes.

## Reproduction

1. Open Chuchu on Android.
2. Start an SSH terminal session.
3. Leave the session active while terminal/session state continues to emit updates.
4. Watch logcat for notification activity from Chuchu.

On an OPPO/ColorOS device this showed repeated foreground-service notification churn for the same notification id, including system rate-shedding/noise such as:

```text
notification_enqueue: [..., com.jossephus.chuchu, ..., Notification(channel=chuchu_terminal_session ...)]
notification error: com.jossephus.chuchu|com.jossephus.chuchu|...|1|22
NotificationService: Package enqueue rate is ... Shedding ... package=com.jossephus.chuchu
OplusFgsManagerController-->onForegroundStateChanged: com.jossephus.chuchu ... true ...
```

OPPO made the problem very visible, but the underlying issue is not OPPO-specific: the app was asking Android to start/update the same foreground-service notification repeatedly even when the foreground-service state and label had not changed.

## Cause

`TerminalSessionRepository` collects every tab/session-state emission and recalculates whether any terminal session is alive. Before this change, every collected emission did one of these calls:

- `SessionForegroundService.start(...)` whenever any session was connecting/connected/reconnecting
- `SessionForegroundService.stop(...)` whenever no session was alive

For active sessions, terminal state can emit frequently. Most of those emissions do not change whether the foreground service should be running or what notification label should be shown, so repeatedly calling `start(...)` creates unnecessary notification and foreground-service churn.

## Mitigation / Fix

Track the last foreground-service state in `TerminalSessionRepository`:

- whether the foreground service is currently considered running;
- the last notification label used.

Then only:

- call `SessionForegroundService.start(...)` when a session becomes alive or the notification label changes;
- call `SessionForegroundService.stop(...)` once when the last alive session ends;
- ignore session emissions that do not change foreground-service state or label.

This keeps the persistent terminal notification correct while avoiding redundant Android notification posts and foreground-service restarts.

## Validation

- Built successfully with `./gradlew :app:assembleDebug`.
- Tested on the affected OPPO/ColorOS device.
- After the throttle build, fresh log checks showed no new Chuchu notification enqueue/rate-shedding spam during the test window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreground service behavior for terminal sessions: the service now starts only when one or more sessions are active, stops when none remain, and updates notifications only when the visible session label changes. Notification labeling now follows the current active tab selection to keep displayed info accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->