### PR TITLE
fix: verify the host key in "test connection"

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/ssh/HostKeyStore.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/ssh/HostKeyStore.kt
@@ -7,6 +7,10 @@ import java.security.MessageDigest
 class HostKeyStore(
     private val prefs: SharedPreferences,
 ) {
+    companion object {
+        const val PREFS_NAME = "host_keys"
+    }
+
     fun loadKey(host: String, port: Int, algorithm: String): ByteArray? {
         val encoded = prefs.getString(key(host, port, algorithm), null) ?: return null
         return Base64.decode(encoded, Base64.NO_WRAP)
@@ -17,12 +21,39 @@ class HostKeyStore(
         prefs.edit().putString(key(host, port, algorithm), encoded).apply()
     }
 
-    fun fingerprintSha256(keyBytes: ByteArray): String {
-        val digest = MessageDigest.getInstance("SHA-256").digest(keyBytes)
-        val encoded = Base64.encodeToString(digest, Base64.NO_WRAP)
-        return "SHA256:$encoded"
+    fun check(
+        host: String,
+        port: Int,
+        algorithm: String,
+        keyBytes: ByteArray,
+    ): HostKeyCheck {
+        val existing = loadKey(host, port, algorithm)
+        return when {
+            existing == null -> HostKeyCheck.Unknown(fingerprint = fingerprintSha256(keyBytes))
+            existing.contentEquals(keyBytes) -> HostKeyCheck.Match
+            else ->
+                HostKeyCheck.Changed(
+                    previousFingerprint = fingerprintSha256(existing),
+                    fingerprint = fingerprintSha256(keyBytes),
+                )
+        }
     }
 
     private fun key(host: String, port: Int, algorithm: String): String =
         "$host:$port:$algorithm"
+
+    private fun fingerprintSha256(keyBytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(keyBytes)
+        val encoded = Base64.encodeToString(digest, Base64.NO_WRAP)
+        return "SHA256:$encoded"
+    }
+}
+
+sealed interface HostKeyCheck {
+    data object Match : HostKeyCheck
+    data class Unknown(val fingerprint: String) : HostKeyCheck
+    data class Changed(
+        val previousFingerprint: String,
+        val fingerprint: String,
+    ) : HostKeyCheck
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -14,6 +14,7 @@ import com.jossephus.chuchu.service.multiplexer.MultiplexerAvailability
 import com.jossephus.chuchu.service.multiplexer.MultiplexerCommandResult
 import com.jossephus.chuchu.service.multiplexer.MultiplexerRegistry
 import com.jossephus.chuchu.service.multiplexer.RemoteMultiplexerSession
+import com.jossephus.chuchu.service.ssh.HostKeyCheck
 import com.jossephus.chuchu.service.ssh.HostKeyStore
 import com.jossephus.chuchu.service.ssh.NativeSshService
 import com.jossephus.chuchu.service.ssh.TailscaleStatusChecker
@@ -620,11 +621,12 @@ class TerminalSessionEngine(
         algorithm: String,
         keyBytes: ByteArray,
     ): Boolean {
-        val existing = hostKeyStore.loadKey(host, port, algorithm)
-        if (existing != null && existing.contentEquals(keyBytes)) return true
-
-        val previousFingerprint = existing?.let { hostKeyStore.fingerprintSha256(it) }
-        val fingerprint = hostKeyStore.fingerprintSha256(keyBytes)
+        val (fingerprint, previousFingerprint) =
+            when (val result = hostKeyStore.check(host, port, algorithm, keyBytes)) {
+                is HostKeyCheck.Match -> return true
+                is HostKeyCheck.Unknown -> result.fingerprint to null
+                is HostKeyCheck.Changed -> result.fingerprint to result.previousFingerprint
+            }
         val deferred =
             hostKeyDecision
                 ?: CompletableDeferred<Boolean>().also {

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -39,7 +39,7 @@ class TerminalSessionRepository private constructor(application: Application) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private val hostKeyStore =
-        HostKeyStore(appContext.getSharedPreferences("host_keys", Application.MODE_PRIVATE))
+        HostKeyStore(appContext.getSharedPreferences(HostKeyStore.PREFS_NAME, Application.MODE_PRIVATE))
     private val tailscaleStatusChecker = TailscaleStatusChecker(appContext)
     private val clipboard = appContext.getSystemService(ClipboardManager::class.java)
     private val osc52ClipboardPolicy = Osc52ClipboardPolicy.Deny

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerViewModel.kt
@@ -14,6 +14,7 @@ import com.jossephus.chuchu.model.MultiplexerType
 import com.jossephus.chuchu.model.SshKey
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.ssh.Ed25519KeyGenerator
+import com.jossephus.chuchu.service.ssh.HostKeyCheck
 import com.jossephus.chuchu.service.ssh.HostKeyPolicy
 import com.jossephus.chuchu.service.ssh.HostKeyStore
 import com.jossephus.chuchu.service.ssh.NativeSshService
@@ -49,7 +50,7 @@ class AddServerViewModel(
     private val hostKeyStore =
         HostKeyStore(
             application.applicationContext.getSharedPreferences(
-                "host_keys",
+                HostKeyStore.PREFS_NAME,
                 Application.MODE_PRIVATE,
             ),
         )
@@ -225,18 +226,15 @@ class AddServerViewModel(
                 runCatching {
                     val port = current.port.toIntOrNull() ?: 22
                     val policy = HostKeyPolicy { host, port, algorithm, keyBytes ->
-                        val existing = hostKeyStore.loadKey(host, port, algorithm)
-                        when {
-                            existing == null -> {
+                        when (val result = hostKeyStore.check(host, port, algorithm, keyBytes)) {
+                            is HostKeyCheck.Match -> true
+                            is HostKeyCheck.Unknown -> {
                                 hostKeyError = "host key not verified — connect once to verify this host"
                                 false
                             }
-                            existing.contentEquals(keyBytes) -> true
-                            else -> {
-                                val previousFingerprint = hostKeyStore.fingerprintSha256(existing)
-                                val fingerprint = hostKeyStore.fingerprintSha256(keyBytes)
+                            is HostKeyCheck.Changed -> {
                                 hostKeyError =
-                                    "host key CHANGED ($previousFingerprint → $fingerprint) — connect once to verify this host"
+                                    "host key CHANGED (${result.previousFingerprint} → ${result.fingerprint}) — connect once to verify this host"
                                 false
                             }
                         }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerViewModel.kt
@@ -15,6 +15,7 @@ import com.jossephus.chuchu.model.SshKey
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.ssh.Ed25519KeyGenerator
 import com.jossephus.chuchu.service.ssh.HostKeyPolicy
+import com.jossephus.chuchu.service.ssh.HostKeyStore
 import com.jossephus.chuchu.service.ssh.NativeSshService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,6 +46,13 @@ class AddServerViewModel(
     private val hostRepository = HostRepository(db.hostProfileDao())
     private val sshKeyRepository = SshKeyRepository(db.sshKeyDao())
     private val keyGenerator = Ed25519KeyGenerator()
+    private val hostKeyStore =
+        HostKeyStore(
+            application.applicationContext.getSharedPreferences(
+                "host_keys",
+                Application.MODE_PRIVATE,
+            ),
+        )
 
     private val _form = MutableStateFlow(AddServerForm())
     val form: StateFlow<AddServerForm> = _form.asStateFlow()
@@ -212,23 +220,40 @@ class AddServerViewModel(
         if (username.isBlank()) return
         _testState.value = ConnectionTestState(status = ConnectionTestStatus.Running)
         viewModelScope.launch {
+            var hostKeyError: String? = null
             val result = withContext(Dispatchers.IO) {
                 runCatching {
                     val port = current.port.toIntOrNull() ?: 22
-                    val policy = HostKeyPolicy { _, _, _, _ -> true }
-                    val nativeSsh = NativeSshService(hostKeyPolicy = policy)
-                    check(nativeSsh.isAvailable()) { "Native SSH unavailable" }
-                    nativeSsh.connect(
-                        host = current.host.trim(),
-                        port = port,
-                        username = username,
-                        authMethod = current.authMethod,
-                        password = if (current.authMethod == AuthMethod.Password) current.password else "",
-                        publicKeyOpenSsh = current.publicKeyOpenSsh,
-                        privateKeyPem = current.privateKeyPem,
-                        keyPassphrase = current.keyPassphrase,
-                    )
-                    nativeSsh.close()
+                    val policy = HostKeyPolicy { host, port, algorithm, keyBytes ->
+                        val existing = hostKeyStore.loadKey(host, port, algorithm)
+                        when {
+                            existing == null -> {
+                                hostKeyError = "host key not verified — connect once to verify this host"
+                                false
+                            }
+                            existing.contentEquals(keyBytes) -> true
+                            else -> {
+                                val previousFingerprint = hostKeyStore.fingerprintSha256(existing)
+                                val fingerprint = hostKeyStore.fingerprintSha256(keyBytes)
+                                hostKeyError =
+                                    "host key CHANGED ($previousFingerprint → $fingerprint) — connect once to verify this host"
+                                false
+                            }
+                        }
+                    }
+                    NativeSshService(hostKeyPolicy = policy).use { nativeSsh ->
+                        check(nativeSsh.isAvailable()) { "Native SSH unavailable" }
+                        nativeSsh.connect(
+                            host = current.host.trim(),
+                            port = port,
+                            username = username,
+                            authMethod = current.authMethod,
+                            password = if (current.authMethod == AuthMethod.Password) current.password else "",
+                            publicKeyOpenSsh = current.publicKeyOpenSsh,
+                            privateKeyPem = current.privateKeyPem,
+                            keyPassphrase = current.keyPassphrase,
+                        )
+                    }
                 }
             }
             _testState.value = if (result.isSuccess) {
@@ -236,7 +261,7 @@ class AddServerViewModel(
             } else {
                 ConnectionTestState(
                     status = ConnectionTestStatus.Error,
-                    message = result.exceptionOrNull()?.message ?: "Connection failed",
+                    message = hostKeyError ?: result.exceptionOrNull()?.message ?: "Connection failed",
                 )
             }
         }


### PR DESCRIPTION
### Problem

`[ test connection ]` on the add/edit server screen accepts **any** host key:

```kotlin
// AddServerViewModel.testConnection()
val policy = HostKeyPolicy { _, _, _, _ -> true }
val nativeSsh = NativeSshService(hostKeyPolicy = policy)
```

It then performs a **full authentication** — `password`, `privateKeyPem` and `keyPassphrase` are all
passed to `NativeSshService.connect()`, and `connect()` verifies the host key *before* the auth block.
So against an unverified host, "test connection" transmits the user's credentials to whatever machine
answers that address, and prints a green **Connected** while doing it — which is the moment a user is
most inclined to trust the result.

Reproduced on device against a brand new host: `[ test connection ]` reported "Connected" with no
prompt whatsoever, and the *real* connect afterwards still showed "Verify host key" — proving nothing
had been verified or stored by the test path.

### Change

Verify the offered key against the same `host_keys` store the real connection uses, and fail closed:

- unknown key → `host key not verified — connect once to verify this host`
- **changed** key → says so explicitly, since that is the dangerous case
- known and matching → unchanged, still reports `Connected`

Adding a host-key prompt to the add-server screen is a bigger change and is deliberately **not** part
of this one; failing closed with a clear message is the fix here.

### Verified on device

Oppo Pad Mini, against the same host that previously returned a green "Connected" with no prompt:

- unknown key → red `host key not verified — connect once to verify this host`, and authentication
  never runs
- after trusting the host through the normal connect flow → `[ test connection ]` reports `Connected`
  again as before

Based on `5b059b0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SSH host-key validation during connection testing and terminal sessions.
  - Displays SHA-256 fingerprints when a host key is unknown or has changed.
  - Prompts users to review unknown or changed host keys before continuing.

- **Bug Fixes**
  - Matching host keys are accepted automatically.
  - Host-key validation errors are shown clearly and take priority over generic connection failures.
  - Improved cleanup after connection testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->