### PR TITLE
feat: target aarch64 for default ci releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,7 @@ jobs:
           nix develop -c bash -c '
             set -e
             cd zig-src
-            zig build -Doptimize=ReleaseSmall jni
+            zig build -Doptimize=ReleaseSmall -Dtarget=aarch64-linux-android.24 jni
           '
 
       - name: generate release key
@@ -87,6 +87,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           VERSION_CODE: ${{ steps.version.outputs.version_code }}
           VERSION_NAME: ${{ steps.version.outputs.version_name }}
+          ANDROID_ABI_FILTERS: arm64-v8a
         run: |
           nix develop -c bash -c '
             set -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           nix develop -c bash -c '
             set -e
             cd zig-src
-            zig build -Doptimize=ReleaseSmall jni 
+            zig build -Doptimize=ReleaseSmall -Dtarget=aarch64-linux-android.24 jni
           '
 
       - name: generate release key
@@ -71,6 +71,7 @@ jobs:
           VERSION_MAJOR: ${{ steps.version.outputs.major }}
           VERSION_MINOR: ${{ steps.version.outputs.minor }}
           VERSION_PATCH: ${{ steps.version.outputs.patch }}
+          ANDROID_ABI_FILTERS: arm64-v8a
         run: |
           nix develop -c bash -c '
             set -e

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,6 +31,17 @@ android {
         versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: (releaseBase * 1_000)
         versionName = System.getenv("VERSION_NAME") ?: "$major.$minor.$patch"
 
+        System.getenv("ANDROID_ABI_FILTERS")
+            ?.split(',')
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { filters ->
+                ndk {
+                    abiFilters += filters
+                }
+            }
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     }

--- a/zig-src/build.zig
+++ b/zig-src/build.zig
@@ -2,12 +2,29 @@ const std = @import("std");
 const builtin = @import("builtin");
 const ndk = @import("src/ndk.zig");
 
-const build_targets: []const std.Target.Query = &.{
+const default_build_targets: []const std.Target.Query = &.{
     .{ .cpu_arch = .aarch64, .os_tag = .linux, .abi = .android, .android_api_level = 24 },
     .{ .cpu_arch = .arm, .os_tag = .linux, .abi = .androideabi, .android_api_level = 24 },
     .{ .cpu_arch = .x86, .os_tag = .linux, .abi = .android, .android_api_level = 24 },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .android, .android_api_level = 24 },
 };
+
+fn resolveBuildTargets(b: *std.Build) []const std.Target.Query {
+    const maybe_target = b.option(
+        []const u8,
+        "target",
+        "Android target triple (default: all supported ABIs)",
+    ) orelse return default_build_targets;
+
+    var query = std.Target.Query.parse(.{ .arch_os_abi = maybe_target }) catch |err| {
+        std.debug.panic("invalid -Dtarget '{s}': {s}", .{ maybe_target, @errorName(err) });
+    };
+    if (query.android_api_level == null) query.android_api_level = 24;
+
+    const targets = b.allocator.alloc(std.Target.Query, 1) catch @panic("OOM");
+    targets[0] = query;
+    return targets;
+}
 
 fn ndkPrebuiltTag() []const u8 {
     const os_part = switch (builtin.os.tag) {
@@ -158,6 +175,7 @@ fn buildNativeLibrary(
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const build_targets = resolveBuildTargets(b);
     const has_android_ndk = b.graph.env_map.get("ANDROID_NDK_HOME") != null or b.graph.env_map.get("ANDROID_NDK_ROOT") != null;
 
     const native_step = b.step("native", "Build native JNI library");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Android release builds now target ARM64 devices running API level 24.
  * Android packaging supports configurable ABI filters for more controlled release builds.
  * Android builds can target specific architectures while retaining support for the standard ABI set by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->