### PR TITLE
fix: handle large Mosh output events

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/mosh/NativeMoshService.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/mosh/NativeMoshService.kt
@@ -41,6 +41,12 @@ enum class MoshState(val code: Int) {
 class NativeMoshService(
     private val bridge: NativeMoshBridge = NativeMoshBridge(),
 ) : Closeable {
+    private companion object {
+        const val INITIAL_OUTPUT_BUFFER_SIZE = 4096
+        const val MAX_OUTPUT_BUFFER_SIZE = 1024 * 1024
+        const val OUTPUT_BUFFER_TOO_SMALL = 6
+    }
+
     private var handle: Long = 0L
     private val outputMeta = LongArray(5)
     private val stateBuf = LongArray(7)
@@ -81,20 +87,28 @@ class NativeMoshService(
     /// Poll one output event. Returns null if no event is queued.
     fun pollOutput(): MoshOutputEvent? {
         if (handle == 0L) return null
-        val buf = ByteArray(4096)
-        val rc = bridge.nativePollOutput(handle, buf, outputMeta)
-        if (rc != 0) return null
-        val eventType = outputMeta[0].toInt()
-        if (eventType == 0) return null // MOSH_EVENT_NONE
-        val written = outputMeta[1].toInt()
-        val payload = if (written > 0) buf.copyOfRange(0, written) else ByteArray(0)
-        return MoshOutputEvent(
-            eventType = eventType,
-            payload = payload,
-            cols = outputMeta[2].toInt(),
-            rows = outputMeta[3].toInt(),
-            echoAck = outputMeta[4],
-        )
+        var capacity = INITIAL_OUTPUT_BUFFER_SIZE
+        while (true) {
+            val buf = ByteArray(capacity)
+            val rc = bridge.nativePollOutput(handle, buf, outputMeta)
+            if (rc == OUTPUT_BUFFER_TOO_SMALL && capacity < MAX_OUTPUT_BUFFER_SIZE) {
+                capacity = (capacity * 2).coerceAtMost(MAX_OUTPUT_BUFFER_SIZE)
+                continue
+            }
+            check(rc == 0) { "Failed to poll mosh output (error $rc, buffer $capacity bytes)" }
+
+            val eventType = outputMeta[0].toInt()
+            if (eventType == 0) return null // MOSH_EVENT_NONE
+            val written = outputMeta[1].toInt()
+            val payload = if (written > 0) buf.copyOfRange(0, written) else ByteArray(0)
+            return MoshOutputEvent(
+                eventType = eventType,
+                payload = payload,
+                cols = outputMeta[2].toInt(),
+                rows = outputMeta[3].toInt(),
+                echoAck = outputMeta[4],
+            )
+        }
     }
 
     fun pollState(): MoshRuntimeState? {


### PR DESCRIPTION
## Summary

- retry Mosh output polling with progressively larger buffers when the native core reports `output_buffer_too_small`
- cap output allocation growth at 1 MiB
- surface unexpected native polling errors instead of silently treating them as an empty queue

## Root cause

`NativeMoshService.pollOutput()` always supplied a 4 KiB buffer. When a full-screen TUI produced a larger host-bytes event, the native Mosh core re-queued that event at the front and returned `output_buffer_too_small`. Kotlin treated every non-zero result as "no output", so that same event permanently blocked all later display updates while network pumping and input remained alive.

## Verification

Reproduced on an OPPO Pad Mini over Mosh using a tmux workload that repainted more than 4 KiB per frame:

- before: the remote tmux frame advanced while the tablet terminal region remained pixel-identical
- after: the tablet continuously repainted across repeated captures with no Mosh polling or read-loop errors

Also passed:

- `app:compileDebugKotlin`
- `app:testDebugUnitTest`
- `app:assembleDebug`
- `app:lintDebug`
- APK native library packaging check for `lib/arm64-v8a/libchuchu_jni.so`

Closes #66.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large connection output by dynamically expanding the output buffer.
  * Prevented valid events from being dropped when the initial buffer is too small.
  * Correctly ignores empty events while continuing to process available output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->