### PR TITLE
feat: emit DEC 2048 in-band size reports on resize

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -366,6 +366,9 @@ class TerminalSessionEngine(
                 screenHeight = newScreenHeight
                 if (handle != 0L) {
                     bridge.nativeResize(handle, cols, rows, cellWidth, cellHeight)
+                    // Flush pty output from the resize (e.g. the DEC 2048 in-band
+                    // size report) so Textual-based TUIs detect the resize.
+                    flushPtyWrites()
                     bridge.nativeSetMouseEncodingSize(
                         handle,
                         screenWidth,

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -1232,6 +1232,24 @@ export fn chuchu_resize(handle: c.jlong, cols: c.jint, rows: c.jint, cell_width:
     terminal.cell_height = @intCast(clampI32(cell_height, 1, 1));
     terminal.terminal.width_px = @as(u32, new_cols) * terminal.cell_width;
     terminal.terminal.height_px = @as(u32, new_rows) * terminal.cell_height;
+
+    // Emit a DEC 2048 in-band size report on resize. TUIs like Textual disable
+    // their SIGWINCH fallback once mode 2048 is on and rely on this report.
+    // Report form: ESC [ 48 ; rows ; cols ; height_px ; width_px t
+    if (terminal.terminal.modes.get(.in_band_size_reports)) {
+        // Spec-allowed: show resize changes immediately.
+        terminal.terminal.modes.set(.synchronized_output, false);
+        var report_buf: [64]u8 = undefined;
+        if (std.fmt.bufPrint(&report_buf, "\x1b[48;{d};{d};{d};{d}t", .{
+            new_rows,
+            new_cols,
+            @as(u32, new_rows) * terminal.cell_height,
+            @as(u32, new_cols) * terminal.cell_width,
+        })) |report| {
+            appendPtyWrite(terminal, report);
+        } else |_| {}
+    }
+
     update_render_state(terminal);
 }
 

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -1237,8 +1237,11 @@ export fn chuchu_resize(handle: c.jlong, cols: c.jint, rows: c.jint, cell_width:
     // their SIGWINCH fallback once mode 2048 is on and rely on this report.
     // Report form: ESC [ 48 ; rows ; cols ; height_px ; width_px t
     if (terminal.terminal.modes.get(.in_band_size_reports)) {
-        // Spec-allowed: show resize changes immediately.
+        // Spec-allowed: show resize changes immediately. Restore the mode
+        // afterward so synchronized output isn't permanently disabled.
+        const was_synchronized = terminal.terminal.modes.get(.synchronized_output);
         terminal.terminal.modes.set(.synchronized_output, false);
+        defer terminal.terminal.modes.set(.synchronized_output, was_synchronized);
         var report_buf: [64]u8 = undefined;
         if (std.fmt.bufPrint(&report_buf, "\x1b[48;{d};{d};{d};{d}t", .{
             new_rows,

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -1233,15 +1233,12 @@ export fn chuchu_resize(handle: c.jlong, cols: c.jint, rows: c.jint, cell_width:
     terminal.terminal.width_px = @as(u32, new_cols) * terminal.cell_width;
     terminal.terminal.height_px = @as(u32, new_rows) * terminal.cell_height;
 
+    terminal.terminal.modes.set(.synchronized_output, false);
+
     // Emit a DEC 2048 in-band size report on resize. TUIs like Textual disable
     // their SIGWINCH fallback once mode 2048 is on and rely on this report.
     // Report form: ESC [ 48 ; rows ; cols ; height_px ; width_px t
     if (terminal.terminal.modes.get(.in_band_size_reports)) {
-        // Spec-allowed: show resize changes immediately. Restore the mode
-        // afterward so synchronized output isn't permanently disabled.
-        const was_synchronized = terminal.terminal.modes.get(.synchronized_output);
-        terminal.terminal.modes.set(.synchronized_output, false);
-        defer terminal.terminal.modes.set(.synchronized_output, was_synchronized);
         var report_buf: [64]u8 = undefined;
         if (std.fmt.bufPrint(&report_buf, "\x1b[48;{d};{d};{d};{d}t", .{
             new_rows,


### PR DESCRIPTION
Emit DEC 2048 in-band size reports on resize

     When the terminal has DEC private mode 2048 (in-band size reports) active,
     chuchu_resize now emits the ESC[48;rows;cols;height_px;width_px t report
     immediately after resizing. The Kotlin side calls flushPtyWrites() after
     nativeResize() so the report reaches the remote before any further input.


     TUI frameworks like Textual enable mode 2048 and then disable their SIGWINCH
     fallback, relying entirely on the terminal to proactively report new dimensions
     after a resize. Without this report, a resized Textual app never learns its new
     size — layout and image placement commands target stale dimensions until the
     next application-initiated redraw.

Changes
     - chuchu_snapshot.zig — After updating width_px/height_px in chuchu_resize,
       check terminal.modes.get(.in_band_size_reports) and if active, clear
       synchronized output and write the \x1b[48;rows;cols;height_px;width_px t
       report via appendPtyWrite.
     - TerminalSessionEngine.kt — Call flushPtyWrites() after nativeResize() so the
       in-band report is flushed to the remote immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resize handling so any resize-related output is delivered immediately and can be detected by terminal UI applications.
  * When in-band size reporting is enabled, the terminal now emits updated size reports after resizing, including correct row/column and pixel-dimension values.
  * Terminal user interfaces should more consistently observe dimension changes during resize operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->