### PR TITLE
feat: add zmx for session persistance

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/model/MultiplexerType.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/model/MultiplexerType.kt
@@ -7,7 +7,7 @@ enum class MultiplexerType(
 ) {
     Tmux("tmux", "tmux", true),
     Zellij("zellij", "zellij", false),
-    Zmx("zmx", "zmx", false),
+    Zmx("zmx", "zmx", true),
     ;
 
     companion object {

--- a/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/MultiplexerRegistry.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/MultiplexerRegistry.kt
@@ -7,7 +7,7 @@ object MultiplexerRegistry {
 
     fun forType(type: MultiplexerType): Multiplexer? = when (type) {
         MultiplexerType.Tmux -> TmuxMultiplexer
-        MultiplexerType.Zellij,
-        MultiplexerType.Zmx -> null
+        MultiplexerType.Zmx -> ZmxMultiplexer
+        MultiplexerType.Zellij -> null
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexer.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexer.kt
@@ -1,0 +1,60 @@
+package com.jossephus.chuchu.service.multiplexer
+
+import com.jossephus.chuchu.model.MultiplexerType
+
+object ZmxMultiplexer : Multiplexer {
+    override val type: MultiplexerType = MultiplexerType.Zmx
+
+    override fun availabilityCommand(): String = "command -v zmx >/dev/null 2>&1"
+
+    override fun listSessionsCommand(): String =
+        "if ! command -v zmx >/dev/null 2>&1; then printf 'zmx executable not found\\n' >&2; false; " +
+            "else zmx list 2>/dev/null; fi"
+
+    override fun parseSessions(output: String): List<RemoteMultiplexerSession> =
+        output
+            .lineSequence()
+            .mapNotNull { line ->
+                val trimmed = line.trimEnd('\r')
+                if (trimmed.isBlank()) return@mapNotNull null
+                val fields = trimmed
+                    .split('\t')
+                    .mapNotNull { part ->
+                        val separator = part.indexOf('=')
+                        if (separator <= 0) return@mapNotNull null
+                        part.substring(0, separator) to part.substring(separator + 1)
+                    }
+                    .toMap()
+                val name = fields["name"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                RemoteMultiplexerSession(
+                    name = name,
+                    attached = fields["clients"]?.toIntOrNull()?.let { it > 0 } == true,
+                )
+            }
+            .toList()
+
+    override fun launchCommand(
+        sessionName: String,
+        createIfMissing: Boolean,
+        trustedRemoteName: Boolean,
+    ): String {
+        val target = shellQuote(sessionName)
+        return if (createIfMissing) {
+            "exec zmx attach $target"
+        } else {
+            "if zmx list --short 2>/dev/null | grep -Fqx -- $target; then exec zmx attach $target; " +
+                "else printf 'zmx session %s is no longer available\\n' $target; exec \"\${SHELL:-/bin/sh}\" -l; fi"
+        }
+    }
+
+    override fun defaultSessionName(
+        remoteSessions: Collection<RemoteMultiplexerSession>,
+        localSessionNames: Collection<String>,
+    ): String = MultiplexerSessionAllocator.nextChuchuSessionName(
+        remoteSessions = remoteSessions,
+        localSessionNames = localSessionNames,
+    )
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\\''") + "'"
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
@@ -411,7 +411,7 @@ private fun MultiplexerSection(
         ),
         selected = selectedOption,
         onSelect = { onSelect(it.type) },
-        disabledOptions = setOf(MultiplexerOption.Zellij, MultiplexerOption.Zmx),
+        disabledOptions = setOf(MultiplexerOption.Zellij),
     )
 }
 

--- a/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/MultiplexerModelsTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/MultiplexerModelsTest.kt
@@ -13,13 +13,18 @@ class MultiplexerModelsTest {
     }
 
     @Test
-    fun registryLeavesFutureMultiplexersUnsupportedForNow() {
+    fun registryReturnsZmxRuntime() {
+        assertSame(ZmxMultiplexer, MultiplexerRegistry.forType(MultiplexerType.Zmx))
+    }
+
+    @Test
+    fun registryLeavesFutureZellijUnsupportedForNow() {
         assertNull(MultiplexerRegistry.forType(MultiplexerType.Zellij))
-        assertNull(MultiplexerRegistry.forType(MultiplexerType.Zmx))
     }
 
     @Test
     fun persistedValuesResolveByStableId() {
         assertEquals(MultiplexerType.Tmux, MultiplexerType.fromPersistedValue("tmux"))
+        assertEquals(MultiplexerType.Zmx, MultiplexerType.fromPersistedValue("zmx"))
     }
 }

--- a/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexerTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexerTest.kt
@@ -1,0 +1,69 @@
+package com.jossephus.chuchu.service.multiplexer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ZmxMultiplexerTest {
+    @Test
+    fun launchCreateUsesAttachUpsert() {
+        val command = ZmxMultiplexer.launchCommand(
+            sessionName = "chuchu-1",
+            createIfMissing = true,
+            trustedRemoteName = false,
+        )
+
+        assertEquals("exec zmx attach 'chuchu-1'", command)
+    }
+
+    @Test
+    fun launchExistingChecksListBeforeAttach() {
+        val command = ZmxMultiplexer.launchCommand(
+            sessionName = "main",
+            createIfMissing = false,
+            trustedRemoteName = true,
+        )
+
+        assertEquals(
+            "if zmx list --short 2>/dev/null | grep -Fqx -- 'main'; then exec zmx attach 'main'; " +
+                "else printf 'zmx session %s is no longer available\\n' 'main'; exec \"\${SHELL:-/bin/sh}\" -l; fi",
+            command,
+        )
+    }
+
+    @Test
+    fun launchQuotesTrustedRemoteNames() {
+        val command = ZmxMultiplexer.launchCommand(
+            sessionName = "work'space; rm -rf /",
+            createIfMissing = true,
+            trustedRemoteName = true,
+        )
+
+        assertEquals("exec zmx attach 'work'\\''space; rm -rf /'", command)
+    }
+
+    @Test
+    fun listSessionsCommandChecksExecutable() {
+        val command = ZmxMultiplexer.listSessionsCommand()
+
+        assertEquals(
+            "if ! command -v zmx >/dev/null 2>&1; then printf 'zmx executable not found\\n' >&2; false; else zmx list 2>/dev/null; fi",
+            command,
+        )
+    }
+
+    @Test
+    fun parsesSessionList() {
+        val sessions = ZmxMultiplexer.parseSessions(
+            "name=main\tpid=123\tclients=1\tcreated=0\tstart_dir=/tmp\n" +
+                "name=work\tpid=456\tclients=0\tcreated=1\n",
+        )
+
+        assertEquals(
+            listOf(
+                RemoteMultiplexerSession(name = "main", attached = true),
+                RemoteMultiplexerSession(name = "work", attached = false),
+            ),
+            sessions,
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zmx as a remote terminal multiplexer option. Users can now select Zmx when configuring remote servers for session management and attachment.

* **Tests**
  * Added comprehensive test coverage for Zmx multiplexer functionality, including session operations and command generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->