### PR TITLE
fix: preserve Mosh sessions across network loss

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/mosh/MoshReconnectPolicy.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/mosh/MoshReconnectPolicy.kt
@@ -1,0 +1,25 @@
+package com.jossephus.chuchu.service.mosh
+
+/**
+ * Keeps transient network loss inside the existing Mosh session.
+ *
+ * The server expires before the client declares a prolonged outage fatal, so
+ * timeout-driven recovery does not replace a remote session that is still alive.
+ */
+internal object MoshReconnectPolicy {
+    const val SERVER_NETWORK_TIMEOUT_SECONDS = 30L * 24 * 60 * 60
+    const val CLIENT_NETWORK_TIMEOUT_MS = (SERVER_NETWORK_TIMEOUT_SECONDS + 24 * 60 * 60) * 1_000
+
+    // The bundled client also fails permanently when an unacknowledged state
+    // reaches this count. Keep that guard beyond the network timeout window,
+    // even at the client's normalized minimum retransmit interval.
+    const val CLIENT_MIN_RETRANSMIT_INTERVAL_MS = 50L
+    const val CLIENT_MAX_RETRANSMIT_COUNT =
+        CLIENT_NETWORK_TIMEOUT_MS / CLIENT_MIN_RETRANSMIT_INTERVAL_MS + 1
+
+    fun bootstrapCommand(): String =
+        "env LANG=C.UTF-8 LC_ALL=C.UTF-8 " +
+            "MOSH_SERVER_NETWORK_TMOUT=$SERVER_NETWORK_TIMEOUT_SECONDS " +
+            "PATH=\"/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/opt/local/bin:\$PATH\" " +
+            "mosh-server new -s -c 256"
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicy.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicy.kt
@@ -1,0 +1,16 @@
+package com.jossephus.chuchu.service.terminal
+
+import com.jossephus.chuchu.model.Transport
+
+internal enum class ReadLoopExitAction {
+    Disconnect,
+    RequireManualReconnect,
+    AutomaticReconnect,
+}
+
+internal fun readLoopExitAction(transport: Transport?): ReadLoopExitAction =
+    when (transport) {
+        Transport.LocalShell -> ReadLoopExitAction.Disconnect
+        Transport.Mosh -> ReadLoopExitAction.RequireManualReconnect
+        else -> ReadLoopExitAction.AutomaticReconnect
+    }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -7,6 +7,7 @@ import com.jossephus.chuchu.model.MultiplexerType
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.mosh.MoshBootstrapParser
 import com.jossephus.chuchu.service.mosh.MoshEventType
+import com.jossephus.chuchu.service.mosh.MoshReconnectPolicy
 import com.jossephus.chuchu.service.mosh.MoshState
 import com.jossephus.chuchu.service.mosh.NativeMoshService
 import com.jossephus.chuchu.service.multiplexer.MultiplexerAvailability
@@ -414,13 +415,19 @@ class TerminalSessionEngine(
                 }
             } catch (e: Exception) {
                 Log.e("TerminalSession", "Resize failed", e)
+                val transport = lastConnectionParams?.transport
                 val shouldReconnect =
                     !disconnectRequested &&
                         lastConnectionParams != null &&
-                        lastConnectionParams?.transport != Transport.LocalShell
+                        readLoopExitAction(transport) == ReadLoopExitAction.AutomaticReconnect
                 if (shouldReconnect) {
                     scheduleReconnect("Connection interrupted: ${e.message ?: "resize failed"}")
                 } else {
+                    if (transport == Transport.Mosh) {
+                        readJob?.cancel()
+                        readJob = null
+                        moshService.close()
+                    }
                     _state.value =
                         _state.value.copy(
                             status = SessionStatus.Error,
@@ -643,9 +650,10 @@ class TerminalSessionEngine(
             scope.launch(dispatcher) {
                 val transport = lastConnectionParams?.transport
                 var failed = false
+                var moshFailureCode: Int? = null
                 try {
                     when (transport) {
-                        Transport.Mosh -> startMoshReadLoop()
+                        Transport.Mosh -> moshFailureCode = startMoshReadLoop()
                         Transport.LocalShell -> startLocalShellReadLoop()
                         else -> startSshReadLoop()
                     }
@@ -662,13 +670,25 @@ class TerminalSessionEngine(
                             )
                     }
                 }
-                if (transport == Transport.LocalShell) {
-                    localShellService.close()
-                    if (!disconnectRequested && !failed) {
-                        _state.value = _state.value.copy(status = SessionStatus.Disconnected)
+                when (readLoopExitAction(transport)) {
+                    ReadLoopExitAction.Disconnect -> {
+                        localShellService.close()
+                        if (!disconnectRequested && !failed) {
+                            _state.value = _state.value.copy(status = SessionStatus.Disconnected)
+                        }
                     }
-                } else {
-                    scheduleReconnect("Connection interrupted")
+                    ReadLoopExitAction.RequireManualReconnect -> {
+                        moshService.close()
+                        if (!disconnectRequested) {
+                            val failure = moshFailureCode?.let { " (failure code $it)" }.orEmpty()
+                            _state.value =
+                                _state.value.copy(
+                                    status = SessionStatus.Error,
+                                    error = "Mosh session ended$failure. Reconnect to start a new session.",
+                                )
+                        }
+                    }
+                    ReadLoopExitAction.AutomaticReconnect -> scheduleReconnect("Connection interrupted")
                 }
             }
     }
@@ -724,10 +744,11 @@ class TerminalSessionEngine(
         }
     }
 
-    private suspend fun startMoshReadLoop() {
+    private suspend fun startMoshReadLoop(): Int? {
         Log.d("TerminalSession", "MOSH: read loop started")
         var loopCount = 0
         var lastActivityMs = System.currentTimeMillis()
+        var failureCode: Int? = null
         while (currentCoroutineContext().isActive) {
             loopCount++
 
@@ -783,7 +804,8 @@ class TerminalSessionEngine(
             val runtime = moshService.pollState()
             if (runtime != null) {
                 if (runtime.state == MoshState.Failed.code) {
-                    Log.e("TerminalSession", "MOSH: session FAILED code=${runtime.lastFailureCode}")
+                    failureCode = runtime.lastFailureCode
+                    Log.e("TerminalSession", "MOSH: session FAILED code=$failureCode")
                     break
                 }
             }
@@ -793,6 +815,7 @@ class TerminalSessionEngine(
             delay(idleReadDelayMs(System.currentTimeMillis() - lastActivityMs))
         }
         Log.d("TerminalSession", "MOSH: read loop exited after $loopCount iterations")
+        return failureCode
     }
 
     private suspend fun establishConnection(params: ConnectionParams, username: String) {
@@ -852,7 +875,7 @@ class TerminalSessionEngine(
         )
         // Use exec channel to bypass shell init noise and MOTD.
         // Falls back to shell if the remote server doesn't support exec.
-        val moshCommand = "env LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=\"/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/opt/local/bin:\$PATH\" mosh-server new -s -c 256"
+        val moshCommand = MoshReconnectPolicy.bootstrapCommand()
         val execOpened = runCatching { nativeSsh.openExec(moshCommand) }.getOrDefault(false)
         if (!execOpened) {
             Log.w("TerminalSession", "MOSH: exec channel unavailable, falling back to shell")
@@ -889,6 +912,8 @@ class TerminalSessionEngine(
                                     put("host", result.endpoint.host)
                                     put("port", result.endpoint.port)
                                     put("keyBase64_22", result.endpoint.key)
+                                    put("networkTimeoutMs", MoshReconnectPolicy.CLIENT_NETWORK_TIMEOUT_MS)
+                                    put("maxRetransmitCount", MoshReconnectPolicy.CLIENT_MAX_RETRANSMIT_COUNT)
                                     put("useNetworkCrypto", true)
                                 }
                                 .toString()

--- a/android/app/src/test/java/com/jossephus/chuchu/service/mosh/MoshReconnectPolicyTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/mosh/MoshReconnectPolicyTest.kt
@@ -1,0 +1,36 @@
+package com.jossephus.chuchu.service.mosh
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MoshReconnectPolicyTest {
+    @Test
+    fun serverExpiresBeforeClientAllowsReplacementSession() {
+        val serverTimeoutMs = MoshReconnectPolicy.SERVER_NETWORK_TIMEOUT_SECONDS * 1_000
+
+        assertTrue(MoshReconnectPolicy.CLIENT_NETWORK_TIMEOUT_MS > serverTimeoutMs)
+        assertTrue(MoshReconnectPolicy.CLIENT_NETWORK_TIMEOUT_MS <= 0xFFFF_FFFFL)
+    }
+
+    @Test
+    fun retransmitBudgetOutlivesClientTimeout() {
+        assertTrue(
+            MoshReconnectPolicy.CLIENT_MAX_RETRANSMIT_COUNT *
+                MoshReconnectPolicy.CLIENT_MIN_RETRANSMIT_INTERVAL_MS >
+                MoshReconnectPolicy.CLIENT_NETWORK_TIMEOUT_MS,
+        )
+        assertTrue(MoshReconnectPolicy.CLIENT_MAX_RETRANSMIT_COUNT <= 0xFFFF_FFFFL)
+    }
+
+    @Test
+    fun bootstrapAppliesServerNetworkTimeout() {
+        val command = MoshReconnectPolicy.bootstrapCommand()
+
+        assertTrue(
+            command.contains(
+                "MOSH_SERVER_NETWORK_TMOUT=${MoshReconnectPolicy.SERVER_NETWORK_TIMEOUT_SECONDS}",
+            ),
+        )
+        assertTrue(command.endsWith("mosh-server new -s -c 256"))
+    }
+}

--- a/android/app/src/test/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicyTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicyTest.kt
@@ -1,0 +1,35 @@
+package com.jossephus.chuchu.service.terminal
+
+import com.jossephus.chuchu.model.Transport
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConnectionRecoveryPolicyTest {
+    @Test
+    fun moshFailureRequiresExplicitReconnect() {
+        assertEquals(
+            ReadLoopExitAction.RequireManualReconnect,
+            readLoopExitAction(Transport.Mosh),
+        )
+    }
+
+    @Test
+    fun remoteShellTransportsKeepAutomaticReconnect() {
+        assertEquals(
+            ReadLoopExitAction.AutomaticReconnect,
+            readLoopExitAction(Transport.SSH),
+        )
+        assertEquals(
+            ReadLoopExitAction.AutomaticReconnect,
+            readLoopExitAction(Transport.TailscaleSSH),
+        )
+    }
+
+    @Test
+    fun localShellDisconnectsWithoutRemoteReconnect() {
+        assertEquals(
+            ReadLoopExitAction.Disconnect,
+            readLoopExitAction(Transport.LocalShell),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- keep the existing Mosh client alive through transient network loss instead of replacing its remote session
- set the client timeout to 31 days and size its retransmit budget beyond that window
- set `MOSH_SERVER_NETWORK_TMOUT=2592000` (30 days) so abandoned remote servers eventually clean themselves up
- require an explicit reconnect after a terminal Mosh failure; SSH and Tailscale SSH retain their existing automatic reconnect behavior
- cover timeout ordering and per-transport recovery policy with unit tests

## Root cause

Chuchu pins `zig-mosh-client` at `7ddaa2d`, which is also that repository's current `main`. Its default configuration declares a permanent timeout after 30 seconds without inbound traffic:

- [`network_timeout_ms = 30_000`](https://github.com/jossephus/zig-mosh-client/blob/7ddaa2df217ee2e48106a2c970db4a22403924a8/src/types.zig#L62-L80)
- [`maintenanceTick` transitions the client to `failed`](https://github.com/jossephus/zig-mosh-client/blob/7ddaa2df217ee2e48106a2c970db4a22403924a8/src/core.zig#L462-L471)

Chuchu then treated that failed Mosh read loop like SSH loss and ran its generic reconnect path. That path destroys the local client, executes another `mosh-server new`, and sends the startup/post-connect command again. A backgrounded device, paused VPN, or network switch could therefore accumulate remote Mosh servers and duplicate attached frontends.

## Fix details

The app now supplies a reconnect policy through the dependency's existing JSON configuration:

- server cleanup: 30 days
- client fatal timeout: 31 days, ensuring server cleanup occurs first
- retransmit limit: calculated to outlive the client timeout even at the dependency's normalized minimum retransmit interval

The 30-day server timeout follows the value recommended by the official [`mosh-server` manual](https://github.com/mobile-shell/mosh/blob/master/man/mosh-server.1).

Mosh read-loop and resize failures no longer call the automatic reconnect/bootstrap path. They close the failed local client and surface an error so a new remote session is created only after an explicit user reconnect.

## Validation

- `git diff --check`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`
- independent reconnect-path review confirming no automatic Mosh `mosh-server new` path remains


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Mosh connection stability with tuned network timeouts and retransmission handling.
  * Added clearer recovery behavior when terminal connections fail.
  * Mosh sessions now provide more informative failure details and may require explicit reconnection when automatic recovery is unavailable.
  * Local shell sessions disconnect cleanly, while supported remote connections continue to recover automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->