### PR TITLE
feat: add keep screen awake option for terminal sessions

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
@@ -53,6 +53,9 @@ class SettingsRepository(context: Context) {
     private val _localShellEnabled = MutableStateFlow(prefs.getBoolean(KEY_LOCAL_SHELL_ENABLED, true))
     val localShellEnabled: StateFlow<Boolean> = _localShellEnabled.asStateFlow()
 
+    private val _keepScreenAwake = MutableStateFlow(prefs.getBoolean(KEY_KEEP_SCREEN_AWAKE, false))
+    val keepScreenAwake: StateFlow<Boolean> = _keepScreenAwake.asStateFlow()
+
     private val _terminalTabMode = MutableStateFlow(
         parseTabMode(prefs.getString(KEY_TAB_MODE, TerminalTabMode.Classic.name)),
     )
@@ -131,6 +134,11 @@ class SettingsRepository(context: Context) {
         _localShellEnabled.value = enabled
     }
 
+    fun setKeepScreenAwake(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_KEEP_SCREEN_AWAKE, enabled).apply()
+        _keepScreenAwake.value = enabled
+    }
+
     fun setThemeMode(mode: ThemeMode) {
         prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
         _themeMode.value = mode
@@ -193,6 +201,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_APP_LOCK_ENABLED = "app_lock_enabled"
         private const val KEY_REQUIRE_AUTH_ON_CONNECT = "require_auth_on_connect"
         private const val KEY_LOCAL_SHELL_ENABLED = "local_shell_enabled"
+        private const val KEY_KEEP_SCREEN_AWAKE = "keep_screen_awake"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_LIGHT_THEME = "light_theme_name"
         private const val KEY_TERMINAL_FONT_SIZE = "terminal_font_size_sp"

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -127,6 +127,7 @@ fun ApplicationNavController() {
             val builtinShortcuts by settingsRepo.builtinShortcuts.collectAsStateWithLifecycle()
             val tabMode by settingsRepo.terminalTabMode.collectAsStateWithLifecycle()
             val localShellEnabled by settingsRepo.localShellEnabled.collectAsStateWithLifecycle()
+            val keepScreenAwake by settingsRepo.keepScreenAwake.collectAsStateWithLifecycle()
             val themeMode by settingsRepo.themeMode.collectAsStateWithLifecycle()
             val terminalFontSize by settingsRepo.terminalFontSize.collectAsStateWithLifecycle()
             val lightThemeName by settingsRepo.lightThemeName.collectAsStateWithLifecycle()
@@ -136,6 +137,7 @@ fun ApplicationNavController() {
                 appLockEnabled = appLockEnabled,
                 requireAuthOnConnect = requireAuthOnConnect,
                 localShellEnabled = localShellEnabled,
+                keepScreenAwake = keepScreenAwake,
                 currentAccessoryLayoutIds = accessoryLayoutIds,
                 accessoryBarSingleRow = accessoryBarSingleRow,
                 currentTerminalCustomKeyGroups = customKeyGroups,
@@ -154,6 +156,7 @@ fun ApplicationNavController() {
                 onAppLockEnabledChanged = settingsRepo::setAppLockEnabled,
                 onRequireAuthOnConnectChanged = settingsRepo::setRequireAuthOnConnect,
                 onLocalShellEnabledChanged = settingsRepo::setLocalShellEnabled,
+                onKeepScreenAwakeChanged = settingsRepo::setKeepScreenAwake,
                 onAccessoryLayoutChanged = settingsRepo::setAccessoryLayoutIds,
                 onAccessoryBarSingleRowChanged = settingsRepo::setAccessoryBarSingleRow,
                 currentTerminalFontSize = terminalFontSize,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ fun SettingsScreen(
     appLockEnabled: Boolean,
     requireAuthOnConnect: Boolean,
     localShellEnabled: Boolean,
+    keepScreenAwake: Boolean,
     currentAccessoryLayoutIds: List<String>,
     accessoryBarSingleRow: Boolean,
     currentTerminalCustomKeyGroups: List<TerminalCustomKeyGroup>,
@@ -64,6 +65,7 @@ fun SettingsScreen(
     onAppLockEnabledChanged: (Boolean) -> Unit,
     onRequireAuthOnConnectChanged: (Boolean) -> Unit,
     onLocalShellEnabledChanged: (Boolean) -> Unit,
+    onKeepScreenAwakeChanged: (Boolean) -> Unit,
     onAccessoryLayoutChanged: (List<String>) -> Unit,
     onAccessoryBarSingleRowChanged: (Boolean) -> Unit,
     currentTerminalFontSize: Float = 14f,
@@ -187,6 +189,8 @@ fun SettingsScreen(
                         onTabModeChanged = onTabModeChanged,
                         localShellEnabled = localShellEnabled,
                         onLocalShellEnabledChanged = onLocalShellEnabledChanged,
+                        keepScreenAwake = keepScreenAwake,
+                        onKeepScreenAwakeChanged = onKeepScreenAwakeChanged,
                     )
                 }
             }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
@@ -93,6 +93,8 @@ internal fun TerminalSettings(
     onTabModeChanged: (TerminalTabMode) -> Unit = {},
     localShellEnabled: Boolean = false,
     onLocalShellEnabledChanged: (Boolean) -> Unit = {},
+    keepScreenAwake: Boolean = false,
+    onKeepScreenAwakeChanged: (Boolean) -> Unit = {},
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
@@ -483,6 +485,33 @@ internal fun TerminalSettings(
                 ChuSwitch(
                     checked = localShellEnabled,
                     onCheckedChange = onLocalShellEnabledChanged,
+                )
+            }
+        }
+
+        ChuCard(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 48.dp)
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    ChuText("keep screen awake", style = typography.label)
+                    ChuText(
+                        "prevent the display from sleeping while a terminal is open",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+                ChuSwitch(
+                    checked = keepScreenAwake,
+                    onCheckedChange = onKeepScreenAwakeChanged,
                 )
             }
         }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -1,11 +1,13 @@
 package com.jossephus.chuchu.ui.screens.Terminal
 
+import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.webkit.MimeTypeMap
 import android.widget.Toast
@@ -40,6 +42,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +61,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
@@ -332,6 +336,17 @@ fun TerminalScreen(
     val currentTerminalCustomKeyGroups by
         settingsRepo.terminalCustomKeyGroups.collectAsStateWithLifecycle()
     val settingsFontSize by settingsRepo.terminalFontSize.collectAsStateWithLifecycle()
+    val keepScreenAwake by settingsRepo.keepScreenAwake.collectAsStateWithLifecycle()
+    val keepAwakeView = LocalView.current
+    DisposableEffect(keepScreenAwake, keepAwakeView) {
+        val window = (keepAwakeView.context as? Activity)?.window
+        if (keepScreenAwake) {
+            window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
 
     val accessoryLayout =
         remember(currentAccessoryLayoutIds) {


### PR DESCRIPTION
## Summary

Adds an optional setting that keeps the screen on while a terminal session is open, off by default. Today the display follows the system timeout and blanks mid-session even though the session is still live. It is most disruptive over Mosh, where the connection survives but the screen switching off interrupts monitoring.

- `keepScreenAwake` setting in `SettingsRepository`, a SharedPreferences-backed `StateFlow` defaulting to off, following the existing boolean-toggle pattern.
- A `keep screen awake` switch in the TERMINAL settings section, next to the local shell toggle.
- A `DisposableEffect` at the `TerminalScreen` root that adds `FLAG_KEEP_SCREEN_ON` to the Activity window while the setting is on and clears it on dispose.

The scope is "while a terminal is on screen". The effect lives on the terminal screen, so leaving it clears the window flag, and the server list and settings keep the normal timeout. Toggling the setting takes effect immediately. `FLAG_KEEP_SCREEN_ON` needs no permission and is inert while the app is backgrounded.

Closes #68

## Validation

- `zig build -Doptimize=ReleaseSmall jni`
- `./gradlew assembleDebug`
- `./gradlew app:testDebugUnitTest`

Device (Android 16):

- setting on, terminal open, past the system timeout: screen stays on
- back on the server list, wait: screen sleeps
- setting off with a terminal open: screen sleeps
- rotate with a terminal open: screen stays on

No unit test is included: the change is a window flag toggled directly by the setting, with no isolated logic to assert. It is verified by the device checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Keep screen awake” setting for terminal sessions.
  * Users can enable or disable the setting from the app’s Settings screen.
  * When enabled, the display remains awake while a terminal is open.
  * The preference is saved and restored automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->