### PR TITLE
fix: align Kitty graphics to the terminal cell grid

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -377,7 +377,7 @@ class TerminalSessionEngine(
                         0,
                         0,
                     )
-                    resizeRemote(cols, rows, screenWidth, screenHeight)
+                    resizeRemote(cols, rows, ptyWidthPx(), ptyHeightPx())
                     requestSnapshot(force = true)
                 }
             } catch (e: Exception) {
@@ -747,9 +747,9 @@ class TerminalSessionEngine(
         )
         val startupCommand = params.multiplexerStartupCommand()?.trim().orEmpty()
         if (startupCommand.isNotEmpty()) {
-            nativeSsh.openExecPty(startupCommand, cols, rows, screenWidth, screenHeight)
+            nativeSsh.openExecPty(startupCommand, cols, rows, ptyWidthPx(), ptyHeightPx())
         } else {
-            nativeSsh.openShell(cols, rows, screenWidth, screenHeight)
+            nativeSsh.openShell(cols, rows, ptyWidthPx(), ptyHeightPx())
         }
     }
 
@@ -772,7 +772,7 @@ class TerminalSessionEngine(
         val execOpened = runCatching { nativeSsh.openExec(moshCommand) }.getOrDefault(false)
         if (!execOpened) {
             Log.w("TerminalSession", "MOSH: exec channel unavailable, falling back to shell")
-            nativeSsh.openShell(cols, rows, screenWidth, screenHeight)
+            nativeSsh.openShell(cols, rows, ptyWidthPx(), ptyHeightPx())
             val fallback = "$moshCommand\n"
             nativeSsh.write(fallback.toByteArray(Charsets.UTF_8))
         }
@@ -1067,6 +1067,13 @@ class TerminalSessionEngine(
             }
         }
     }
+
+    // Pixel size reported to the remote pty (ws_xpixel/ypixel): the integer grid
+    // extent (cols*cellW x rows*cellH), not the full canvas — apps derive
+    // px-per-cell as ws_xpixel/cols, so the canvas would misplace Kitty graphics.
+    // Falls back to the canvas before the first real cell size.
+    private fun ptyWidthPx(): Int = if (cellWidth > 0) cols * cellWidth else screenWidth
+    private fun ptyHeightPx(): Int = if (cellHeight > 0) rows * cellHeight else screenHeight
 
     private fun resizeRemote(cols: Int, rows: Int, widthPx: Int, heightPx: Int) {
         if (lastConnectionParams?.transport == Transport.Mosh) {

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
@@ -6,8 +6,10 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 data class ImagePlacement(
-    val destX: Int,
-    val destY: Int,
+    val cellCol: Int,
+    val cellRow: Int,
+    val cellXOffset: Int,
+    val cellYOffset: Int,
     val destW: Int,
     val destH: Int,
     val srcX: Int,
@@ -79,7 +81,7 @@ data class TerminalSnapshot(
         const val CELL_FLAG_SPACER: Int = 0x80
         private const val HEADER_I32_COUNT = 12
         private const val CELL_SIZE_BYTES = 11
-        private const val IMAGE_HEADER_BYTES = 44
+        private const val IMAGE_HEADER_BYTES = 52
 
         private fun graphemeExtrasEquals(
             a: Map<Int, IntArray>,
@@ -216,8 +218,10 @@ data class TerminalSnapshot(
             val images = ArrayList<ImagePlacement>(count)
             for (i in 0 until count) {
                 if (wrapped.remaining() < IMAGE_HEADER_BYTES) break
-                val destX = wrapped.int
-                val destY = wrapped.int
+                val cellCol = wrapped.int
+                val cellRow = wrapped.int
+                val cellXOffset = wrapped.int
+                val cellYOffset = wrapped.int
                 val destW = wrapped.int
                 val destH = wrapped.int
                 val srcX = wrapped.int
@@ -249,8 +253,10 @@ data class TerminalSnapshot(
                 wrapped.position(wrapped.position() + dataLen)
 
                 images += ImagePlacement(
-                    destX = destX,
-                    destY = destY,
+                    cellCol = cellCol,
+                    cellRow = cellRow,
+                    cellXOffset = cellXOffset,
+                    cellYOffset = cellYOffset,
                     destW = destW,
                     destH = destH,
                     srcX = srcX,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -154,6 +154,11 @@ fun TerminalCanvas(
     val baselineOffset = -fontMetrics.ascent
     val cellWidthInt = max(1, ceil(cellWidthPx).toInt())
     val cellHeightInt = max(1, ceil(cellHeightPx).toInt())
+    // Snap cell dimensions to integers so the renderer agrees with Ghostty's
+    // internal grid.  This eliminates sub-pixel drift that accumulates across
+    // rows/columns and misaligns Kitty images.
+    val cellWidth = cellWidthInt.toFloat()
+    val cellHeight = cellHeightInt.toFloat()
     val selectionBackgroundArgb = selectionBackgroundColor.toArgb()
     val selectionForegroundArgb = selectionForegroundColor?.toArgb()
     val hasSelectionFg = selectionForegroundArgb != null
@@ -207,10 +212,10 @@ fun TerminalCanvas(
         }
     }
 
-    LaunchedEffect(canvasSize, cellWidthPx, cellHeightPx) {
+    LaunchedEffect(canvasSize, cellWidth, cellHeight) {
         if (canvasSize.width <= 0 || canvasSize.height <= 0) return@LaunchedEffect
-        val cols = max(1, floor(canvasSize.width / cellWidthPx).toInt())
-        val rows = max(1, floor(canvasSize.height / cellHeightPx).toInt())
+        val cols = max(1, floor(canvasSize.width / cellWidth).toInt())
+        val rows = max(1, floor(canvasSize.height / cellHeight).toInt())
         val grid = Pair(cols, rows)
         if (grid != lastResizedGrid) {
             lastResizedGrid = grid
@@ -227,15 +232,15 @@ fun TerminalCanvas(
             if (!enableGestures) {
                 baseModifier
             } else {
-                baseModifier.pointerInput(cellWidthPx, cellHeightPx, selectionResetKey) {
+                baseModifier.pointerInput(cellWidth, cellHeight, selectionResetKey) {
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
                         fun toSnapshotSpace(position: Offset, s: TerminalSnapshot): Offset {
                             if (!fitSnapshotToCanvas) return position
                             val cols = max(s.cols, 1)
                             val rows = max(s.rows, 1)
-                            val contentWidth = cols * cellWidthPx
-                            val contentHeight = rows * cellHeightPx
+                            val contentWidth = cols * cellWidth
+                            val contentHeight = rows * cellHeight
                             if (contentWidth <= 0f || contentHeight <= 0f) return position
                             val scale = minOf(canvasSize.width / contentWidth, canvasSize.height / contentHeight)
                             if (scale <= 0f) return position
@@ -266,7 +271,7 @@ fun TerminalCanvas(
                             if (event == null) {
                                 val s = currentSnapshot.value
                                 val downPos = toSnapshotSpace(down.position, s)
-                                val selectedCell = s.cellAt(downPos.x, downPos.y, cellWidthPx, cellHeightPx)
+                                val selectedCell = s.cellAt(downPos.x, downPos.y, cellWidth, cellHeight)
                                 selection = selectedCell?.let { TerminalSelection(it, it) }
                                 if (selectedCell != null) {
                                     selectionAnchorOffset = downPos
@@ -296,7 +301,7 @@ fun TerminalCanvas(
                                     doubleTapState.lastPos = tapPos
 
                                     if (timeSinceLastTap < doubleTapTimeoutMillis && distSinceLastTap < doubleTapSlopPx) {
-                                        val cellIdx = s.cellAt(tapPos.x, tapPos.y, cellWidthPx, cellHeightPx)
+                                        val cellIdx = s.cellAt(tapPos.x, tapPos.y, cellWidth, cellHeight)
                                         if (cellIdx != null) {
                                             val wordRange = s.wordAt(cellIdx)
                                             if (wordRange != null) {
@@ -350,7 +355,7 @@ fun TerminalCanvas(
                             val changePos = toSnapshotSpace(change.position, s)
                             val changePrevPos = toSnapshotSpace(change.previousPosition, s)
                             val downPos = toSnapshotSpace(down.position, s)
-                            val selectedCell = s.cellAt(changePos.x, changePos.y, cellWidthPx, cellHeightPx)
+                            val selectedCell = s.cellAt(changePos.x, changePos.y, cellWidth, cellHeight)
                             if (longPressActive && selectedCell != null) {
                                 val currentSelection = selection
                                 if (currentSelection == null || currentSelection.focusIndex != selectedCell) {
@@ -378,7 +383,7 @@ fun TerminalCanvas(
                             }
                             val verticalIntent = abs(dragY) > abs(dragX) * 1.2f
                             if (verticalIntent) {
-                                dragRemainder += dragY / cellHeightPx
+                                dragRemainder += dragY / cellHeight
                             }
 
                             if (didDragGesture && abs(dragRemainder) >= 1f) {
@@ -402,8 +407,6 @@ fun TerminalCanvas(
     Canvas(modifier = canvasModifier) {
         val cols = max(snapshot.cols, 1)
         val rows = max(snapshot.rows, 1)
-        val cellWidth = cellWidthPx
-        val cellHeight = cellHeightPx
         val contentWidth = cols * cellWidth
         val contentHeight = rows * cellHeight
         val previewScale = if (fitSnapshotToCanvas && contentWidth > 0f && contentHeight > 0f) {
@@ -558,14 +561,20 @@ fun TerminalCanvas(
                 }
             }
 
-            // Images
+            // Images: origin from cell coords (same cell size as text, so it lands
+            // on the grid); size is libghostty's scaled dest_w/dest_h, already
+            // centered by cell_*_offset. Don't recompute size as grid*cell.
             for (img in snapshot.images) {
                 val srcRect = Rect(img.srcX, img.srcY, img.srcX + img.srcW, img.srcY + img.srcH)
+                val imgDestX = (img.cellCol * cellWidth + img.cellXOffset.toFloat()).toInt()
+                val imgDestY = (img.cellRow * cellHeight + img.cellYOffset.toFloat()).toInt()
+                val imgDestW = img.destW
+                val imgDestH = img.destH
                 val dstRect = RectF(
-                    img.destX.toFloat(),
-                    img.destY.toFloat(),
-                    (img.destX + img.destW).toFloat(),
-                    (img.destY + img.destH).toFloat(),
+                    imgDestX.toFloat(),
+                    imgDestY.toFloat(),
+                    (imgDestX + imgDestW).toFloat(),
+                    (imgDestY + imgDestH).toFloat(),
                 )
                 nCanvas.drawBitmap(img.bitmap, srcRect, dstRect, null)
             }
@@ -650,10 +659,10 @@ private data class TerminalSelection(
 private fun safeChars(cp: Int): String =
     if (cp in 0..0x10FFFF) String(Character.toChars(cp)) else "\uFFFD"
 
-private fun TerminalSnapshot.cellAt(x: Float, y: Float, cellWidthPx: Float, cellHeightPx: Float): Int? {
-    if (cols <= 0 || rows <= 0 || cellWidthPx <= 0f || cellHeightPx <= 0f) return null
-    val col = floor(x / cellWidthPx).toInt().coerceIn(0, cols - 1)
-    val row = floor(y / cellHeightPx).toInt().coerceIn(0, rows - 1)
+private fun TerminalSnapshot.cellAt(x: Float, y: Float, cellWidth: Float, cellHeight: Float): Int? {
+    if (cols <= 0 || rows <= 0 || cellWidth <= 0f || cellHeight <= 0f) return null
+    val col = floor(x / cellWidth).toInt().coerceIn(0, cols - 1)
+    val row = floor(y / cellHeight).toInt().coerceIn(0, rows - 1)
     return row * cols + col
 }
 

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -34,8 +34,12 @@ const CELL_FLAG_HAS_GRAPHEME: u8 = 1 << 6;
 // These are serialized with codepoint=32 but should not force a shaping
 // run break between neighboring glyph cells.
 const CELL_FLAG_SPACER: u8 = 1 << 7;
-const IMAGE_HEADER_BYTES = 44;
+const IMAGE_HEADER_BYTES = 52;
 const MAX_KITTY_IMAGES = 64;
+// Kitty Unicode graphics placeholder (U+10EEEE). These cells only mark where an
+// image is composited; we blank them so the raw glyph never shows through a gap
+// the image doesn't fully cover.
+const KITTY_PLACEHOLDER_CP: u32 = 0x10EEEE;
 const DeviceAttributes = blk: {
     const device_attributes_opt = @FieldType(ghostty.TerminalStream.Handler.Effects, "device_attributes");
     const device_attributes_fn = @typeInfo(device_attributes_opt).optional.child;
@@ -49,8 +53,14 @@ const ImageFreeMode = enum(c_int) {
 };
 
 const PlacementInfo = struct {
-    dest_x: i32,
-    dest_y: i32,
+    // Cell-grid position; Kotlin derives the pixel origin as cell*cellSize +
+    // cell_*_offset. dest_w/dest_h are libghostty's *scaled* image size that
+    // cell_*_offset centers — use them straight (rendered.dest_width for virtual,
+    // grid*cell for direct); recomputing as grid_cols*cell shifts it ~1px.
+    cell_col: i32,
+    cell_row: i32,
+    cell_x_offset: u32,
+    cell_y_offset: u32,
     dest_w: u32,
     dest_h: u32,
     src_x: u32,
@@ -659,11 +669,15 @@ fn resolvedCodepoint(render_cell: ghostty.RenderState.Cell) u32 {
     // character (e.g. keycaps would lose the digit and ZWJ chains could
     // degrade to U+200D as the visible codepoint).
     const cp = render_cell.raw.codepoint();
+    if (cp == KITTY_PLACEHOLDER_CP) return 32;
     return if (cp == 0) 32 else cp;
 }
 
 fn cellHasExtras(render_cell: ghostty.RenderState.Cell) bool {
     if (render_cell.raw.wide == .spacer_tail or render_cell.raw.wide == .spacer_head) return false;
+    // Placeholder cells carry row/column diacritics as grapheme extras; drop
+    // them so the combining marks aren't painted (see KITTY_PLACEHOLDER_CP).
+    if (render_cell.raw.codepoint() == KITTY_PLACEHOLDER_CP) return false;
     return render_cell.raw.content_tag == .codepoint_grapheme and render_cell.grapheme.len > 0;
 }
 
@@ -1021,8 +1035,11 @@ export fn chuchu_build_image_snapshot(handle: c.jlong, out_size: [*c]usize) call
             };
         }
         placements[count] = .{
-            .dest_x = viewport.col * @as(i32, @intCast(terminal.cell_width)) + @as(i32, @intCast(placement.x_offset)),
-            .dest_y = viewport.row * @as(i32, @intCast(terminal.cell_height)) + @as(i32, @intCast(placement.y_offset)),
+            .cell_col = viewport.col,
+            .cell_row = viewport.row,
+            .cell_x_offset = placement.x_offset,
+            .cell_y_offset = placement.y_offset,
+            // Direct placement: image fills its whole cell grid (no aspect-fit).
             .dest_w = grid_size.cols * terminal.cell_width,
             .dest_h = grid_size.rows * terminal.cell_height,
             .src_x = rect.x,
@@ -1064,8 +1081,13 @@ export fn chuchu_build_image_snapshot(handle: c.jlong, out_size: [*c]usize) call
 
             const prepared = prepareImageData(virtual_placement.image_id, image) orelse continue;
             placements[count] = .{
-                .dest_x = @as(i32, @intCast(viewport.viewport.x)) * @as(i32, @intCast(terminal.cell_width)) + @as(i32, @intCast(rendered.offset_x)),
-                .dest_y = @as(i32, @intCast(viewport.viewport.y)) * @as(i32, @intCast(terminal.cell_height)) + @as(i32, @intCast(rendered.offset_y)),
+                .cell_col = @intCast(viewport.viewport.x),
+                .cell_row = @intCast(viewport.viewport.y),
+                // Virtual placement: libghostty aspect-fits the image into the
+                // grid and centers it via offset_x/offset_y; dest_width/height is
+                // the resulting scaled size the offsets are measured against.
+                .cell_x_offset = rendered.offset_x,
+                .cell_y_offset = rendered.offset_y,
                 .dest_w = rendered.dest_width,
                 .dest_h = rendered.dest_height,
                 .src_x = rendered.source_x,
@@ -1101,17 +1123,19 @@ export fn chuchu_build_image_snapshot(handle: c.jlong, out_size: [*c]usize) call
     writeIntLe(i32, buf[0..total], 0, @intCast(count));
     var offset: usize = 4;
     for (placements[0..count]) |p| {
-        writeIntLe(i32, buf[0..total], offset + 0, p.dest_x);
-        writeIntLe(i32, buf[0..total], offset + 4, p.dest_y);
-        writeIntLe(u32, buf[0..total], offset + 8, p.dest_w);
-        writeIntLe(u32, buf[0..total], offset + 12, p.dest_h);
-        writeIntLe(u32, buf[0..total], offset + 16, p.src_x);
-        writeIntLe(u32, buf[0..total], offset + 20, p.src_y);
-        writeIntLe(u32, buf[0..total], offset + 24, p.src_w);
-        writeIntLe(u32, buf[0..total], offset + 28, p.src_h);
-        writeIntLe(u32, buf[0..total], offset + 32, p.img_w);
-        writeIntLe(u32, buf[0..total], offset + 36, p.img_h);
-        writeIntLe(u32, buf[0..total], offset + 40, @intCast(p.data_len));
+        writeIntLe(i32, buf[0..total], offset + 0, p.cell_col);
+        writeIntLe(i32, buf[0..total], offset + 4, p.cell_row);
+        writeIntLe(u32, buf[0..total], offset + 8, p.cell_x_offset);
+        writeIntLe(u32, buf[0..total], offset + 12, p.cell_y_offset);
+        writeIntLe(u32, buf[0..total], offset + 16, p.dest_w);
+        writeIntLe(u32, buf[0..total], offset + 20, p.dest_h);
+        writeIntLe(u32, buf[0..total], offset + 24, p.src_x);
+        writeIntLe(u32, buf[0..total], offset + 28, p.src_y);
+        writeIntLe(u32, buf[0..total], offset + 32, p.src_w);
+        writeIntLe(u32, buf[0..total], offset + 36, p.src_h);
+        writeIntLe(u32, buf[0..total], offset + 40, p.img_w);
+        writeIntLe(u32, buf[0..total], offset + 44, p.img_h);
+        writeIntLe(u32, buf[0..total], offset + 48, @intCast(p.data_len));
         @memcpy(buf[offset + IMAGE_HEADER_BYTES .. offset + IMAGE_HEADER_BYTES + p.data_len], p.data_ptr[0..p.data_len]);
         offset += IMAGE_HEADER_BYTES + p.data_len;
         switch (p.free_mode) {


### PR DESCRIPTION
Align Kitty graphics to the terminal cell grid

     Kitty images drifted off the text grid — the error grew with distance from the
     top-left. Four causes, one fix:

     1. Sub-pixel drift — Fractional font-metric cell sizes accumulated error across
        columns/rows. Now snapped to integer values.
     2. Absolute-pixel placement — The wire format pre-computed pixel offsets in Zig;
        any disagreement with the Kotlin renderer misplaced images permanently. Now
        sends cell-grid coordinates + sub-cell offsets, and Kotlin derives pixels
        from the same snapped dimensions used for text.
     3. PTY pixel mismatch — Shell/resize calls passed the full canvas size as
        ws_xpixel/ypixel instead of cols×cellWidth, causing remote apps to
        miscalculate px-per-cell. Now uses grid-aligned dimensions.
     4. Placeholder bleed — U+10EEEE Kitty placeholder glyphs and their combining
        marks could show through image gaps. Now blanked to space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal window resize handling to properly report dimensions to remote sessions
  * Enhanced image rendering within the terminal to align with grid positioning
  * Fixed coordinate calculations for more accurate gesture interactions and text selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->