### PR TITLE
fix: handle leading whitespace in zmx session list

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexer.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexer.kt
@@ -15,7 +15,7 @@ object ZmxMultiplexer : Multiplexer {
         output
             .lineSequence()
             .mapNotNull { line ->
-                val trimmed = line.trimEnd('\r')
+                val trimmed = line.trim()
                 if (trimmed.isBlank()) return@mapNotNull null
                 val fields = trimmed
                     .split('\t')

--- a/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexerTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/ZmxMultiplexerTest.kt
@@ -66,4 +66,20 @@ class ZmxMultiplexerTest {
             sessions,
         )
     }
+
+    @Test
+    fun parsesSessionListWithLeadingAndTrailingWhitespace() {
+        val sessions = ZmxMultiplexer.parseSessions(
+            "  name=main\tpid=123\tclients=1\tcreated=0\tstart_dir=/tmp\n " +
+                    "  name=work\tpid=456\tclients=0\tcreated=1\n ",
+        )
+
+        assertEquals(
+            listOf(
+                RemoteMultiplexerSession(name = "main", attached = true),
+                RemoteMultiplexerSession(name = "work", attached = false),
+            ),
+            sessions,
+        )
+    }
 }


### PR DESCRIPTION
My copy of zmx (0.6.0 on mac) has leading whitespace on each line of `zmx list`, so the Multiplexer sessions list shows as empty

```
  name=chuchu-1	pid=19053	clients=1	created=1782147173	start_dir=/Users/tom.edge
  name=chuchu-2	pid=20305	clients=1	created=1782147454	start_dir=/Users/tom.edge
  name=chuchu-3	pid=27950	clients=0	created=1782148770	start_dir=/Users/tom.edge
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session parsing now robustly handles leading and trailing whitespace in session data entries, improving compatibility with various data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->