### PR TITLE
fix: do not hold an SSH handshake open while the user verifies a host key

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -73,6 +73,7 @@ class TerminalSessionEngine(
     private val localShellService: NativeLocalShellService,
     private val hostKeyStore: HostKeyStore,
     private val tailscaleStatusChecker: TailscaleStatusChecker,
+    private val onHostKeyVerificationRequired: ((HostKeyPrompt, ByteArray) -> Unit)? = null,
 ) {
     private data class ConnectionParams(
         val host: String,
@@ -635,18 +636,24 @@ class TerminalSessionEngine(
                 is HostKeyCheck.Unknown -> result.fingerprint to null
                 is HostKeyCheck.Changed -> result.fingerprint to result.previousFingerprint
             }
+        val prompt =
+            HostKeyPrompt(
+                host = host,
+                port = port,
+                algorithm = algorithm,
+                fingerprint = fingerprint,
+                previousFingerprint = previousFingerprint,
+            )
+        val verificationHandler = onHostKeyVerificationRequired
+        if (verificationHandler != null) {
+            verificationHandler(prompt, keyBytes.copyOf())
+            return false
+        }
         val deferred =
             hostKeyDecision
                 ?: CompletableDeferred<Boolean>().also {
                     hostKeyDecision = it
-                    _hostKeyPrompt.value =
-                        HostKeyPrompt(
-                            host = host,
-                            port = port,
-                            algorithm = algorithm,
-                            fingerprint = fingerprint,
-                            previousFingerprint = previousFingerprint,
-                        )
+                    _hostKeyPrompt.value = prompt
                 }
         val accepted = runBlocking { deferred.await() }
         if (accepted) {

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -10,10 +10,10 @@ import com.jossephus.chuchu.service.multiplexer.RemoteMultiplexerSession
 import com.jossephus.chuchu.service.ssh.HostKeyStore
 import com.jossephus.chuchu.service.ssh.TailscaleStatusChecker
 import java.util.UUID
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,6 +30,19 @@ import kotlinx.coroutines.sync.withLock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TerminalSessionRepository private constructor(application: Application) {
+    private sealed interface PreflightAttempt<out T> {
+        data class Completed<T>(val value: T) : PreflightAttempt<T>
+
+        data class HostKeyVerificationRequired(
+            val verification: PreflightHostKeyVerification,
+        ) : PreflightAttempt<Nothing>
+    }
+
+    private data class PreflightHostKeyVerification(
+        val prompt: HostKeyPrompt,
+        val keyBytes: ByteArray,
+    )
+
     private enum class Osc52ClipboardPolicy {
         Deny,
         AllowActiveForegroundSession,
@@ -72,7 +85,7 @@ class TerminalSessionRepository private constructor(application: Application) {
     private val _preflightHostKeyPrompt = MutableStateFlow<HostKeyPrompt?>(null)
     private val preflightMutex = Mutex()
     private var preflightEngine: TerminalSessionEngine? = null
-    private var preflightPromptJob: Job? = null
+    private var preflightHostKeyDecision: CompletableDeferred<Boolean>? = null
 
     private val activeHostKeyPrompt: StateFlow<HostKeyPrompt?> =
         activeTab
@@ -188,36 +201,75 @@ class TerminalSessionRepository private constructor(application: Application) {
         withPreflightEngine { engine -> engine.listMultiplexerSessions(spec) }
 
     private suspend fun <T> withPreflightEngine(block: suspend (TerminalSessionEngine) -> T): T =
-        preflightMutex.withLock {
-            val engine =
-                TerminalSessionEngine(
-                    {},
-                    scope,
-                    newLocalShellService(),
-                    hostKeyStore,
-                    tailscaleStatusChecker,
-                )
-            preflightEngine = engine
-            val promptJob = scope.launch {
-                engine.hostKeyPrompt.collect { prompt ->
-                    if (preflightEngine === engine) {
-                        _preflightHostKeyPrompt.value = prompt
+        preflightMutex.withLock { runPreflightWithHostKeyRetries(block) }
+
+    private suspend fun <T> runPreflightWithHostKeyRetries(
+        block: suspend (TerminalSessionEngine) -> T,
+    ): T {
+        while (true) {
+            when (val attempt = runPreflightAttempt(block)) {
+                is PreflightAttempt.Completed -> return attempt.value
+                is PreflightAttempt.HostKeyVerificationRequired -> {
+                    if (!awaitPreflightHostKeyDecision(attempt.verification)) {
+                        throw IllegalStateException("Host key rejected")
                     }
+                    val prompt = attempt.verification.prompt
+                    hostKeyStore.saveKey(
+                        prompt.host,
+                        prompt.port,
+                        prompt.algorithm,
+                        attempt.verification.keyBytes,
+                    )
                 }
-            }
-            preflightPromptJob = promptJob
-            return@withLock try {
-                block(engine)
-            } finally {
-                promptJob.cancel()
-                if (preflightEngine === engine) {
-                    preflightEngine = null
-                    if (preflightPromptJob === promptJob) preflightPromptJob = null
-                    _preflightHostKeyPrompt.value = null
-                }
-                engine.dispose()
             }
         }
+    }
+
+    private suspend fun <T> runPreflightAttempt(
+        block: suspend (TerminalSessionEngine) -> T,
+    ): PreflightAttempt<T> {
+        var verification: PreflightHostKeyVerification? = null
+        val engine =
+            TerminalSessionEngine(
+                {},
+                scope,
+                newLocalShellService(),
+                hostKeyStore,
+                tailscaleStatusChecker,
+                onHostKeyVerificationRequired = { prompt, keyBytes ->
+                    verification = PreflightHostKeyVerification(prompt, keyBytes)
+                },
+            )
+        preflightEngine = engine
+        return try {
+            PreflightAttempt.Completed(block(engine))
+        } catch (error: IllegalStateException) {
+            verification?.let { PreflightAttempt.HostKeyVerificationRequired(it) } ?: throw error
+        } finally {
+            // A preflight key check must not retain a live libssh2 session while the
+            // user is deciding whether to trust the key.
+            if (preflightEngine === engine) {
+                preflightEngine = null
+            }
+            engine.dispose()
+        }
+    }
+
+    private suspend fun awaitPreflightHostKeyDecision(
+        verification: PreflightHostKeyVerification,
+    ): Boolean {
+        val decision = CompletableDeferred<Boolean>()
+        preflightHostKeyDecision = decision
+        _preflightHostKeyPrompt.value = verification.prompt
+        return try {
+            decision.await()
+        } finally {
+            if (preflightHostKeyDecision === decision) {
+                preflightHostKeyDecision = null
+            }
+            _preflightHostKeyPrompt.value = null
+        }
+    }
 
     fun openTab(spec: TabSpec): TabSession {
         val id = UUID.randomUUID().toString()
@@ -308,8 +360,8 @@ class TerminalSessionRepository private constructor(application: Application) {
     }
 
     fun disconnect() {
-        preflightPromptJob?.cancel()
-        preflightPromptJob = null
+        preflightHostKeyDecision?.cancel()
+        preflightHostKeyDecision = null
         preflightEngine?.dispose()
         preflightEngine = null
         _preflightHostKeyPrompt.value = null
@@ -393,11 +445,11 @@ class TerminalSessionRepository private constructor(application: Application) {
     }
 
     fun respondToHostKey(accepted: Boolean) {
-        if (_preflightHostKeyPrompt.value != null) {
-            preflightEngine?.respondToHostKey(accepted)
-        } else {
-            activeEngine()?.respondToHostKey(accepted)
+        preflightHostKeyDecision?.let { decision ->
+            decision.complete(accepted)
+            return
         }
+        activeEngine()?.respondToHostKey(accepted)
     }
 
     suspend fun sftpListDirectory(path: String): List<String> =

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -857,16 +857,10 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeAuthentica
             return c.JNI_TRUE;
         }
         if (rc != c.LIBSSH2_ERROR_EAGAIN) {
-            const last_errno = c.libssh2_session_last_errno(ssh_session);
-            logError("Public key memory auth failed rc={} last_errno={}", .{ rc, last_errno });
-            var errmsg_ptr: [*c]const u8 = null;
-            var errmsg_len: c_int = 0;
-            _ = c.libssh2_session_last_error(ssh_session, @ptrCast(&errmsg_ptr), &errmsg_len, 0);
-            if (errmsg_ptr != null and errmsg_len > 0) {
-                setError(session, "Public key memory auth failed (rc={} last_errno={}): {s}", .{ rc, last_errno, errmsg_ptr[0..@intCast(errmsg_len)] });
-            } else {
-                setError(session, "Public key memory auth failed (rc={} last_errno={})", .{ rc, last_errno });
-            }
+            logError("Public key memory auth failed rc={}", .{rc});
+            // userauth_list() can leave an unrelated EAGAIN message behind, so
+            // report the return code from this attempt rather than that stale text.
+            setError(session, "Public key memory auth failed (rc={})", .{rc});
             return c.JNI_FALSE;
         }
         if (nowMs() >= deadline_ms) {


### PR DESCRIPTION
### Problem

On a host with **session persistence = tmux/zmx** whose host key is not yet trusted, the first
connect never completes:

1. `[ connect ]` → "Verify host key" appears → `[ Accept ]`
2. **Nothing happens.** No tab, no tmux session on the server, no login in `last`
3. `[ connect ]` again (key now trusted, no prompt) → connects in ~2s

Reproduced 4/4 on device. The control is telling: the identical flow with session persistence **off**
works — accepting the key connects immediately. So this is specific to the multiplexer pre-flight route.

### Cause

`TerminalSessionEngine.verifyHostKey` parks the SSH thread in `runBlocking { deferred.await() }`
waiting for a human decision, **in the middle of an in-flight libssh2 handshake**. On the multiplexer
route that handshake belongs to a throwaway pre-flight engine created by
`TerminalSessionRepository.withPreflightEngine`, and the half-open session does not survive the wait —
so the attempt dies after the key has been accepted and stored. Holding a handshake open across an
arbitrarily long user interaction is fragile by construction.

### Change

Give the engine an optional host-key verification callback. Only the pre-flight engine sets it; when
set, `verifyHostKey` captures the prompt and the key and **fails the attempt immediately instead of
blocking**. The repository then disposes the engine, asks the user with no live SSH session held,
saves the key on acceptance, and re-runs the pre-flight — which now finds a known key and proceeds.
Rejection fails closed exactly as before, and the interactive (non-multiplexer) tab path keeps its
existing prompt behaviour.

Also stops reporting libssh2's `last_error` alongside a public-key auth failure:
`libssh2_userauth_list()` leaves an unrelated `Waiting for USERAUTH response` EAGAIN message behind,
so the text contradicted the `rc` it was printed with. That cost real debugging time.

### Verified on device

tmux-persistence host, host key never trusted by this install → `[ connect ]` → **one** `[ Accept ]` →
attached tab, session created and attached server-side. Same host once trusted: unchanged.
Persistence-off route: unchanged.

Complementary to (but independent of) the sibling PR that removes the silent drop on this same route.

Based on `5b059b0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host-key verification prompts for previously unknown or changed server keys.
  * Accepted host keys are saved, and connections retry after verification.
  * Improved session reuse and startup command handling for terminal connections.

* **Bug Fixes**
  * Declined host keys now correctly reject connections.
  * Improved public-key authentication failures by reporting the relevant authentication result without potentially stale error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->