### PR TITLE
feat: add osc 52 clipboard support

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/GhosttyBridge.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/GhosttyBridge.kt
@@ -30,6 +30,7 @@ class GhosttyBridge {
     external fun nativeSnapshot(handle: Long): ByteBuffer
     external fun nativePollTitle(handle: Long): String?
     external fun nativePollPwd(handle: Long): String?
+    external fun nativePollClipboard(handle: Long): ByteArray?
     external fun nativeDrainBellCount(handle: Long): Int
     external fun nativeSetColorScheme(handle: Long, scheme: Int)
     external fun nativeSetDefaultColors(

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalMouseProtocol.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalMouseProtocol.kt
@@ -1,0 +1,11 @@
+package com.jossephus.chuchu.service.terminal
+
+object TerminalMouseAction {
+    const val Release = 0
+    const val Press = 1
+    const val Motion = 2
+}
+
+object TerminalMouseButton {
+    const val Left = 1
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -1,5 +1,6 @@
 package com.jossephus.chuchu.service.terminal
 
+import android.content.ClipData
 import android.util.Log
 import com.jossephus.chuchu.model.AuthMethod
 import com.jossephus.chuchu.model.MultiplexerType
@@ -19,6 +20,7 @@ import java.util.concurrent.Executors
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -63,6 +65,7 @@ data class HostKeyPrompt(
 )
 
 class TerminalSessionEngine(
+    private val publishClipboardText: (String) -> Unit,
     private val scope: CoroutineScope,
     private val localShellService: NativeLocalShellService,
     private val hostKeyStore: HostKeyStore,
@@ -736,7 +739,7 @@ class TerminalSessionEngine(
                 when (event.eventType) {
                     MoshEventType.HostBytes.code -> {
                         if (event.payload.isNotEmpty() && handle != 0L) {
-                            bridge.nativeWriteRemote(handle, event.payload)
+                            feedRemoteChunk(event.payload)
                         }
                     }
                     MoshEventType.Resize.code -> {
@@ -1096,6 +1099,16 @@ class TerminalSessionEngine(
         }
     }
 
+    private fun publishClipboard(text: String) {
+        scope.launch(Dispatchers.Main.immediate) {
+            runCatching {
+                publishClipboardText(text)
+            }.onFailure { error ->
+                Log.w("TerminalSession", "OSC 52 clipboard update failed", error)
+            }
+        }
+    }
+
     private suspend fun sendStartupCommand(params: ConnectionParams) {
         val multiplexerCommand = params.multiplexerStartupCommand()?.trim().orEmpty()
         if (multiplexerCommand.isNotEmpty() && params.transport != Transport.Mosh) return
@@ -1209,12 +1222,16 @@ class TerminalSessionEngine(
             val snap = TerminalSnapshot.fromByteBuffer(raw, images)
             val nextTitle = bridge.nativePollTitle(handle)
             val nextPwd = bridge.nativePollPwd(handle)
+            val nextClipboard = bridge.nativePollClipboard(handle)
             val bellCount = bridge.nativeDrainBellCount(handle)
             if (nextTitle != null) {
                 title = nextTitle
             }
             if (nextPwd != null) {
                 pwd = nextPwd
+            }
+            if (nextClipboard != null) {
+                publishClipboard(nextClipboard.toString(Charsets.UTF_8))
             }
             _state.value =
                 _state.value.copy(

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -1,6 +1,8 @@
 package com.jossephus.chuchu.service.terminal
 
 import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
 import com.jossephus.chuchu.model.MultiplexerType
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.multiplexer.MultiplexerRegistry
@@ -34,6 +36,11 @@ class TerminalSessionRepository private constructor(application: Application) {
     private val hostKeyStore =
         HostKeyStore(appContext.getSharedPreferences("host_keys", Application.MODE_PRIVATE))
     private val tailscaleStatusChecker = TailscaleStatusChecker(appContext)
+    private val clipboard = appContext.getSystemService(ClipboardManager::class.java)
+
+    private fun publishTerminalClipboard(text: String) {
+        clipboard?.setPrimaryClip(ClipData.newPlainText("terminal clipboard", text))
+    }
 
     private val _tabs = MutableStateFlow<List<TabSession>>(emptyList())
     val tabs: StateFlow<List<TabSession>> = _tabs.asStateFlow()
@@ -168,6 +175,7 @@ class TerminalSessionRepository private constructor(application: Application) {
         preflightMutex.withLock {
             val engine =
                 TerminalSessionEngine(
+                    ::publishTerminalClipboard,
                     scope,
                     newLocalShellService(),
                     hostKeyStore,
@@ -199,6 +207,7 @@ class TerminalSessionRepository private constructor(application: Application) {
         val id = UUID.randomUUID().toString()
         val engine =
             TerminalSessionEngine(
+                ::publishTerminalClipboard,
                 scope,
                 newLocalShellService(),
                 hostKeyStore,

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -30,6 +30,11 @@ import kotlinx.coroutines.sync.withLock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TerminalSessionRepository private constructor(application: Application) {
+    private enum class Osc52ClipboardPolicy {
+        Deny,
+        AllowActiveForegroundSession,
+    }
+
     private val appContext = application.applicationContext
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -37,9 +42,16 @@ class TerminalSessionRepository private constructor(application: Application) {
         HostKeyStore(appContext.getSharedPreferences("host_keys", Application.MODE_PRIVATE))
     private val tailscaleStatusChecker = TailscaleStatusChecker(appContext)
     private val clipboard = appContext.getSystemService(ClipboardManager::class.java)
+    private val osc52ClipboardPolicy = Osc52ClipboardPolicy.Deny
 
-    private fun publishTerminalClipboard(text: String) {
+    private fun publishTerminalClipboard(tabId: String, text: String) {
+        if (!canPublishTerminalClipboard(tabId)) return
         clipboard?.setPrimaryClip(ClipData.newPlainText("terminal clipboard", text))
+    }
+
+    private fun canPublishTerminalClipboard(tabId: String): Boolean {
+        if (osc52ClipboardPolicy != Osc52ClipboardPolicy.AllowActiveForegroundSession) return false
+        return attachedClients > 0 && _activeTabId.value == tabId
     }
 
     private val _tabs = MutableStateFlow<List<TabSession>>(emptyList())
@@ -175,7 +187,7 @@ class TerminalSessionRepository private constructor(application: Application) {
         preflightMutex.withLock {
             val engine =
                 TerminalSessionEngine(
-                    ::publishTerminalClipboard,
+                    {},
                     scope,
                     newLocalShellService(),
                     hostKeyStore,
@@ -207,7 +219,7 @@ class TerminalSessionRepository private constructor(application: Application) {
         val id = UUID.randomUUID().toString()
         val engine =
             TerminalSessionEngine(
-                ::publishTerminalClipboard,
+                { text -> publishTerminalClipboard(id, text) },
                 scope,
                 newLocalShellService(),
                 hostKeyStore,

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
@@ -46,6 +46,14 @@ data class TerminalSnapshot(
      * across snapshots to remap a content-tracking selection anchor.
      */
     val viewportScrollY: Int = 0,
+    /**
+     * True when the running app has enabled a drag-reporting mouse mode
+     * (DECSET 1002/1003). When set, the host forwards long-press drag
+     * gestures to the app so a multiplexer (tmux/zellij/...) can perform
+     * its own pane-scoped selection in copy mode instead of the host
+     * building a grid-wide client-side selection that crosses pane borders.
+     */
+    val appHandlesSelectionDrag: Boolean = false,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -61,7 +69,8 @@ data class TerminalSnapshot(
             flags.contentEquals(other.flags) &&
             graphemeExtrasEquals(graphemeExtras, other.graphemeExtras) &&
             images == other.images &&
-            viewportScrollY == other.viewportScrollY
+            viewportScrollY == other.viewportScrollY &&
+            appHandlesSelectionDrag == other.appHandlesSelectionDrag
     }
 
     override fun hashCode(): Int {
@@ -81,13 +90,14 @@ data class TerminalSnapshot(
         }
         result = 31 * result + images.hashCode()
         result = 31 * result + viewportScrollY
+        result = 31 * result + appHandlesSelectionDrag.hashCode()
         return result
     }
 
     companion object {
         const val CELL_FLAG_HAS_GRAPHEME: Int = 0x40
         const val CELL_FLAG_SPACER: Int = 0x80
-        private const val HEADER_I32_COUNT = 13
+        private const val HEADER_I32_COUNT = 14
         private const val CELL_SIZE_BYTES = 11
         private const val IMAGE_HEADER_BYTES = 52
 
@@ -126,6 +136,7 @@ data class TerminalSnapshot(
             val defaultFgB = wrapped.int
             val extrasOffset = wrapped.int
             val viewportScrollY = wrapped.int
+            val appHandlesSelectionDrag = wrapped.int == 1
 
             val cellCount = cols * rows
             val expectedSize = (HEADER_I32_COUNT * 4) + (cellCount * CELL_SIZE_BYTES)
@@ -213,6 +224,7 @@ data class TerminalSnapshot(
                 graphemeExtras = graphemeExtras,
                 images = images,
                 viewportScrollY = viewportScrollY,
+                appHandlesSelectionDrag = appHandlesSelectionDrag,
             )
 
             return snapshot

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -1215,6 +1215,7 @@ fun TerminalScreen(
                                     onResize = vm::onCanvasSizeChanged,
                                     onTap = requestInputFocus,
                                     onPrimaryClick = vm::onPrimaryMouseClick,
+                                    onAppSelectionDrag = vm::onAppSelectionDrag,
                                     onScroll = vm::onScroll,
                                     onZoom = { zoomFactor ->
                                         terminalFontSizeSp =

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -18,6 +18,8 @@ import com.jossephus.chuchu.service.terminal.HostKeyPrompt
 import com.jossephus.chuchu.service.terminal.SessionState
 import com.jossephus.chuchu.service.terminal.TabSession
 import com.jossephus.chuchu.service.terminal.TabSpec
+import com.jossephus.chuchu.service.terminal.TerminalMouseAction
+import com.jossephus.chuchu.service.terminal.TerminalMouseButton
 import com.jossephus.chuchu.service.terminal.TerminalSessionRepository
 import com.jossephus.chuchu.ui.screens.Files.ConnectionTab
 import com.jossephus.chuchu.ui.screens.Files.FileBrowserEntry
@@ -644,23 +646,35 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun onPrimaryMouseClick(x: Float, y: Float) {
-        sessionRepository.sendMouseEvent(
-            action = GhosttyMouseAction.Press,
-            button = GhosttyMouseButton.Left,
-            mods = 0,
+        sendPrimaryMouseEvent(TerminalMouseAction.Press, x, y, anyButtonPressed = false, trackLastCell = false)
+        sendPrimaryMouseEvent(TerminalMouseAction.Release, x, y, anyButtonPressed = false, trackLastCell = false)
+    }
+
+    fun onAppSelectionDrag(action: Int, x: Float, y: Float) {
+        sendPrimaryMouseEvent(
+            action = action,
             x = x,
             y = y,
-            anyButtonPressed = false,
-            trackLastCell = false,
+            anyButtonPressed = action != TerminalMouseAction.Release,
+            trackLastCell = true,
         )
+    }
+
+    private fun sendPrimaryMouseEvent(
+        action: Int,
+        x: Float,
+        y: Float,
+        anyButtonPressed: Boolean,
+        trackLastCell: Boolean,
+    ) {
         sessionRepository.sendMouseEvent(
-            action = GhosttyMouseAction.Release,
-            button = GhosttyMouseButton.Left,
+            action = action,
+            button = TerminalMouseButton.Left,
             mods = 0,
             x = x,
             y = y,
-            anyButtonPressed = false,
-            trackLastCell = false,
+            anyButtonPressed = anyButtonPressed,
+            trackLastCell = trackLastCell,
         )
     }
 
@@ -741,15 +755,6 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 }
             }
     }
-}
-
-private object GhosttyMouseAction {
-    const val Release = 0
-    const val Press = 1
-}
-
-private object GhosttyMouseButton {
-    const val Left = 1
 }
 
 data class MultiplexerUiState(

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -2,6 +2,7 @@ package com.jossephus.chuchu.ui.terminal
 
 import com.jossephus.chuchu.R
 import com.jossephus.chuchu.service.terminal.GhosttyBridge
+import com.jossephus.chuchu.service.terminal.TerminalMouseAction
 
 import android.graphics.Paint
 import android.graphics.Rect
@@ -68,6 +69,7 @@ fun TerminalCanvas(
         { _, _, _, _, _, _ -> },
     onTap: () -> Unit = {},
     onPrimaryClick: (x: Float, y: Float) -> Unit = { _, _ -> },
+    onAppSelectionDrag: (action: Int, x: Float, y: Float) -> Unit = { _, _, _ -> },
     onScroll: (delta: Int, x: Float, y: Float) -> Unit = { _, _, _ -> },
     onZoom: (zoomFactor: Float) -> Unit = {},
     onSelectionChanged: (TerminalSelectionState?) -> Unit = {},
@@ -176,6 +178,7 @@ fun TerminalCanvas(
     val currentOnSelectionChange = rememberUpdatedState(onSelectionChange)
     val currentOnTap = rememberUpdatedState(onTap)
     val currentOnPrimaryClick = rememberUpdatedState(onPrimaryClick)
+    val currentOnAppSelectionDrag = rememberUpdatedState(onAppSelectionDrag)
     val currentOnScroll = rememberUpdatedState(onScroll)
     val currentOnZoom = rememberUpdatedState(onZoom)
     val ghosttyBridge = remember { GhosttyBridge() }
@@ -279,10 +282,9 @@ fun TerminalCanvas(
                         var didScroll = false
                         var didPinch = false
                         var didDragGesture = false
-                        var didSelect = false
                         var selectionCleared = false
                         var lastSinglePointerId = down.id
-                        var longPressActive = false
+                        var dragMode = DragMode.None
                         var lastEventUptime = down.uptimeMillis
                         val longPressDeadline = down.uptimeMillis + longPressTimeoutMillis
                         var lastPointerPos = down.position
@@ -290,9 +292,9 @@ fun TerminalCanvas(
 
                         while (true) {
                             val timeoutMs = (longPressDeadline - lastEventUptime).coerceAtLeast(1L)
-                            val inAutoScrollZone = longPressActive && autoScrollDir != 0
+                            val inAutoScrollZone = dragMode == DragMode.ClientSelectionDrag && autoScrollDir != 0
                             val event = when {
-                                !longPressActive && !didScroll && !didPinch && !didSelect && !didDragGesture ->
+                                dragMode == DragMode.None && !didScroll && !didPinch && !didDragGesture ->
                                     withTimeoutOrNull(timeoutMs) { awaitPointerEvent() }
                                 inAutoScrollZone ->
                                     withTimeoutOrNull(autoScrollIntervalMs) { awaitPointerEvent() }
@@ -300,13 +302,24 @@ fun TerminalCanvas(
                             }
 
                             if (event == null) {
-                                if (!longPressActive) {
+                                if (dragMode == DragMode.None) {
                                     val s = currentSnapshot.value
                                     val downPos = toSnapshotSpace(down.position, s)
-                                    if (startSelection(s, downPos, cellWidth, cellHeight, currentOnSelectionChange.value)) {
+                                    if (s.appHandlesSelectionDrag) {
+                                        currentOnAppSelectionDrag.value(TerminalMouseAction.Press, downPos.x, downPos.y)
                                         haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        didSelect = true
-                                        longPressActive = true
+                                        didDragGesture = true
+                                        dragMode = DragMode.AppMouseDrag
+                                    } else if (startSelection(
+                                            s,
+                                            downPos,
+                                            cellWidth,
+                                            cellHeight,
+                                            currentOnSelectionChange.value,
+                                        )
+                                    ) {
+                                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        dragMode = DragMode.ClientSelectionDrag
                                     }
                                     continue
                                 }
@@ -328,7 +341,14 @@ fun TerminalCanvas(
                             if (pressed.isEmpty()) {
                                 autoScrollDir = 0
                                 autoScrollingSelection = false
-                                if (didSelect) {
+                                val releasedDragMode = dragMode
+                                dragMode = DragMode.None
+                                if (releasedDragMode == DragMode.AppMouseDrag) {
+                                    val s = currentSnapshot.value
+                                    val releasePos = toSnapshotSpace(lastPointerPos, s)
+                                    currentOnAppSelectionDrag.value(TerminalMouseAction.Release, releasePos.x, releasePos.y)
+                                }
+                                if (releasedDragMode != DragMode.None) {
                                     break
                                 }
                                 if (!didScroll && !didPinch && !didDragGesture) {
@@ -398,7 +418,17 @@ fun TerminalCanvas(
                             val changePrevPos = toSnapshotSpace(change.previousPosition, s)
                             val downPos = toSnapshotSpace(down.position, s)
                             val selectedCell = s.cellAt(changePos.x, changePos.y, cellWidth, cellHeight)
-                            if (longPressActive && selectedCell != null) {
+                            if (dragMode == DragMode.AppMouseDrag) {
+                                lastPointerPos = change.position
+                                autoScrollDir = 0
+                                autoScrollingSelection = false
+                                if (change.position != change.previousPosition) {
+                                    currentOnAppSelectionDrag.value(TerminalMouseAction.Motion, changePos.x, changePos.y)
+                                    change.consume()
+                                }
+                                continue
+                            }
+                            if (dragMode == DragMode.ClientSelectionDrag && selectedCell != null) {
                                 lastPointerPos = change.position
                                 updateSelectionDrag(
                                     existing = currentSelectionState.value,
@@ -423,7 +453,7 @@ fun TerminalCanvas(
                                 (changePos.x - downPos.x).toDouble(),
                                 (changePos.y - downPos.y).toDouble(),
                             ).toFloat()
-                            val abortSlopPx = if (longPressActive) touchSlopPx else longPressSlopPx
+                            val abortSlopPx = if (dragMode != DragMode.None) touchSlopPx else longPressSlopPx
                             if (movedDistance > abortSlopPx) {
                                 didDragGesture = true
                                 if (currentSelectionState.value != null && !selectionCleared) {
@@ -836,6 +866,11 @@ private fun isNerdFontPrivateUse(cp: Int): Boolean {
         (cp in 0x100000..0x10FFFD)
 }
 
+private enum class DragMode {
+    None,
+    ClientSelectionDrag,
+    AppMouseDrag,
+}
 
 /** Tracks double-tap timing/position without triggering Compose recomposition. */
 private class DoubleTapState {

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/EmojiSnapshotRegressionTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/EmojiSnapshotRegressionTest.kt
@@ -15,7 +15,7 @@ class EmojiSnapshotRegressionTest {
         val cols = 4
         val rows = 1
         val cellCount = cols * rows
-        val headerBytes = 13 * 4
+        val headerBytes = 14 * 4
         val gridBytes = cellCount * 11
         val extrasOffset = headerBytes + gridBytes
 
@@ -39,6 +39,7 @@ class EmojiSnapshotRegressionTest {
         raw.putInt(255)
         raw.putInt(extrasOffset)
         raw.putInt(0) // viewport_scroll_y
+        raw.putInt(0) // app_handles_selection_drag
 
         fun putCell(codepoint: Int, flags: Int) {
             raw.putInt(codepoint)
@@ -69,6 +70,45 @@ class EmojiSnapshotRegressionTest {
         assertArrayEquals(intArrayOf(0x200D), snapshot.graphemeExtras[0])
         assertTrue(snapshot.isSpacerContinuation(2))
         assertFalse(snapshot.isSpacerContinuation(3))
+        assertFalse(snapshot.appHandlesSelectionDrag)
+    }
+
+    @Test
+    fun parsesAppSelectionDragFlagFromSnapshotHeader() {
+        val cols = 1
+        val rows = 1
+        val headerBytes = 14 * 4
+        val gridBytes = cols * rows * 11
+        val raw = ByteBuffer.allocate(headerBytes + gridBytes).order(ByteOrder.LITTLE_ENDIAN)
+
+        raw.putInt(cols)
+        raw.putInt(rows)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(1)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(255)
+        raw.putInt(255)
+        raw.putInt(255)
+        raw.putInt(0)
+        raw.putInt(0)
+        raw.putInt(1)
+
+        raw.putInt('a'.code)
+        raw.put(255.toByte())
+        raw.put(255.toByte())
+        raw.put(255.toByte())
+        raw.put(0.toByte())
+        raw.put(0.toByte())
+        raw.put(0.toByte())
+        raw.put(0.toByte())
+
+        raw.position(0)
+        val snapshot = TerminalSnapshot.fromByteBuffer(raw)
+
+        assertTrue(snapshot.appHandlesSelectionDrag)
     }
 
     @Test
@@ -134,7 +174,7 @@ class EmojiSnapshotRegressionTest {
         val cols = 3
         val rows = 1
         val cellCount = cols * rows
-        val headerBytes = 13 * 4
+        val headerBytes = 14 * 4
         val gridBytes = cellCount * 11
         val extrasOffset = headerBytes + gridBytes
 
@@ -162,6 +202,7 @@ class EmojiSnapshotRegressionTest {
         raw.putInt(255)
         raw.putInt(extrasOffset)
         raw.putInt(0) // viewport_scroll_y
+        raw.putInt(0) // app_handles_selection_drag
 
         fun putCell(codepoint: Int, flags: Int) {
             raw.putInt(codepoint)

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -300,7 +300,6 @@ fn updateString(storage: *?[]u8, storage_len: *usize, dirty: *bool, value: ?[:0]
 fn updateBytes(storage: *?[]u8, storage_len: *usize, dirty: *bool, bytes: []const u8) bool {
     if (storage.* != null and storage_len.* == bytes.len) {
         if (bytes.len == 0) return false;
-        if (std.mem.eql(u8, storage.*.?[0..bytes.len], bytes)) return false;
     }
 
     const new_buf = allocator.alloc(u8, bytes.len) catch return false;

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -28,7 +28,12 @@ const verbose_snapshot_perf_logs = false;
 //  12  viewport_scroll_y (screen.y of the content at viewport row 0; stable
 //      content coordinate that changes as the viewport scrolls, so the host
 //      can remap a content-tracking selection anchor across scrolls)
-const SNAPSHOT_HEADER_I32_COUNT = 13;
+//  13  app_handles_selection_drag (1 when the running app has enabled a
+//      drag-reporting mouse mode — DECSET 1002/1003 — so the host forwards
+//      long-press drag gestures to the app instead of starting a client-side
+//      grid selection. This is what lets tmux/zellij perform their own
+//      pane-scoped selection.)
+const SNAPSHOT_HEADER_I32_COUNT = 14;
 const SNAPSHOT_CELL_SIZE_BYTES = 11;
 // Flag bit set on a cell whose codepoint has additional grapheme codepoints
 // in the extras section.
@@ -39,6 +44,7 @@ const CELL_FLAG_HAS_GRAPHEME: u8 = 1 << 6;
 const CELL_FLAG_SPACER: u8 = 1 << 7;
 const IMAGE_HEADER_BYTES = 52;
 const MAX_KITTY_IMAGES = 64;
+const MAX_OSC52_CLIPBOARD_BYTES = 1024 * 1024;
 // Kitty Unicode graphics placeholder (U+10EEEE). These cells only mark where an
 // image is composited; we blank them so the raw glyph never shows through a gap
 // the image doesn't fully cover.
@@ -96,10 +102,18 @@ const MouseEncodingSize = struct {
     padding_right: u32 = 0,
 };
 
+fn appHandlesSelectionDrag(event: anytype) bool {
+    return switch (event) {
+        .button, .any => true,
+        else => false,
+    };
+}
+
 const ChuchuTerminal = struct {
     terminal: ghostty.Terminal,
     render_state: ghostty.RenderState = .empty,
-    stream: ghostty.TerminalStream,
+    stream_handler: ChuchuStreamHandler = undefined,
+    stream: ChuchuTerminalStream,
     cols: u16,
     rows: u16,
     cell_width: u32,
@@ -115,6 +129,9 @@ const ChuchuTerminal = struct {
     pwd: ?[]u8 = null,
     pwd_len: usize = 0,
     pwd_dirty: bool = false,
+    clipboard: ?[]u8 = null,
+    clipboard_len: usize = 0,
+    clipboard_dirty: bool = false,
     bell_count: u32 = 0,
     snapshot_buffer: std.ArrayListUnmanaged(u8) = .empty,
     snapshot_extras_scratch: std.ArrayListUnmanaged(u32) = .empty,
@@ -125,6 +142,33 @@ const ChuchuTerminal = struct {
     snapshot_perf_total_ns: u64 = 0,
     snapshot_perf_last_log_ns: i64 = 0,
 };
+
+const ChuchuStreamHandler = struct {
+    owner: *ChuchuTerminal,
+    inner: ghostty.TerminalStream.Handler,
+
+    pub fn deinit(self: *ChuchuStreamHandler) void {
+        self.inner.deinit();
+    }
+
+    pub fn vt(
+        self: *ChuchuStreamHandler,
+        comptime action: ChuchuTerminalStream.Action.Tag,
+        value: ChuchuTerminalStream.Action.Value(action),
+    ) void {
+        if (action == .clipboard_contents) {
+            self.clipboardContents(value.kind, value.data);
+        }
+        self.inner.vt(action, value);
+    }
+
+    fn clipboardContents(self: *ChuchuStreamHandler, _: u8, data: []const u8) void {
+        if (std.mem.eql(u8, data, "?")) return;
+        storeClipboardData(self.owner, data);
+    }
+};
+
+const ChuchuTerminalStream = ghostty.Stream(*ChuchuStreamHandler);
 
 fn chuchuFromHandle(handle: c.jlong) ?*ChuchuTerminal {
     if (handle == 0) return null;
@@ -253,6 +297,46 @@ fn updateString(storage: *?[]u8, storage_len: *usize, dirty: *bool, value: ?[:0]
     return true;
 }
 
+fn updateBytes(storage: *?[]u8, storage_len: *usize, dirty: *bool, bytes: []const u8) bool {
+    if (storage.* != null and storage_len.* == bytes.len) {
+        if (bytes.len == 0) return false;
+        if (std.mem.eql(u8, storage.*.?[0..bytes.len], bytes)) return false;
+    }
+
+    const new_buf = allocator.alloc(u8, bytes.len) catch return false;
+    if (bytes.len > 0) @memcpy(new_buf, bytes);
+
+    if (storage.*) |old| allocator.free(old);
+    storage.* = new_buf;
+    storage_len.* = bytes.len;
+    dirty.* = true;
+    return true;
+}
+
+fn decodeBase64Clipboard(data: []const u8) ?[]u8 {
+    const decoders = [_]std.base64.Base64Decoder{
+        std.base64.standard.Decoder,
+        std.base64.standard_no_pad.Decoder,
+    };
+    for (decoders) |decoder| {
+        const decoded_len = decoder.calcSizeForSlice(data) catch continue;
+        if (decoded_len > MAX_OSC52_CLIPBOARD_BYTES) return null;
+        const decoded = allocator.alloc(u8, decoded_len) catch return null;
+        decoder.decode(decoded, data) catch {
+            allocator.free(decoded);
+            continue;
+        };
+        return decoded;
+    }
+    return null;
+}
+
+fn storeClipboardData(terminal: *ChuchuTerminal, encoded: []const u8) void {
+    const decoded = decodeBase64Clipboard(encoded) orelse return;
+    defer allocator.free(decoded);
+    _ = updateBytes(&terminal.clipboard, &terminal.clipboard_len, &terminal.clipboard_dirty, decoded);
+}
+
 fn updateMetadata(terminal: *ChuchuTerminal) void {
     _ = updateString(&terminal.title, &terminal.title_len, &terminal.title_dirty, terminal.terminal.getTitle());
     _ = updateString(&terminal.pwd, &terminal.pwd_len, &terminal.pwd_dirty, terminal.terminal.getPwd());
@@ -356,6 +440,7 @@ export fn chuchu_create_terminal(cols: c.jint, rows: c.jint, max_scrollback: c.j
 
     terminal.* = .{
         .terminal = inner,
+        .stream_handler = undefined,
         .stream = undefined,
         .cols = init_cols,
         .rows = init_rows,
@@ -374,7 +459,11 @@ export fn chuchu_create_terminal(cols: c.jint, rows: c.jint, max_scrollback: c.j
         .title_changed = chuchuTitleChanged,
         .xtversion = chuchuXtversion,
     };
-    terminal.stream = ghostty.TerminalStream.initAlloc(allocator, handler);
+    terminal.stream_handler = .{
+        .owner = terminal,
+        .inner = handler,
+    };
+    terminal.stream = ChuchuTerminalStream.initAlloc(allocator, &terminal.stream_handler);
     enableGraphemeClusterMode(terminal);
 
     update_render_state(terminal);
@@ -389,6 +478,7 @@ export fn chuchu_destroy_terminal(handle: c.jlong) callconv(.c) void {
     terminal.pty_write_buffer.deinit(allocator);
     if (terminal.title) |buf| allocator.free(buf);
     if (terminal.pwd) |buf| allocator.free(buf);
+    if (terminal.clipboard) |buf| allocator.free(buf);
     terminal.render_state.deinit(allocator);
     terminal.stream.deinit();
     terminal.terminal.deinit(allocator);
@@ -491,6 +581,12 @@ export fn Java_com_jossephus_chuchu_service_terminal_GhosttyBridge_nativePollPwd
     _ = thiz;
     const value = chuchu_poll_pwd_ptr(handle) orelse return null;
     return jniNewStringUTF(env, value);
+}
+
+export fn Java_com_jossephus_chuchu_service_terminal_GhosttyBridge_nativePollClipboard(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong) callconv(.c) c.jbyteArray {
+    _ = thiz;
+    const bytes = chuchu_poll_clipboard(handle) orelse return null;
+    return jniByteArrayFromBytes(env, bytes);
 }
 
 export fn Java_com_jossephus_chuchu_service_terminal_GhosttyBridge_nativeDrainBellCount(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong) callconv(.c) c.jint {
@@ -722,6 +818,11 @@ export fn chuchu_build_text_snapshot(handle: c.jlong, out_size: [*c]usize) callc
         break :blk @intCast(vp_top.screen.y);
     };
     writeIntLe(i32, buffer[0..base_total_size], 48, viewport_scroll_y);
+    // app_handles_selection_drag: 1 only for drag-reporting mouse modes
+    // (DECSET 1002/1003). Click-only mouse modes still allow the host to keep
+    // its own long-press selection behavior.
+    const app_handles_selection_drag: i32 = if (appHandlesSelectionDrag(terminal.terminal.flags.mouse_event)) 1 else 0;
+    writeIntLe(i32, buffer[0..base_total_size], 52, app_handles_selection_drag);
 
     terminal.snapshot_extras_scratch.clearRetainingCapacity();
     var extras_records: usize = 0;
@@ -1201,6 +1302,13 @@ export fn chuchu_poll_pwd_ptr(handle: c.jlong) callconv(.c) ?[*:0]const u8 {
     return if (terminal.pwd) |pwd| @ptrCast(pwd) else "";
 }
 
+fn chuchu_poll_clipboard(handle: c.jlong) ?[]const u8 {
+    const terminal = chuchuFromHandle(handle) orelse return null;
+    if (!terminal.clipboard_dirty) return null;
+    terminal.clipboard_dirty = false;
+    return if (terminal.clipboard) |clipboard| clipboard[0..terminal.clipboard_len] else &.{};
+}
+
 export fn chuchu_drain_bell_count(handle: c.jlong) callconv(.c) c.jint {
     const terminal = chuchuFromHandle(handle) orelse return 0;
     const count = terminal.bell_count;
@@ -1299,9 +1407,9 @@ export fn chuchu_scroll(handle: c.jlong, delta: c.jint, x: c.jfloat, y: c.jfloat
     const in_alt_screen = alt_screen or alt_screen_legacy or alt_screen_1049;
 
     // Check if mouse reporting is enabled (any mode other than none)
-    const mouse_captured = terminal.terminal.flags.mouse_event != .none;
+    const mouse_reporting_enabled = terminal.terminal.flags.mouse_event != .none;
 
-    if (in_alt_screen or mouse_captured) {
+    if (in_alt_screen or mouse_reporting_enabled) {
         // Send mouse scroll events to the application.
         // Negative delta = scroll up (older content) → button 4.
         // Positive delta = scroll down (newer content) → button 5.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added clipboard synchronization—terminal clipboard contents are now polled from the native layer and published to the system primary clipboard (gated by an OSC 52 clipboard policy and the active tab).
* Improved app-controlled selection drag handling (DECSET 1002/1003): gesture routing now distinguishes client vs app drag and forwards press/motion/release events.

## Bug Fixes
* Extended terminal snapshot parsing to support the new selection-drag flag in the snapshot header.

## Tests
* Updated and added regression coverage for the updated snapshot header/layout and selection-drag flag parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->