### PR TITLE
fix: use bracketed pasted mode for multiline paste

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/GhosttyBridge.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/GhosttyBridge.kt
@@ -40,6 +40,7 @@ class GhosttyBridge {
         paletteRgb: ByteArray?,
     )
     external fun nativeEncodeKey(handle: Long, key: Int, cp: Int, mods: Int, action: Int, utf8: String?): ByteArray?
+    external fun nativeEncodePaste(handle: Long, data: String): ByteArray?
     external fun nativeSetMouseEncodingSize(
         handle: Long,
         screenWidth: Int,

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -302,6 +302,18 @@ class TerminalSessionEngine(
         }
     }
 
+    fun writePaste(text: String) {
+        scope.launch(dispatcher) {
+            if (handle == 0L) return@launch
+            if (text.isEmpty()) return@launch
+            val encoded = bridge.nativeEncodePaste(handle, text) ?: return@launch
+            if (encoded.isEmpty()) return@launch
+            try {
+                writeRemote(encoded)
+            } catch (_: Exception) {}
+        }
+    }
+
     fun setColorScheme(isDark: Boolean) {
         val scheme = if (isDark) 1 else 0
         pendingColorScheme = scheme

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -339,6 +339,10 @@ class TerminalSessionRepository private constructor(application: Application) {
         activeEngine()?.writeText(text)
     }
 
+    fun writePaste(text: String) {
+        activeEngine()?.writePaste(text)
+    }
+
     fun sendFocusEvent(focused: Boolean) {
         activeEngine()?.sendFocusEvent(focused)
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -692,16 +691,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     fun onPasteText(text: String) {
         if (text.isEmpty()) return
         sessionRepository.scrollToActive()
-        val chunkSize = 512
-        viewModelScope.launch {
-            var index = 0
-            while (index < text.length) {
-                val end = (index + chunkSize).coerceAtMost(text.length)
-                sessionRepository.writeText(text.substring(index, end))
-                index = end
-                delay(8)
-            }
-        }
+        sessionRepository.writePaste(text)
     }
 
     fun onFocusChanged(focused: Boolean) {

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -545,6 +545,38 @@ export fn Java_com_jossephus_chuchu_service_terminal_GhosttyBridge_nativeEncodeK
     return jniByteArrayFromBytes(env, writer.buffered());
 }
 
+export fn Java_com_jossephus_chuchu_service_terminal_GhosttyBridge_nativeEncodePaste(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong, data_jstring: c.jstring) callconv(.c) c.jbyteArray {
+    _ = thiz;
+    const terminal = chuchuFromHandle(handle) orelse return jniEmptyByteArray(env);
+    if (data_jstring == null) return jniEmptyByteArray(env);
+
+    const chars = env.*.*.GetStringUTFChars.?(env, data_jstring, null) orelse return jniEmptyByteArray(env);
+    defer env.*.*.ReleaseStringUTFChars.?(env, data_jstring, chars);
+    const data_len = std.mem.span(chars).len;
+    if (data_len == 0) return jniEmptyByteArray(env);
+
+    // encodePaste may need to mutate the data in place (stripping unsafe
+    // bytes and, for non-bracketed pastes, converting newlines to \r), so
+    // copy the JNI string into a mutable buffer before encoding.
+    const data_copy = allocator.alloc(u8, data_len) catch return jniEmptyByteArray(env);
+    defer allocator.free(data_copy);
+    @memcpy(data_copy, chars[0..data_len]);
+
+    const segments = ghostty.input.encodePaste(data_copy, ghostty.input.PasteOptions.fromTerminal(&terminal.terminal));
+    const total = segments[0].len + segments[1].len + segments[2].len;
+    if (total == 0) return jniEmptyByteArray(env);
+
+    const out = allocator.alloc(u8, total) catch return jniEmptyByteArray(env);
+    defer allocator.free(out);
+    var offset: usize = 0;
+    for (segments) |segment| {
+        @memcpy(out[offset..][0..segment.len], segment);
+        offset += segment.len;
+    }
+
+    return jniByteArrayFromBytes(env, out);
+}
+
 export fn Java_com_jossephus_chuchu_service_terminal_GhosttyBridge_nativeEncodeMouse(env: *c.JNIEnv, thiz: c.jobject, handle: c.jlong, action: c.jint, button: c.jint, mods: c.jint, x: c.jfloat, y: c.jfloat, any_button_pressed: c.jboolean, track_last_cell: c.jboolean) callconv(.c) c.jbyteArray {
     _ = thiz;
     const terminal = chuchuFromHandle(handle) orelse return jniEmptyByteArray(env);


### PR DESCRIPTION
Closes #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced paste functionality with efficient native-level encoding for improved reliability and performance when pasting text.
  * Streamlined paste operations by removing artificial chunk delays, resulting in faster and more responsive text insertion when pasting content into terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->