### PR TITLE
feat: show OSC terminal title on tabs with ellipsis

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabManager.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabManager.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.service.multiplexer.RemoteMultiplexerSession
 import com.jossephus.chuchu.service.terminal.SessionStatus
@@ -268,15 +269,18 @@ fun TerminalTabManager(
 
                                 // Tab info column
                                 Column(modifier = Modifier.weight(1f)) {
+                                    val displayLabel = title ?: label
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
                                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                                     ) {
                                         ChuText(
-                                            label,
+                                            displayLabel,
                                             style = typography.body,
                                             color = if (isFocused) colors.accent
                                             else colors.textPrimary,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
                                         )
                                         if (isActive) {
                                             ChuText(
@@ -286,10 +290,10 @@ fun TerminalTabManager(
                                             )
                                         }
                                     }
-                                    // Secondary details
+                                    // Show alias as secondary when title is primary
                                     if (title != null) {
                                         ChuText(
-                                            title,
+                                            label,
                                             style = typography.bodySmall,
                                             color = colors.textSecondary,
                                         )

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +31,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.service.terminal.SessionStatus
+import kotlinx.coroutines.flow.map
 import kotlin.math.roundToInt
 import com.jossephus.chuchu.service.terminal.TabSession
 import com.jossephus.chuchu.ui.components.ChuButton
@@ -95,7 +97,11 @@ fun TerminalTabStrip(
         ) {
             tabs.forEach { tab ->
                 val isActive = tab.id == activeTabId
-                val label = terminalTabAlias(tab)
+                val alias = terminalTabAlias(tab)
+                val title by remember(tab) {
+                    tab.sessionState.map { it.title?.takeIf(String::isNotBlank) }
+                }.collectAsStateWithLifecycle(initialValue = null)
+                val label = title ?: alias
 
                 Box(
                     modifier = Modifier
@@ -104,7 +110,7 @@ fun TerminalTabStrip(
                         }
                         .semantics { contentDescription = label }
                         .defaultMinSize(minHeight = 32.dp)
-                        .widthIn(min = 44.dp)
+                        .widthIn(min = 44.dp, max = 160.dp)
                         .clip(androidx.compose.foundation.shape.RoundedCornerShape(4.dp))
                         .background(
                             if (isActive) colors.accent.copy(alpha = 0.16f)


### PR DESCRIPTION
Use the session's OSC title as the primary tab label (falling back to the alias), show the alias as the secondary line, and constrain/ellipsize long titles (maxLines=1, widthIn max 160.dp) so the tab strip stays compact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal tab display to properly show session titles with single-line text truncation, falling back to alias labels when titles are unavailable.
  * Adjusted tab width constraints for improved layout consistency across different session configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->