### PR TITLE
fix: correct terminal mouse action encoding

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalMouseProtocol.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalMouseProtocol.kt
@@ -1,8 +1,8 @@
 package com.jossephus.chuchu.service.terminal
 
 object TerminalMouseAction {
-    const val Release = 0
-    const val Press = 1
+    const val Press = 0
+    const val Release = 1
     const val Motion = 2
 }
 

--- a/android/app/src/test/java/com/jossephus/chuchu/service/terminal/TerminalMouseProtocolTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/terminal/TerminalMouseProtocolTest.kt
@@ -1,0 +1,14 @@
+package com.jossephus.chuchu.service.terminal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TerminalMouseProtocolTest {
+    @Test
+    fun actionAndButtonValuesMatchGhosttyAbi() {
+        assertEquals(0, TerminalMouseAction.Press)
+        assertEquals(1, TerminalMouseAction.Release)
+        assertEquals(2, TerminalMouseAction.Motion)
+        assertEquals(1, TerminalMouseButton.Left)
+    }
+}


### PR DESCRIPTION
## Summary

- correct the Kotlin mouse action constants to match Ghostty's `press = 0`, `release = 1`, `motion = 2` ABI
- restore proper press-then-release encoding for terminal mouse clicks and app-owned drag gestures
- add a focused regression test for the mirrored mouse action and button values

## Root cause

`nativeEncodeMouse` converts the Kotlin action integer directly to Ghostty's mouse action enum. The Kotlin constants had press and release reversed, so touch taps were emitted as release-then-press. Mouse-aware terminal applications such as Herdr therefore ignored or mishandled finger taps.

## Validation

- `git diff --check`
- `./gradlew app:compileDebugKotlin app:testDebugUnitTest --tests com.jossephus.chuchu.service.terminal.TerminalMouseProtocolTest`
- clean debug APK assembly and Android lint
- fresh JNI libraries built from this upstream revision for all configured Android ABIs
- verified on an Android device with Herdr: finger taps now activate mouse-driven controls


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected terminal mouse press and release event values for improved compatibility and accurate mouse input handling.

* **Tests**
  * Added coverage to verify terminal mouse actions and button values match the expected protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->