### PR TITLE
feat: smooth stepped pinch zoom for terminal font size

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/CommandPalette.kt
@@ -212,7 +212,7 @@ fun CommandPalette(
                     onTap = {},
                     onPrimaryClick = { _, _ -> },
                     onScroll = { _, _, _ -> },
-                    onZoom = {},
+                    onFontSizeChange = {},
                     onSelectionChanged = {},
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -1248,6 +1248,8 @@ fun TerminalScreen(
                                 TerminalCanvas(
                                     snapshot = snapshot,
                                     fontSizeSp = terminalFontSizeSp,
+                                    minFontSizeSp = SettingsRepository.MIN_TERMINAL_FONT_SIZE,
+                                    maxFontSizeSp = SettingsRepository.MAX_TERMINAL_FONT_SIZE,
                                     cursorColor =
                                         ghosttyTheme?.cursorColor
                                             ?: Color.White.copy(alpha = 0.28f),
@@ -1266,14 +1268,7 @@ fun TerminalScreen(
                                     onPrimaryClick = vm::onPrimaryMouseClick,
                                     onAppSelectionDrag = vm::onAppSelectionDrag,
                                     onScroll = vm::onScroll,
-                                    onZoom = { zoomFactor ->
-                                        terminalFontSizeSp =
-                                            (terminalFontSizeSp * zoomFactor)
-                                                .coerceIn(
-                                                    SettingsRepository.MIN_TERMINAL_FONT_SIZE,
-                                                    SettingsRepository.MAX_TERMINAL_FONT_SIZE,
-                                                )
-                                    },
+                                    onFontSizeChange = { sizeSp -> terminalFontSizeSp = sizeSp },
                                     onSelectionChanged = { state -> selectionState = state },
                                 )
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -308,225 +308,238 @@ fun TerminalCanvas(
                         var lastPointerPos = down.position
                         var autoScrollDir = 0
 
-                        while (true) {
-                            val timeoutMs = (longPressDeadline - lastEventUptime).coerceAtLeast(1L)
-                            val inAutoScrollZone = dragMode == DragMode.ClientSelectionDrag && autoScrollDir != 0
-                            val event = when {
-                                dragMode == DragMode.None && !didScroll && !didPinch && !didDragGesture ->
-                                    withTimeoutOrNull(timeoutMs) { awaitPointerEvent() }
-                                inAutoScrollZone ->
-                                    withTimeoutOrNull(autoScrollIntervalMs) { awaitPointerEvent() }
-                                else -> awaitPointerEvent()
-                            }
+                        try {
+                            while (true) {
+                                val timeoutMs = (longPressDeadline - lastEventUptime).coerceAtLeast(1L)
+                                val inAutoScrollZone = dragMode == DragMode.ClientSelectionDrag && autoScrollDir != 0
+                                val event = when {
+                                    dragMode == DragMode.None && !didScroll && !didPinch && !didDragGesture ->
+                                        withTimeoutOrNull(timeoutMs) { awaitPointerEvent() }
+                                    inAutoScrollZone ->
+                                        withTimeoutOrNull(autoScrollIntervalMs) { awaitPointerEvent() }
+                                    else -> awaitPointerEvent()
+                                }
 
-                            if (event == null) {
-                                if (dragMode == DragMode.None) {
-                                    val s = currentSnapshot.value
-                                    val downPos = toSnapshotSpace(down.position, s)
-                                    if (s.appHandlesSelectionDrag) {
-                                        currentOnAppSelectionDrag.value(TerminalMouseAction.Press, downPos.x, downPos.y)
-                                        currentHaptics.value.performHapticFeedback(
-                                            HapticFeedbackType.LongPress,
-                                        )
-                                        didDragGesture = true
-                                        dragMode = DragMode.AppMouseDrag
-                                    } else if (startSelection(
-                                            s,
-                                            downPos,
-                                            currentCellWidth.value,
-                                            currentCellHeight.value,
-                                            currentOnSelectionChange.value,
-                                        )
-                                    ) {
-                                        currentHaptics.value.performHapticFeedback(
-                                            HapticFeedbackType.LongPress,
-                                        )
-                                        dragMode = DragMode.ClientSelectionDrag
+                                if (event == null) {
+                                    if (dragMode == DragMode.None) {
+                                        val s = currentSnapshot.value
+                                        val downPos = toSnapshotSpace(down.position, s)
+                                        if (s.appHandlesSelectionDrag) {
+                                            currentOnAppSelectionDrag.value(TerminalMouseAction.Press, downPos.x, downPos.y)
+                                            currentHaptics.value.performHapticFeedback(
+                                                HapticFeedbackType.LongPress,
+                                            )
+                                            didDragGesture = true
+                                            dragMode = DragMode.AppMouseDrag
+                                        } else if (startSelection(
+                                                s,
+                                                downPos,
+                                                currentCellWidth.value,
+                                                currentCellHeight.value,
+                                                currentOnSelectionChange.value,
+                                            )
+                                        ) {
+                                            currentHaptics.value.performHapticFeedback(
+                                                HapticFeedbackType.LongPress,
+                                            )
+                                            dragMode = DragMode.ClientSelectionDrag
+                                        }
+                                        continue
+                                    }
+                                    val pos = lastPointerPos
+                                    val depth = if (autoScrollDir > 0) {
+                                        pos.y - (canvasSize.height - currentAutoScrollEdgeZonePx.value)
+                                    } else {
+                                        currentAutoScrollEdgeZonePx.value - pos.y
+                                    }.coerceAtLeast(0f)
+                                    val rows = (depth / currentCellHeight.value).toInt().coerceIn(1, 8)
+                                    scrollDeltaChannel.trySend(
+                                        TerminalScrollDelta(autoScrollDir * rows, pos.x, pos.y),
+                                    )
+                                    continue
+                                }
+
+                                lastEventUptime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
+                                val pressed = event.changes.filter { it.pressed }
+                                if (pressed.isEmpty()) {
+                                    autoScrollDir = 0
+                                    autoScrollingSelection = false
+                                    val releasedDragMode = dragMode
+                                    dragMode = DragMode.None
+                                    if (releasedDragMode == DragMode.AppMouseDrag) {
+                                        val s = currentSnapshot.value
+                                        val releasePos = toSnapshotSpace(lastPointerPos, s)
+                                        currentOnAppSelectionDrag.value(TerminalMouseAction.Release, releasePos.x, releasePos.y)
+                                    }
+                                    if (releasedDragMode != DragMode.None) {
+                                        break
+                                    }
+                                    if (!didScroll && !didPinch && !didDragGesture) {
+                                        val tapTime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
+                                        val s = currentSnapshot.value
+                                        val tapPos = toSnapshotSpace(down.position, s)
+                                        val timeSinceLastTap = tapTime - doubleTapState.lastTime
+                                        val distSinceLastTap = hypot(
+                                            (tapPos.x - doubleTapState.lastPos.x).toDouble(),
+                                            (tapPos.y - doubleTapState.lastPos.y).toDouble(),
+                                        ).toFloat()
+                                        doubleTapState.lastTime = tapTime
+                                        doubleTapState.lastPos = tapPos
+
+                                        if (timeSinceLastTap < currentDoubleTapTimeoutMillis.value &&
+                                            distSinceLastTap < currentDoubleTapSlopPx.value
+                                        ) {
+                                            val cellIdx = s.cellAt(
+                                                tapPos.x,
+                                                tapPos.y,
+                                                currentCellWidth.value,
+                                                currentCellHeight.value,
+                                            )
+                                            if (cellIdx != null) {
+                                                val wordRange = s.wordAt(cellIdx)
+                                                if (wordRange != null) {
+                                                    currentOnSelectionChange.value(TerminalSelection(wordRange.first, wordRange.last))
+                                                    currentHaptics.value.performHapticFeedback(
+                                                        HapticFeedbackType.LongPress,
+                                                    )
+                                                }
+                                            }
+                                        } else {
+                                            if (currentSelectionState.value != null) {
+                                                currentOnSelectionChange.value(null)
+                                            } else {
+                                                currentOnPrimaryClick.value(tapPos.x, tapPos.y)
+                                                currentOnTap.value()
+                                            }
+                                        }
+                                    }
+                                    break
+                                }
+
+                                if (pressed.size >= 2) {
+                                    didPinch = true
+                                    val first = pressed[0].position
+                                    val second = pressed[1].position
+                                    val distance = hypot(
+                                        (first.x - second.x).toDouble(),
+                                        (first.y - second.y).toDouble(),
+                                    ).toFloat()
+                                    if (startPinchDistance == null && distance > 0f) {
+                                        startPinchDistance = distance
+                                        anchorFontSp = currentFontSizeSp.value
+                                        lastSentSp = round(anchorFontSp)
+                                    }
+                                    val startDistance = startPinchDistance
+                                    if (startDistance != null && distance > 0f) {
+                                        val steppedSp = round(anchorFontSp * (distance / startDistance))
+                                            .coerceIn(currentMinFontSizeSp.value, currentMaxFontSizeSp.value)
+                                        if (steppedSp != lastSentSp) {
+                                            currentOnFontSizeChange.value(steppedSp)
+                                            currentHaptics.value.performHapticFeedback(
+                                                HapticFeedbackType.TextHandleMove,
+                                            )
+                                            lastSentSp = steppedSp
+                                        }
+                                    }
+                                    pressed.forEach { change ->
+                                        if (change.position != change.previousPosition) change.consume()
                                     }
                                     continue
                                 }
-                                val pos = lastPointerPos
-                                val depth = if (autoScrollDir > 0) {
-                                    pos.y - (canvasSize.height - currentAutoScrollEdgeZonePx.value)
-                                } else {
-                                    currentAutoScrollEdgeZonePx.value - pos.y
-                                }.coerceAtLeast(0f)
-                                val rows = (depth / currentCellHeight.value).toInt().coerceIn(1, 8)
-                                scrollDeltaChannel.trySend(
-                                    TerminalScrollDelta(autoScrollDir * rows, pos.x, pos.y),
+
+                                startPinchDistance = null
+                                val change = pressed.firstOrNull { it.id == lastSinglePointerId } ?: pressed.first().also {
+                                    lastSinglePointerId = it.id
+                                }
+
+                                // Selection drag takes priority once activated
+                                val s = currentSnapshot.value
+                                val changePos = toSnapshotSpace(change.position, s)
+                                val changePrevPos = toSnapshotSpace(change.previousPosition, s)
+                                val downPos = toSnapshotSpace(down.position, s)
+                                val selectedCell = s.cellAt(
+                                    changePos.x,
+                                    changePos.y,
+                                    currentCellWidth.value,
+                                    currentCellHeight.value,
                                 )
-                                continue
-                            }
-
-                            lastEventUptime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
-                            val pressed = event.changes.filter { it.pressed }
-                            if (pressed.isEmpty()) {
-                                autoScrollDir = 0
-                                autoScrollingSelection = false
-                                val releasedDragMode = dragMode
-                                dragMode = DragMode.None
-                                if (releasedDragMode == DragMode.AppMouseDrag) {
-                                    val s = currentSnapshot.value
-                                    val releasePos = toSnapshotSpace(lastPointerPos, s)
-                                    currentOnAppSelectionDrag.value(TerminalMouseAction.Release, releasePos.x, releasePos.y)
-                                }
-                                if (releasedDragMode != DragMode.None) {
-                                    break
-                                }
-                                if (!didScroll && !didPinch && !didDragGesture) {
-                                    val tapTime = event.changes.maxOfOrNull { it.uptimeMillis } ?: lastEventUptime
-                                    val s = currentSnapshot.value
-                                    val tapPos = toSnapshotSpace(down.position, s)
-                                    val timeSinceLastTap = tapTime - doubleTapState.lastTime
-                                    val distSinceLastTap = hypot(
-                                        (tapPos.x - doubleTapState.lastPos.x).toDouble(),
-                                        (tapPos.y - doubleTapState.lastPos.y).toDouble(),
-                                    ).toFloat()
-                                    doubleTapState.lastTime = tapTime
-                                    doubleTapState.lastPos = tapPos
-
-                                    if (timeSinceLastTap < currentDoubleTapTimeoutMillis.value &&
-                                        distSinceLastTap < currentDoubleTapSlopPx.value
-                                    ) {
-                                        val cellIdx = s.cellAt(
-                                            tapPos.x,
-                                            tapPos.y,
-                                            currentCellWidth.value,
-                                            currentCellHeight.value,
-                                        )
-                                        if (cellIdx != null) {
-                                            val wordRange = s.wordAt(cellIdx)
-                                            if (wordRange != null) {
-                                                currentOnSelectionChange.value(TerminalSelection(wordRange.first, wordRange.last))
-                                                currentHaptics.value.performHapticFeedback(
-                                                    HapticFeedbackType.LongPress,
-                                                )
-                                            }
-                                        }
-                                    } else {
-                                        if (currentSelectionState.value != null) {
-                                            currentOnSelectionChange.value(null)
-                                        } else {
-                                            currentOnPrimaryClick.value(tapPos.x, tapPos.y)
-                                            currentOnTap.value()
-                                        }
+                                if (dragMode == DragMode.AppMouseDrag) {
+                                    lastPointerPos = change.position
+                                    autoScrollDir = 0
+                                    autoScrollingSelection = false
+                                    if (change.position != change.previousPosition) {
+                                        currentOnAppSelectionDrag.value(TerminalMouseAction.Motion, changePos.x, changePos.y)
+                                        change.consume()
                                     }
+                                    continue
                                 }
-                                break
-                            }
+                                if (dragMode == DragMode.ClientSelectionDrag && selectedCell != null) {
+                                    lastPointerPos = change.position
+                                    updateSelectionDrag(
+                                        existing = currentSelectionState.value,
+                                        selectedCell = selectedCell,
+                                        onSelectionChange = currentOnSelectionChange.value,
+                                    )
+                                    autoScrollDir = when {
+                                        change.position.y < currentAutoScrollEdgeZonePx.value -> -1
+                                        change.position.y > canvasSize.height - currentAutoScrollEdgeZonePx.value -> 1
+                                        else -> 0
+                                    }
+                                    autoScrollingSelection = autoScrollDir != 0
+                                    if (change.position != change.previousPosition) {
+                                        change.consume()
+                                    }
+                                    continue
+                                }
 
-                            if (pressed.size >= 2) {
-                                didPinch = true
-                                val first = pressed[0].position
-                                val second = pressed[1].position
-                                val distance = hypot(
-                                    (first.x - second.x).toDouble(),
-                                    (first.y - second.y).toDouble(),
+                                val dragX = changePos.x - changePrevPos.x
+                                val dragY = changePos.y - changePrevPos.y
+                                val movedDistance = hypot(
+                                    (changePos.x - downPos.x).toDouble(),
+                                    (changePos.y - downPos.y).toDouble(),
                                 ).toFloat()
-                                if (startPinchDistance == null && distance > 0f) {
-                                    startPinchDistance = distance
-                                    anchorFontSp = currentFontSizeSp.value
-                                    lastSentSp = round(anchorFontSp)
+                                val abortSlopPx = if (dragMode != DragMode.None) {
+                                    currentTouchSlopPx.value
+                                } else {
+                                    currentLongPressSlopPx.value
                                 }
-                                val startDistance = startPinchDistance
-                                if (startDistance != null && distance > 0f) {
-                                    val steppedSp = round(anchorFontSp * (distance / startDistance))
-                                        .coerceIn(currentMinFontSizeSp.value, currentMaxFontSizeSp.value)
-                                    if (steppedSp != lastSentSp) {
-                                        currentOnFontSizeChange.value(steppedSp)
-                                        currentHaptics.value.performHapticFeedback(
-                                            HapticFeedbackType.TextHandleMove,
-                                        )
-                                        lastSentSp = steppedSp
+                                if (movedDistance > abortSlopPx) {
+                                    didDragGesture = true
+                                    if (currentSelectionState.value != null && !selectionCleared) {
+                                        currentOnSelectionChange.value(null)
+                                        selectionCleared = true
                                     }
                                 }
-                                pressed.forEach { change ->
-                                    if (change.position != change.previousPosition) change.consume()
-                                }
-                                continue
-                            }
-
-                            startPinchDistance = null
-                            val change = pressed.firstOrNull { it.id == lastSinglePointerId } ?: pressed.first().also {
-                                lastSinglePointerId = it.id
-                            }
-
-                            // Selection drag takes priority once activated
-                            val s = currentSnapshot.value
-                            val changePos = toSnapshotSpace(change.position, s)
-                            val changePrevPos = toSnapshotSpace(change.previousPosition, s)
-                            val downPos = toSnapshotSpace(down.position, s)
-                            val selectedCell = s.cellAt(
-                                changePos.x,
-                                changePos.y,
-                                currentCellWidth.value,
-                                currentCellHeight.value,
-                            )
-                            if (dragMode == DragMode.AppMouseDrag) {
-                                lastPointerPos = change.position
                                 autoScrollDir = 0
                                 autoScrollingSelection = false
-                                if (change.position != change.previousPosition) {
-                                    currentOnAppSelectionDrag.value(TerminalMouseAction.Motion, changePos.x, changePos.y)
-                                    change.consume()
+                                val verticalIntent = abs(dragY) > abs(dragX) * 1.2f
+                                if (verticalIntent) {
+                                    dragRemainder += dragY / currentCellHeight.value
                                 }
-                                continue
-                            }
-                            if (dragMode == DragMode.ClientSelectionDrag && selectedCell != null) {
-                                lastPointerPos = change.position
-                                updateSelectionDrag(
-                                    existing = currentSelectionState.value,
-                                    selectedCell = selectedCell,
-                                    onSelectionChange = currentOnSelectionChange.value,
-                                )
-                                autoScrollDir = when {
-                                    change.position.y < currentAutoScrollEdgeZonePx.value -> -1
-                                    change.position.y > canvasSize.height - currentAutoScrollEdgeZonePx.value -> 1
-                                    else -> 0
-                                }
-                                autoScrollingSelection = autoScrollDir != 0
-                                if (change.position != change.previousPosition) {
-                                    change.consume()
-                                }
-                                continue
-                            }
 
-                            val dragX = changePos.x - changePrevPos.x
-                            val dragY = changePos.y - changePrevPos.y
-                            val movedDistance = hypot(
-                                (changePos.x - downPos.x).toDouble(),
-                                (changePos.y - downPos.y).toDouble(),
-                            ).toFloat()
-                            val abortSlopPx = if (dragMode != DragMode.None) {
-                                currentTouchSlopPx.value
-                            } else {
-                                currentLongPressSlopPx.value
-                            }
-                            if (movedDistance > abortSlopPx) {
-                                didDragGesture = true
-                                if (currentSelectionState.value != null && !selectionCleared) {
-                                    currentOnSelectionChange.value(null)
-                                    selectionCleared = true
+                                if (didDragGesture && abs(dragRemainder) >= 1f) {
+                                    val delta = dragRemainder.toInt()
+                                    dragRemainder -= delta
+                                    if (delta != 0) {
+                                        didScroll = true
+                                        scrollDeltaChannel.trySend(TerminalScrollDelta(-delta, changePos.x, changePos.y))
+                                    }
+                                }
+
+                                if (change.position != change.previousPosition) {
+                                    change.consume()
                                 }
                             }
-                            autoScrollDir = 0
+                        } finally {
                             autoScrollingSelection = false
-                            val verticalIntent = abs(dragY) > abs(dragX) * 1.2f
-                            if (verticalIntent) {
-                                dragRemainder += dragY / currentCellHeight.value
-                            }
-
-                            if (didDragGesture && abs(dragRemainder) >= 1f) {
-                                val delta = dragRemainder.toInt()
-                                dragRemainder -= delta
-                                if (delta != 0) {
-                                    didScroll = true
-                                    scrollDeltaChannel.trySend(TerminalScrollDelta(-delta, changePos.x, changePos.y))
-                                }
-                            }
-
-                            if (change.position != change.previousPosition) {
-                                change.consume()
+                            if (dragMode == DragMode.AppMouseDrag) {
+                                val s = currentSnapshot.value
+                                val releasePos = toSnapshotSpace(lastPointerPos, s)
+                                currentOnAppSelectionDrag.value(
+                                    TerminalMouseAction.Release,
+                                    releasePos.x,
+                                    releasePos.y,
+                                )
                             }
                         }
                     }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -45,6 +45,7 @@ import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.hypot
 import kotlin.math.max
+import kotlin.math.round
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withTimeoutOrNull
@@ -71,7 +72,9 @@ fun TerminalCanvas(
     onPrimaryClick: (x: Float, y: Float) -> Unit = { _, _ -> },
     onAppSelectionDrag: (action: Int, x: Float, y: Float) -> Unit = { _, _, _ -> },
     onScroll: (delta: Int, x: Float, y: Float) -> Unit = { _, _, _ -> },
-    onZoom: (zoomFactor: Float) -> Unit = {},
+    minFontSizeSp: Float = 1f,
+    maxFontSizeSp: Float = Float.MAX_VALUE,
+    onFontSizeChange: (sizeSp: Float) -> Unit = {},
     onSelectionChanged: (TerminalSelectionState?) -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -180,7 +183,20 @@ fun TerminalCanvas(
     val currentOnPrimaryClick = rememberUpdatedState(onPrimaryClick)
     val currentOnAppSelectionDrag = rememberUpdatedState(onAppSelectionDrag)
     val currentOnScroll = rememberUpdatedState(onScroll)
-    val currentOnZoom = rememberUpdatedState(onZoom)
+    val currentOnFontSizeChange = rememberUpdatedState(onFontSizeChange)
+    val currentFontSizeSp = rememberUpdatedState(fontSizeSp)
+    val currentMinFontSizeSp = rememberUpdatedState(minFontSizeSp)
+    val currentMaxFontSizeSp = rememberUpdatedState(maxFontSizeSp)
+    val currentCellWidth = rememberUpdatedState(cellWidth)
+    val currentCellHeight = rememberUpdatedState(cellHeight)
+    val currentFitSnapshotToCanvas = rememberUpdatedState(fitSnapshotToCanvas)
+    val currentHaptics = rememberUpdatedState(haptics)
+    val currentTouchSlopPx = rememberUpdatedState(touchSlopPx)
+    val currentLongPressSlopPx = rememberUpdatedState(longPressSlopPx)
+    val currentLongPressTimeoutMillis = rememberUpdatedState(longPressTimeoutMillis)
+    val currentAutoScrollEdgeZonePx = rememberUpdatedState(autoScrollEdgeZonePx)
+    val currentDoubleTapTimeoutMillis = rememberUpdatedState(doubleTapTimeoutMillis)
+    val currentDoubleTapSlopPx = rememberUpdatedState(doubleTapSlopPx)
     val ghosttyBridge = remember { GhosttyBridge() }
 
     var selectionViewportBaseline by remember { mutableStateOf<Int?>(null) }
@@ -261,15 +277,15 @@ fun TerminalCanvas(
             if (!enableGestures) {
                 baseModifier
             } else {
-                baseModifier.pointerInput(cellWidth, cellHeight) {
+                baseModifier.pointerInput(Unit) {
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
                         fun toSnapshotSpace(position: Offset, s: TerminalSnapshot): Offset {
-                            if (!fitSnapshotToCanvas) return position
+                            if (!currentFitSnapshotToCanvas.value) return position
                             val cols = max(s.cols, 1)
                             val rows = max(s.rows, 1)
-                            val contentWidth = cols * cellWidth
-                            val contentHeight = rows * cellHeight
+                            val contentWidth = cols * currentCellWidth.value
+                            val contentHeight = rows * currentCellHeight.value
                             if (contentWidth <= 0f || contentHeight <= 0f) return position
                             val scale = minOf(canvasSize.width / contentWidth, canvasSize.height / contentHeight)
                             if (scale <= 0f) return position
@@ -278,7 +294,9 @@ fun TerminalCanvas(
                             return Offset((position.x - offsetX) / scale, (position.y - offsetY) / scale)
                         }
                         var dragRemainder = 0f
-                        var lastPinchDistance: Float? = null
+                        var startPinchDistance: Float? = null
+                        var anchorFontSp = 0f
+                        var lastSentSp = 0f
                         var didScroll = false
                         var didPinch = false
                         var didDragGesture = false
@@ -286,7 +304,7 @@ fun TerminalCanvas(
                         var lastSinglePointerId = down.id
                         var dragMode = DragMode.None
                         var lastEventUptime = down.uptimeMillis
-                        val longPressDeadline = down.uptimeMillis + longPressTimeoutMillis
+                        val longPressDeadline = down.uptimeMillis + currentLongPressTimeoutMillis.value
                         var lastPointerPos = down.position
                         var autoScrollDir = 0
 
@@ -307,29 +325,33 @@ fun TerminalCanvas(
                                     val downPos = toSnapshotSpace(down.position, s)
                                     if (s.appHandlesSelectionDrag) {
                                         currentOnAppSelectionDrag.value(TerminalMouseAction.Press, downPos.x, downPos.y)
-                                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        currentHaptics.value.performHapticFeedback(
+                                            HapticFeedbackType.LongPress,
+                                        )
                                         didDragGesture = true
                                         dragMode = DragMode.AppMouseDrag
                                     } else if (startSelection(
                                             s,
                                             downPos,
-                                            cellWidth,
-                                            cellHeight,
+                                            currentCellWidth.value,
+                                            currentCellHeight.value,
                                             currentOnSelectionChange.value,
                                         )
                                     ) {
-                                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        currentHaptics.value.performHapticFeedback(
+                                            HapticFeedbackType.LongPress,
+                                        )
                                         dragMode = DragMode.ClientSelectionDrag
                                     }
                                     continue
                                 }
                                 val pos = lastPointerPos
                                 val depth = if (autoScrollDir > 0) {
-                                    pos.y - (canvasSize.height - autoScrollEdgeZonePx)
+                                    pos.y - (canvasSize.height - currentAutoScrollEdgeZonePx.value)
                                 } else {
-                                    autoScrollEdgeZonePx - pos.y
+                                    currentAutoScrollEdgeZonePx.value - pos.y
                                 }.coerceAtLeast(0f)
-                                val rows = (depth / cellHeight).toInt().coerceIn(1, 8)
+                                val rows = (depth / currentCellHeight.value).toInt().coerceIn(1, 8)
                                 scrollDeltaChannel.trySend(
                                     TerminalScrollDelta(autoScrollDir * rows, pos.x, pos.y),
                                 )
@@ -363,13 +385,22 @@ fun TerminalCanvas(
                                     doubleTapState.lastTime = tapTime
                                     doubleTapState.lastPos = tapPos
 
-                                    if (timeSinceLastTap < doubleTapTimeoutMillis && distSinceLastTap < doubleTapSlopPx) {
-                                        val cellIdx = s.cellAt(tapPos.x, tapPos.y, cellWidth, cellHeight)
+                                    if (timeSinceLastTap < currentDoubleTapTimeoutMillis.value &&
+                                        distSinceLastTap < currentDoubleTapSlopPx.value
+                                    ) {
+                                        val cellIdx = s.cellAt(
+                                            tapPos.x,
+                                            tapPos.y,
+                                            currentCellWidth.value,
+                                            currentCellHeight.value,
+                                        )
                                         if (cellIdx != null) {
                                             val wordRange = s.wordAt(cellIdx)
                                             if (wordRange != null) {
                                                 currentOnSelectionChange.value(TerminalSelection(wordRange.first, wordRange.last))
-                                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                currentHaptics.value.performHapticFeedback(
+                                                    HapticFeedbackType.LongPress,
+                                                )
                                             }
                                         }
                                     } else {
@@ -386,28 +417,36 @@ fun TerminalCanvas(
 
                             if (pressed.size >= 2) {
                                 didPinch = true
-                                val s = currentSnapshot.value
-                                val first = toSnapshotSpace(pressed[0].position, s)
-                                val second = toSnapshotSpace(pressed[1].position, s)
+                                val first = pressed[0].position
+                                val second = pressed[1].position
                                 val distance = hypot(
                                     (first.x - second.x).toDouble(),
                                     (first.y - second.y).toDouble(),
                                 ).toFloat()
-                                val previous = lastPinchDistance
-                                if (previous != null && previous > 0f && distance > 0f) {
-                                    val zoomFactor = distance / previous
-                                    if (abs(zoomFactor - 1f) > 0.02f) {
-                                        currentOnZoom.value(zoomFactor)
+                                if (startPinchDistance == null && distance > 0f) {
+                                    startPinchDistance = distance
+                                    anchorFontSp = currentFontSizeSp.value
+                                    lastSentSp = round(anchorFontSp)
+                                }
+                                val startDistance = startPinchDistance
+                                if (startDistance != null && distance > 0f) {
+                                    val steppedSp = round(anchorFontSp * (distance / startDistance))
+                                        .coerceIn(currentMinFontSizeSp.value, currentMaxFontSizeSp.value)
+                                    if (steppedSp != lastSentSp) {
+                                        currentOnFontSizeChange.value(steppedSp)
+                                        currentHaptics.value.performHapticFeedback(
+                                            HapticFeedbackType.TextHandleMove,
+                                        )
+                                        lastSentSp = steppedSp
                                     }
                                 }
-                                lastPinchDistance = distance
                                 pressed.forEach { change ->
                                     if (change.position != change.previousPosition) change.consume()
                                 }
                                 continue
                             }
 
-                            lastPinchDistance = null
+                            startPinchDistance = null
                             val change = pressed.firstOrNull { it.id == lastSinglePointerId } ?: pressed.first().also {
                                 lastSinglePointerId = it.id
                             }
@@ -417,7 +456,12 @@ fun TerminalCanvas(
                             val changePos = toSnapshotSpace(change.position, s)
                             val changePrevPos = toSnapshotSpace(change.previousPosition, s)
                             val downPos = toSnapshotSpace(down.position, s)
-                            val selectedCell = s.cellAt(changePos.x, changePos.y, cellWidth, cellHeight)
+                            val selectedCell = s.cellAt(
+                                changePos.x,
+                                changePos.y,
+                                currentCellWidth.value,
+                                currentCellHeight.value,
+                            )
                             if (dragMode == DragMode.AppMouseDrag) {
                                 lastPointerPos = change.position
                                 autoScrollDir = 0
@@ -436,8 +480,8 @@ fun TerminalCanvas(
                                     onSelectionChange = currentOnSelectionChange.value,
                                 )
                                 autoScrollDir = when {
-                                    change.position.y < autoScrollEdgeZonePx -> -1
-                                    change.position.y > canvasSize.height - autoScrollEdgeZonePx -> 1
+                                    change.position.y < currentAutoScrollEdgeZonePx.value -> -1
+                                    change.position.y > canvasSize.height - currentAutoScrollEdgeZonePx.value -> 1
                                     else -> 0
                                 }
                                 autoScrollingSelection = autoScrollDir != 0
@@ -453,7 +497,11 @@ fun TerminalCanvas(
                                 (changePos.x - downPos.x).toDouble(),
                                 (changePos.y - downPos.y).toDouble(),
                             ).toFloat()
-                            val abortSlopPx = if (dragMode != DragMode.None) touchSlopPx else longPressSlopPx
+                            val abortSlopPx = if (dragMode != DragMode.None) {
+                                currentTouchSlopPx.value
+                            } else {
+                                currentLongPressSlopPx.value
+                            }
                             if (movedDistance > abortSlopPx) {
                                 didDragGesture = true
                                 if (currentSelectionState.value != null && !selectionCleared) {
@@ -465,7 +513,7 @@ fun TerminalCanvas(
                             autoScrollingSelection = false
                             val verticalIntent = abs(dragY) > abs(dragX) * 1.2f
                             if (verticalIntent) {
-                                dragRemainder += dragY / cellHeight
+                                dragRemainder += dragY / currentCellHeight.value
                             }
 
                             if (didDragGesture && abs(dragRemainder) >= 1f) {


### PR DESCRIPTION
## Problem

Pinch-to-zoom on the terminal canvas felt broken: one erratic jump per grip, then the gesture went dead until fingers were lifted and re-pressed. Three compounding causes:

- The gesture `pointerInput` is keyed on `cellWidth`/`cellHeight`, so the first committed font change restarted the gesture coroutine mid-pinch — the restarted handler sits in `awaitFirstDown` and never sees the still-pressed fingers.
- Zoom committed a fractional font size (e.g. 13.4sp) on every pinch frame past a 2% dead-zone — each commit recreating paints and triggering a PTY resize.
- The dead-zone discarded sub-threshold movement while still updating the reference distance, so tracking was lossy.

## Change

- **Anchored absolute zoom**: record start distance + start font size when the 2-pointer phase begins; target size = anchor × spread ratio. No per-frame compounding, no dead-zone.
- **Whole-sp steps**: the target is rounded to integer sp and clamped, so text re-renders crisply a handful of times per gesture (with a subtle `TextHandleMove` haptic tick per step) instead of every frame — terminal-native feel, like Ctrl+= / Ctrl+- on desktop.
- **Gesture survives steps**: `pointerInput(Unit)` + `rememberUpdatedState` holders for every mutable value read inside the handler, so committed steps no longer cancel the in-flight pinch. Pinch distance is measured in raw canvas coordinates so it stays independent of cell metrics.
- **API**: `TerminalCanvas` now takes `minFontSizeSp`/`maxFontSizeSp` and exposes `onFontSizeChange(sizeSp)` (absolute, pre-stepped, pre-clamped) instead of the relative `onZoom(zoomFactor)` — call-site lambdas reduce to a plain assignment.

No changes to persistence or settings; the existing `SettingsRepository` font bounds are passed through. Single-pointer gestures (tap, long-press selection, drag, scroll) untouched.

Verified on-device (Android tablet): continuous pinch from 14sp to 30sp in one motion, crisp text at every step, single-finger gestures unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01634UryFkSv94cq7S4WD6vq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pinch-to-zoom for adjusting terminal text size.
  - Terminal text size now enforces configured minimum and maximum limits.
  - Font-size adjustments are applied directly and include haptic feedback when changed.

- **Bug Fixes**
  - Improved gesture handling so terminal interactions consistently use the latest sizing and settings during gestures.
  - Preserved selection, dragging, auto-scroll, and double-tap behavior with more responsive hit-testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->