### PR TITLE
feat: add grouped accessory keys

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
@@ -63,9 +63,9 @@ import com.jossephus.chuchu.ui.components.ChuCard
 import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.components.ChuSwitch
 import com.jossephus.chuchu.ui.components.ChuTextField
-import com.jossephus.chuchu.ui.terminal.AccessoryKeyItem
 import com.jossephus.chuchu.ui.terminal.KeyboardAccessoryBar
 import com.jossephus.chuchu.ui.terminal.ModifierState
+import com.jossephus.chuchu.ui.terminal.ResolvedAccessoryEntry
 import com.jossephus.chuchu.ui.terminal.TerminalAccessoryLayoutStore
 import com.jossephus.chuchu.ui.terminal.TerminalCustomKeyGroup
 import com.jossephus.chuchu.ui.theme.ChuColors
@@ -92,7 +92,7 @@ internal fun TerminalSettings(
     var tabModeExpanded by remember { mutableStateOf(false) }
     var tabModeAnchorBounds by remember { mutableStateOf<Rect?>(null) }
     var tabModeContainerBounds by remember { mutableStateOf<Rect?>(null) }
-    val selectedItems = remember(currentAccessoryLayoutIds) {
+    val selectedEntries = remember(currentAccessoryLayoutIds) {
         TerminalAccessoryLayoutStore.resolveSelectedLayout(currentAccessoryLayoutIds)
     }
     val density = LocalDensity.current
@@ -293,7 +293,7 @@ internal fun TerminalSettings(
                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         ChuText("accessory keys", style = typography.label)
                         ChuText(
-                            if (selectedItems.isEmpty()) "no keys enabled" else "${selectedItems.size} keys enabled",
+                            if (selectedEntries.isEmpty()) "no keys enabled" else "${selectedEntries.size} keys enabled",
                             style = typography.body,
                             color = colors.textMuted,
                         )
@@ -331,7 +331,7 @@ internal fun TerminalSettings(
                     )
                 }
 
-                if (selectedItems.isEmpty()) {
+                if (selectedEntries.isEmpty()) {
                     ChuText(
                         "choose the accessory keys you want in the terminal bar.",
                         style = typography.body,
@@ -344,7 +344,7 @@ internal fun TerminalSettings(
                             .background(colors.surfaceVariant),
                     ) {
                         KeyboardAccessoryBar(
-                            items = selectedItems,
+                            entries = selectedEntries,
                             modifierState = ModifierState(),
                             onAction = {},
                             useSingleRow = accessoryBarSingleRow,
@@ -440,7 +440,7 @@ internal fun AccessoryLayoutEditorSheet(
     val typography = ChuTypography.current
     val density = LocalDensity.current
     val reorderStepPx = with(density) { 40.dp.toPx() }
-    val allItems = remember { TerminalAccessoryLayoutStore.catalog() }
+    val allEntries = remember { TerminalAccessoryLayoutStore.allCatalogEntries() }
     var draftSelectedIds by remember(selectedIds) {
         mutableStateOf(TerminalAccessoryLayoutStore.normalizeIds(selectedIds))
     }
@@ -448,15 +448,15 @@ internal fun AccessoryLayoutEditorSheet(
     var previewDragRemainderPx by remember { mutableFloatStateOf(0f) }
     var previewDragOffsetPx by remember { mutableFloatStateOf(0f) }
 
-    val selectedItems = remember(draftSelectedIds) {
+    val selectedEntries = remember(draftSelectedIds) {
         TerminalAccessoryLayoutStore.resolveSelectedLayout(draftSelectedIds)
     }
 
-    fun toggleItem(item: AccessoryKeyItem) {
-        draftSelectedIds = if (item.id in draftSelectedIds) {
-            draftSelectedIds.filterNot { it == item.id }
+    fun toggleEntry(entry: ResolvedAccessoryEntry) {
+        draftSelectedIds = if (entry.id in draftSelectedIds) {
+            draftSelectedIds.filterNot { it == entry.id }
         } else {
-            draftSelectedIds + item.id
+            draftSelectedIds + entry.id
         }
     }
 
@@ -547,13 +547,13 @@ internal fun AccessoryLayoutEditorSheet(
                         ) {
                             ChuText("preview", style = typography.label)
                             ChuText(
-                                if (selectedItems.isEmpty()) "0" else selectedItems.size.toString(),
+                                if (selectedEntries.isEmpty()) "0" else selectedEntries.size.toString(),
                                 style = typography.labelSmall,
                                 color = colors.textMuted,
                             )
                         }
 
-                        if (selectedItems.isEmpty()) {
+                        if (selectedEntries.isEmpty()) {
                             ChuText(
                                 "no accessory keys selected.",
                                 style = typography.body,
@@ -567,11 +567,11 @@ internal fun AccessoryLayoutEditorSheet(
                             horizontalArrangement = Arrangement.spacedBy(6.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            selectedItems.forEach { item ->
+                            selectedEntries.forEach { item ->
                                 key(item.id) {
                                     val isDragging = previewDraggingId == item.id
                                     PreviewKeyChip(
-                                        item = item,
+                                        entry = item,
                                         dragging = isDragging,
                                         modifier = Modifier.pointerInput(item.id) {
                                             detectDragGesturesAfterLongPress(
@@ -634,12 +634,12 @@ internal fun AccessoryLayoutEditorSheet(
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    allItems.forEach { item ->
+                    allEntries.forEach { item ->
                         val selected = item.id in draftSelectedIds
                         AccessoryChooserRow(
-                            item = item,
+                            entry = item,
                             selected = selected,
-                            onClick = { toggleItem(item) },
+                            onClick = { toggleEntry(item) },
                         )
                     }
                 }
@@ -672,7 +672,7 @@ internal fun AccessoryLayoutEditorSheet(
 
 @Composable
 private fun PreviewKeyChip(
-    item: AccessoryKeyItem,
+    entry: ResolvedAccessoryEntry,
     dragging: Boolean,
     dragOffsetPx: Float,
     modifier: Modifier = Modifier,
@@ -687,22 +687,40 @@ private fun PreviewKeyChip(
             .padding(horizontal = 10.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
-        ChuText(
-            text = item.label,
-            style = typography.label,
-            color = if (dragging) colors.accent else colors.textPrimary,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ChuText(
+                text = entry.label,
+                style = typography.label,
+                color = if (dragging) colors.accent else colors.textPrimary,
+            )
+            if (entry is ResolvedAccessoryEntry.Group) {
+                ChuText(
+                    text = "▾",
+                    style = typography.labelSmall,
+                    color = if (dragging) colors.accent else colors.textMuted,
+                    modifier = Modifier.padding(start = 4.dp),
+                )
+            }
+        }
     }
 }
 
 @Composable
 private fun AccessoryChooserRow(
-    item: AccessoryKeyItem,
+    entry: ResolvedAccessoryEntry,
     selected: Boolean,
     onClick: () -> Unit,
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
+    val group = entry as? ResolvedAccessoryEntry.Group
+    val childCount = group?.group?.children?.size ?: 0
+    val description =
+        if (group != null) {
+            if (childCount > 0) "group · $childCount keys" else "group"
+        } else {
+            "key"
+        }
 
     Row(
         modifier = Modifier
@@ -727,10 +745,17 @@ private fun AccessoryChooserRow(
             )
         }
 
-        ChuText(
-            text = item.label,
-            style = typography.label,
-            color = colors.textPrimary,
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            ChuText(
+                text = entry.label,
+                style = typography.label,
+                color = colors.textPrimary,
+            )
+            ChuText(
+                text = description,
+                style = typography.labelSmall,
+                color = colors.textMuted,
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
@@ -46,9 +46,9 @@ import com.jossephus.chuchu.ui.components.ChuButton
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
 import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.terminal.AccessoryAction
-import com.jossephus.chuchu.ui.terminal.AccessoryKeyItem
 import com.jossephus.chuchu.ui.terminal.KeyboardAccessoryBar
 import com.jossephus.chuchu.ui.terminal.ModifierState
+import com.jossephus.chuchu.ui.terminal.ResolvedAccessoryEntry
 import com.jossephus.chuchu.ui.terminal.TerminalCanvas
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
@@ -59,7 +59,7 @@ fun CommandPalette(
     activeTabId: String?,
     focusedTabIndex: Int,
     onFocusedTabIndexChange: (Int) -> Unit,
-    accessoryItems: List<AccessoryKeyItem>,
+    accessoryEntries: List<ResolvedAccessoryEntry>,
     accessoryModifierState: ModifierState,
     onAccessoryAction: (AccessoryAction) -> Unit,
     onChuchuKey: () -> Unit,
@@ -251,7 +251,7 @@ fun CommandPalette(
         }
       }
       KeyboardAccessoryBar(
-          items = accessoryItems,
+          entries = accessoryEntries,
           modifierState = accessoryModifierState,
           onAction = onAccessoryAction,
           onSettings = onOpenSettings,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -1561,7 +1561,7 @@ fun TerminalScreen(
                                 )
                             }
                             KeyboardAccessoryBar(
-                                items = accessoryLayout,
+                                entries = accessoryLayout,
                                 modifierState = modifierState,
                                 onAction = ::dispatchAccessoryAction,
                                 onSettings = onOpenSettings,
@@ -1656,7 +1656,7 @@ fun TerminalScreen(
                         activeTabId = activeTabId,
                         focusedTabIndex = focusedTabIndex,
                         onFocusedTabIndexChange = { focusedTabIndex = it },
-                        accessoryItems = accessoryLayout,
+                        accessoryEntries = accessoryLayout,
                         accessoryModifierState = modifierState,
                         onAccessoryAction = paletteAccessoryAction,
                         onChuchuKey = { chuchuKeys.togglePrefix() },

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/KeyboardAccessoryBar.kt
@@ -1,11 +1,18 @@
 package com.jossephus.chuchu.ui.terminal
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
@@ -49,7 +56,7 @@ private const val REPEAT_INTERVAL_MS = 50L
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun KeyboardAccessoryBar(
-    items: List<AccessoryKeyItem>,
+    entries: List<ResolvedAccessoryEntry>,
     modifierState: ModifierState,
     onAction: (AccessoryAction) -> Unit,
     onSettings: (() -> Unit)? = null,
@@ -63,21 +70,83 @@ fun KeyboardAccessoryBar(
 ) {
     val buttonHeight = 30.dp
     val buttonPadding = PaddingValues(start = 10.dp, end = 10.dp, top = 3.dp, bottom = 3.dp)
+    var expandedGroupId by remember { mutableStateOf<String?>(null) }
+    val onChildAction: (AccessoryAction) -> Unit = { action ->
+        onAction(action)
+    }
 
-    if (useSingleRow) {
-        Row(
-            modifier = modifier
+    Column(modifier = modifier) {
+        expandedGroupId?.let { groupId ->
+            val expandedGroup =
+                entries.firstOrNull { it is ResolvedAccessoryEntry.Group && it.group.id == groupId }
+                    as? ResolvedAccessoryEntry.Group
+            if (expandedGroup != null) {
+                GroupPopover(
+                    group = expandedGroup.group,
+                    modifierState = modifierState,
+                    onAction = onChildAction,
+                    buttonHeight = buttonHeight,
+                    buttonPadding = buttonPadding,
+                    horizontalPadding = horizontalPadding,
+                )
+            }
+        }
+
+        if (useSingleRow) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPadding, vertical = verticalPadding)
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                entries.forEach { entry ->
+                    AccessoryEntry(
+                        entry = entry,
+                        expanded = expandedGroupId == entry.id,
+                        modifierState = modifierState,
+                        onAction = onAction,
+                        onToggleGroup = { id ->
+                            expandedGroupId = if (expandedGroupId == id) null else id
+                        },
+                        buttonHeight = buttonHeight,
+                        buttonPadding = buttonPadding,
+                    )
+                }
+                FilesButton(
+                    onChuchuKey = onChuchuKey,
+                    chuchuKeyActive = chuchuKeyActive,
+                    onOpenFiles = onOpenFiles,
+                    buttonHeight = buttonHeight,
+                    buttonPadding = buttonPadding,
+                )
+                SettingsButton(
+                    onSettings = onSettings,
+                    buttonHeight = buttonHeight,
+                    buttonPadding = buttonPadding,
+                )
+            }
+            return
+        }
+
+        FlowRow(
+            modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = horizontalPadding, vertical = verticalPadding)
-                .horizontalScroll(rememberScrollState()),
+                .padding(horizontal = horizontalPadding, vertical = verticalPadding),
             horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            maxLines = 2,
         ) {
-            items.forEach { item ->
-                AccessoryButton(
-                    item = item,
+            entries.forEach { entry ->
+                AccessoryEntry(
+                    entry = entry,
+                    expanded = expandedGroupId == entry.id,
                     modifierState = modifierState,
                     onAction = onAction,
+                    onToggleGroup = { id ->
+                        expandedGroupId = if (expandedGroupId == id) null else id
+                    },
                     buttonHeight = buttonHeight,
                     buttonPadding = buttonPadding,
                 )
@@ -95,37 +164,97 @@ fun KeyboardAccessoryBar(
                 buttonPadding = buttonPadding,
             )
         }
-        return
     }
+}
 
-    FlowRow(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = horizontalPadding, vertical = verticalPadding),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-        maxLines = 2,
+@Composable
+private fun GroupPopover(
+    group: AccessoryKeyGroup,
+    modifierState: ModifierState,
+    onAction: (AccessoryAction) -> Unit,
+    buttonHeight: Dp,
+    buttonPadding: PaddingValues,
+    horizontalPadding: Dp,
+) {
+    val colors = ChuColors.current
+    AnimatedVisibility(
+        visible = true,
+        enter = fadeIn() + expandVertically(),
+        exit = fadeOut() + shrinkVertically(),
     ) {
-        items.forEach { item ->
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = horizontalPadding, vertical = 4.dp)
+                .background(colors.surface)
+                .padding(horizontal = 6.dp, vertical = 6.dp)
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            group.children.forEach { child ->
+                AccessoryButton(
+                    item = child,
+                    modifierState = modifierState,
+                    onAction = onAction,
+                    buttonHeight = buttonHeight,
+                    buttonPadding = buttonPadding,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccessoryEntry(
+    entry: ResolvedAccessoryEntry,
+    expanded: Boolean,
+    modifierState: ModifierState,
+    onAction: (AccessoryAction) -> Unit,
+    onToggleGroup: (String) -> Unit,
+    buttonHeight: Dp,
+    buttonPadding: PaddingValues,
+) {
+    when (entry) {
+        is ResolvedAccessoryEntry.Single ->
             AccessoryButton(
-                item = item,
+                item = entry.item,
                 modifierState = modifierState,
                 onAction = onAction,
                 buttonHeight = buttonHeight,
                 buttonPadding = buttonPadding,
             )
-        }
-        FilesButton(
-            onChuchuKey = onChuchuKey,
-            chuchuKeyActive = chuchuKeyActive,
-            onOpenFiles = onOpenFiles,
-            buttonHeight = buttonHeight,
-            buttonPadding = buttonPadding,
-        )
-        SettingsButton(
-            onSettings = onSettings,
-            buttonHeight = buttonHeight,
-            buttonPadding = buttonPadding,
+        is ResolvedAccessoryEntry.Group ->
+            GroupButton(
+                group = entry.group,
+                expanded = expanded,
+                onToggle = { onToggleGroup(entry.group.id) },
+                buttonHeight = buttonHeight,
+                buttonPadding = buttonPadding,
+            )
+    }
+}
+
+@Composable
+private fun GroupButton(
+    group: AccessoryKeyGroup,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    buttonHeight: Dp,
+    buttonPadding: PaddingValues,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    ChuButton(
+        onClick = onToggle,
+        variant = if (expanded) ChuButtonVariant.Filled else ChuButtonVariant.Outlined,
+        modifier = Modifier.height(buttonHeight),
+        contentPadding = buttonPadding,
+    ) {
+        ChuText(
+            group.label,
+            style = typography.label,
+            color = if (expanded) colors.onAccent else colors.textPrimary,
         )
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalAccessory.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalAccessory.kt
@@ -111,6 +111,27 @@ data class AccessoryKeyItem(
     val action: AccessoryAction,
 )
 
+data class AccessoryKeyGroup(
+    val id: String,
+    val label: String,
+    val children: List<AccessoryKeyItem>,
+)
+
+sealed interface ResolvedAccessoryEntry {
+    val id: String
+    val label: String
+
+    data class Single(val item: AccessoryKeyItem) : ResolvedAccessoryEntry {
+        override val id: String get() = item.id
+        override val label: String get() = item.label
+    }
+
+    data class Group(val group: AccessoryKeyGroup) : ResolvedAccessoryEntry {
+        override val id: String get() = group.id
+        override val label: String get() = group.label
+    }
+}
+
 data class AccessoryDispatchResult(
     val modifierState: ModifierState,
     val text: String? = null,
@@ -184,7 +205,22 @@ object TerminalAccessoryLayoutStore {
         AccessoryKeyItem("paste", "Paste", AccessoryAction.Paste),
     )
 
+    private val compositeGroups: List<AccessoryKeyGroup> = listOf(
+        AccessoryKeyGroup(
+            id = "digits",
+            label = "0-9",
+            children = (0..9).map { d ->
+                AccessoryKeyItem(
+                    id = "digit_$d",
+                    label = d.toString(),
+                    action = AccessoryAction.SendText(d.toString()),
+                )
+            },
+        ),
+    )
+
     private val catalogById: Map<String, AccessoryKeyItem> = catalogItems.associateBy { it.id }
+    private val compositeGroupById: Map<String, AccessoryKeyGroup> = compositeGroups.associateBy { it.id }
 
     private val defaultLayoutIds: List<String> = listOf(
         "escape",
@@ -201,31 +237,31 @@ object TerminalAccessoryLayoutStore {
         "space",
     )
 
-    fun defaultLayout(): List<AccessoryKeyItem> = resolveLayout(defaultLayoutIds)
+    fun defaultEntries(): List<ResolvedAccessoryEntry> = resolveSelectedLayout(defaultLayoutIds)
 
     fun defaultLayoutIds(): List<String> = defaultLayoutIds
 
     fun catalog(): List<AccessoryKeyItem> = catalogItems
 
-    fun resolveSelectedLayout(ids: List<String>): List<AccessoryKeyItem> =
-        normalizeIds(ids).mapNotNull(catalogById::get)
+    fun compositeGroups(): List<AccessoryKeyGroup> = compositeGroups
+
+    fun allCatalogEntries(): List<ResolvedAccessoryEntry> =
+        compositeGroups.map { ResolvedAccessoryEntry.Group(it) } +
+            catalogItems.map { ResolvedAccessoryEntry.Single(it) }
+
+    fun resolveSelectedLayout(ids: List<String>): List<ResolvedAccessoryEntry> =
+        normalizeIds(ids).mapNotNull { id ->
+            catalogById[id]?.let { ResolvedAccessoryEntry.Single(it) }
+                ?: compositeGroupById[id]?.let { ResolvedAccessoryEntry.Group(it) }
+        }
 
     fun normalizeIds(ids: List<String>): List<String> {
         val seen = LinkedHashSet<String>()
         ids.forEach { id ->
-            if (catalogById.containsKey(id)) {
+            if (catalogById.containsKey(id) || compositeGroupById.containsKey(id)) {
                 seen += id
             }
         }
         return seen.toList()
-    }
-
-    private fun resolveLayout(ids: List<String>): List<AccessoryKeyItem> {
-        val resolved = ids.mapNotNull(catalogById::get)
-        return if (resolved.isEmpty()) {
-            defaultLayoutIds.mapNotNull(catalogById::get)
-        } else {
-            resolved
-        }
     }
 }

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/AccessoryLogicTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/AccessoryLogicTest.kt
@@ -215,14 +215,21 @@ class AccessoryLogicTest {
     // ── Layout store ──────────────────────────────────────────────────────
 
     @Test
-    fun `defaultLayout includes expected keys`() {
-        val layout = TerminalAccessoryLayoutStore.defaultLayout()
+    fun `defaultEntries includes expected keys`() {
+        val layout = TerminalAccessoryLayoutStore.defaultEntries()
         val ids = layout.map { it.id }
         assertTrue("escape" in ids)
         assertTrue("up" in ids)
         assertTrue("down" in ids)
         assertTrue("ctrl" in ids)
         assertTrue("cmd" in ids)
+    }
+
+    @Test
+    fun `defaultEntries does not include the digits group by default`() {
+        val layout = TerminalAccessoryLayoutStore.defaultEntries()
+        val ids = layout.map { it.id }
+        assertFalse("digits" in ids)
     }
 
     @Test
@@ -234,20 +241,67 @@ class AccessoryLogicTest {
     }
 
     @Test
-    fun `resolveSelectedLayout returns items for valid ids`() {
-        val items = TerminalAccessoryLayoutStore.resolveSelectedLayout(
+    fun `normalizeIds keeps composite group ids`() {
+        val result = TerminalAccessoryLayoutStore.normalizeIds(
+            listOf("digits", "escape", "digits", "bogus"),
+        )
+        assertEquals(listOf("digits", "escape"), result)
+    }
+
+    @Test
+    fun `resolveSelectedLayout returns entries for valid ids`() {
+        val entries = TerminalAccessoryLayoutStore.resolveSelectedLayout(
             listOf("escape", "ctrl", "up"),
         )
-        assertEquals(3, items.size)
-        assertEquals("escape", items[0].id)
-        assertEquals("ctrl", items[1].id)
-        assertEquals("up", items[2].id)
+        assertEquals(3, entries.size)
+        assertEquals("escape", entries[0].id)
+        assertEquals("ctrl", entries[1].id)
+        assertEquals("up", entries[2].id)
+        assertTrue(entries.all { it is ResolvedAccessoryEntry.Single })
+    }
+
+    @Test
+    fun `resolveSelectedLayout returns a Group entry for a composite id`() {
+        val entries = TerminalAccessoryLayoutStore.resolveSelectedLayout(listOf("digits"))
+        assertEquals(1, entries.size)
+        val group = entries.first()
+        assertTrue("digits must resolve to a Group", group is ResolvedAccessoryEntry.Group)
+        assertEquals("0-9", group.label)
     }
 
     @Test
     fun `resolveSelectedLayout with empty list returns empty`() {
-        val items = TerminalAccessoryLayoutStore.resolveSelectedLayout(emptyList())
-        assertTrue(items.isEmpty())
+        val entries = TerminalAccessoryLayoutStore.resolveSelectedLayout(emptyList())
+        assertTrue(entries.isEmpty())
+    }
+
+    // ── Composite groups ──────────────────────────────────────────────────
+
+    @Test
+    fun `compositeGroups exposes digits`() {
+        val ids = TerminalAccessoryLayoutStore.compositeGroups().map { it.id }
+        assertTrue("digits" in ids)
+    }
+
+    @Test
+    fun `digits group has ten children 0 through 9`() {
+        val digits = TerminalAccessoryLayoutStore.compositeGroups().first { it.id == "digits" }
+        assertEquals(10, digits.children.size)
+        val labels = digits.children.joinToString("") { it.label }
+        assertEquals("0123456789", labels)
+        digits.children.forEach { child ->
+            val text = (child.action as? AccessoryAction.SendText)?.text
+            assertEquals(child.label, text)
+        }
+    }
+
+    @Test
+    fun `allCatalogEntries includes singles and groups`() {
+        val entries = TerminalAccessoryLayoutStore.allCatalogEntries()
+        val hasSingle = entries.any { it is ResolvedAccessoryEntry.Single }
+        val hasGroup = entries.any { it is ResolvedAccessoryEntry.Group }
+        assertTrue("catalog must include single keys", hasSingle)
+        assertTrue("catalog must include composite groups", hasGroup)
     }
 
     // ── Paste action convenience ──────────────────────────────────────────


### PR DESCRIPTION

Closes #48 

<img width="410" height="892" alt="image" src="https://github.com/user-attachments/assets/3981fd37-d91a-4d75-a2a6-269699c69cc3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard accessory bar now supports expandable entry groups for improved key organization and navigation

* **Improvements**
  * Refactored accessory settings UI to display and configure grouped entries more intuitively
  * Added visual indicators for grouped entries (e.g., "group · N keys" labels in settings and previews)
  * Enhanced terminal screen accessory handling to work seamlessly with grouped layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->