### PR TITLE
fix: reattach an existing multiplexer session instead of orphaning it

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/MultiplexerSessionAllocator.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/MultiplexerSessionAllocator.kt
@@ -1,6 +1,28 @@
 package com.jossephus.chuchu.service.multiplexer
 
 object MultiplexerSessionAllocator {
+    private val chuchuSessionRegex = Regex("^chuchu-([1-9][0-9]*)$")
+
+    fun reusableDetachedChuchuSessionName(
+        remoteSessions: Collection<RemoteMultiplexerSession>,
+        localSessionNames: Collection<String>,
+    ): String? {
+        val localNames = localSessionNames.toSet()
+        return remoteSessions
+            .asSequence()
+            .filter { session -> !session.attached && session.name !in localNames }
+            .mapNotNull { session ->
+                chuchuSessionRegex
+                    .matchEntire(session.name)
+                    ?.groupValues
+                    ?.getOrNull(1)
+                    ?.toIntOrNull()
+                    ?.let { index -> session.name to index }
+            }
+            .maxByOrNull { (_, index) -> index }
+            ?.first
+    }
+
     fun nextChuchuSessionName(
         remoteSessions: Collection<RemoteMultiplexerSession>,
         localSessionNames: Collection<String>,

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -13,6 +13,7 @@ import com.jossephus.chuchu.service.mosh.NativeMoshService
 import com.jossephus.chuchu.service.multiplexer.MultiplexerAvailability
 import com.jossephus.chuchu.service.multiplexer.MultiplexerCommandResult
 import com.jossephus.chuchu.service.multiplexer.MultiplexerRegistry
+import com.jossephus.chuchu.service.multiplexer.MultiplexerSessionAllocator
 import com.jossephus.chuchu.service.multiplexer.RemoteMultiplexerSession
 import com.jossephus.chuchu.service.ssh.HostKeyStore
 import com.jossephus.chuchu.service.ssh.NativeSshService
@@ -536,6 +537,7 @@ class TerminalSessionEngine(
     suspend fun resolveMultiplexerSessionName(
         spec: TabSpec,
         localSessionNames: Collection<String>,
+        reuseDetachedChuchuSession: Boolean = false,
     ): String = withContext(dispatcher) {
         val type = spec.multiplexer ?: MultiplexerRegistry.defaultType
         val multiplexer = MultiplexerRegistry.forType(type)
@@ -562,6 +564,12 @@ class TerminalSessionEngine(
         if (existingName != null) {
             if (remoteSessions.any { it.name == existingName }) return@withContext existingName
             throw IllegalStateException("${type.label} session \"$existingName\" is no longer available")
+        }
+        if (reuseDetachedChuchuSession) {
+            MultiplexerSessionAllocator.reusableDetachedChuchuSessionName(
+                remoteSessions = remoteSessions,
+                localSessionNames = localSessionNames,
+            )?.let { return@withContext it }
         }
         multiplexer.defaultSessionName(remoteSessions, localSessionNames)
     }

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -170,13 +170,17 @@ class TerminalSessionRepository private constructor(application: Application) {
         .filter { it.spec.multiplexer == multiplexer }
         .mapNotNull { it.spec.multiplexerSessionName }
 
-    suspend fun resolveMultiplexerSessionName(spec: TabSpec): String = withPreflightEngine { engine ->
+    suspend fun resolveMultiplexerSessionName(
+        spec: TabSpec,
+        reuseDetachedChuchuSession: Boolean = false,
+    ): String = withPreflightEngine { engine ->
         engine.resolveMultiplexerSessionName(
             spec = spec,
             localSessionNames = openMultiplexerSessionNamesForHost(
                 hostId = spec.hostId,
                 multiplexer = spec.multiplexer ?: MultiplexerRegistry.defaultType,
             ),
+            reuseDetachedChuchuSession = reuseDetachedChuchuSession,
         )
     }
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -234,7 +234,14 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         }
         _multiplexerState.value = MultiplexerUiState(reconnectRecovery = reconnectRecovery)
         viewModelScope.launch(Dispatchers.IO) {
-            val result = runCatching { sessionRepository.resolveMultiplexerSessionName(spec) }
+            val result = runCatching {
+                sessionRepository.resolveMultiplexerSessionName(
+                    spec = spec,
+                    reuseDetachedChuchuSession =
+                        preparedAction is PendingMultiplexerAction.Open &&
+                            spec.multiplexerSessionName.isNullOrBlank(),
+                )
+            }
             withContext(Dispatchers.Main) {
                 if (!isCurrentMultiplexerAction(actionGeneration, preparedAction)) return@withContext
                 result.fold(

--- a/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/MultiplexerSessionAllocatorTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/MultiplexerSessionAllocatorTest.kt
@@ -5,6 +5,36 @@ import org.junit.Test
 
 class MultiplexerSessionAllocatorTest {
     @Test
+    fun reusesHighestDetachedChuchuSessionOutsideLocalTabs() {
+        val reusable = MultiplexerSessionAllocator.reusableDetachedChuchuSessionName(
+            remoteSessions = listOf(
+                RemoteMultiplexerSession("chuchu-1", attached = false),
+                RemoteMultiplexerSession("chuchu-2", attached = false),
+                RemoteMultiplexerSession("chuchu-3", attached = false),
+                RemoteMultiplexerSession("chuchu-5", attached = true),
+                RemoteMultiplexerSession("chuchu-7-extra", attached = false),
+            ),
+            localSessionNames = listOf("chuchu-3"),
+        )
+
+        assertEquals("chuchu-2", reusable)
+    }
+
+    @Test
+    fun doesNotReuseAttachedOrLocalChuchuSessions() {
+        val reusable = MultiplexerSessionAllocator.reusableDetachedChuchuSessionName(
+            remoteSessions = listOf(
+                RemoteMultiplexerSession("chuchu-1", attached = true),
+                RemoteMultiplexerSession("chuchu-2", attached = false),
+                RemoteMultiplexerSession("work", attached = false),
+            ),
+            localSessionNames = listOf("chuchu-2"),
+        )
+
+        assertEquals(null, reusable)
+    }
+
+    @Test
     fun skipsUsedRemoteAndLocalNames() {
         val next = MultiplexerSessionAllocator.nextChuchuSessionName(
             remoteSessions = listOf(


### PR DESCRIPTION
### Problem

With **session persistence = tmux**, surviving an app restart is the whole point. It didn't:

- **Warm** reopen (home → relaunch, process alive): correct — same tab, still attached, scrollback intact.
- **Cold** restart (swiped from recents, or an OOM kill): the server list shows `[ connect ]` with no
  hint that a session is waiting. Connecting creates **`chuchu-2`**, a brand-new empty session, and
  leaves `chuchu-1` — with the user's work — detached and orphaned on the server. Repeat, and the
  orphans accumulate.

Verified on device with markers in the session: after `am force-stop`, connecting produced a fresh
empty session while the previous one sat detached.

### Cause

`TerminalSessionEngine.resolveMultiplexerSessionName` only reattaches when `spec.multiplexerSessionName`
is already set, and that lives on the in-memory `TabSpec`, which nothing persists across process death.
So a cold connect falls through to `MultiplexerSessionAllocator.nextChuchuSessionName`, which picks the
lowest **unused** `chuchu-N` — i.e. it deliberately avoids the very session the user wants back.

### Change

Make a plain connect behave like `tmux attach || tmux new`: reuse the highest-numbered `chuchu-N` that
is **detached** remotely and not already open in another tab, and only allocate a fresh name when there
is none. This needs no persistence and no schema change — the remote already reports everything required
(`RemoteMultiplexerSession.attached`, plus the `localSessionNames` the repository already passes in).

Explicit paths are untouched: `+` / `[ dup ]` still create a new session, and `[ attach ]` still attaches
the session you named.

### Verified on device

- one detached `chuchu-1` on the server → connect → **reattaches `chuchu-1`**, scrollback intact
- no chuchu sessions → connect → creates `chuchu-1`
- `chuchu-1` already attached in another tab → `+` → creates a new session, does not steal it
- also survives a real dropped connection: killing the session's `sshd` server-side, the app reconnected
  and reattached within ~3s with scrollback intact

Unit tests added to the existing `MultiplexerSessionAllocatorTest`.

Based on `5b059b0`.
