### PR TITLE
fix: keep IMEs from mangling the host and username fields

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
@@ -90,6 +91,11 @@ fun AddServerScreen(
             label = "Host",
             placeholder = "192.168.1.10",
             singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+            ),
             autoFocus = false,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -99,7 +105,11 @@ fun AddServerScreen(
                 onValueChange = vm::updatePort,
                 label = "Port",
                 singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    capitalization = KeyboardCapitalization.None,
+                    autoCorrectEnabled = false,
+                ),
                 autoFocus = false,
                 modifier = Modifier.weight(0.3f),
             )
@@ -109,6 +119,11 @@ fun AddServerScreen(
                 label = "Username",
                 placeholder = "root",
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Ascii,
+                    capitalization = KeyboardCapitalization.None,
+                    autoCorrectEnabled = false,
+                ),
                 autoFocus = false,
                 modifier = Modifier.weight(0.7f),
             )

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerViewModel.kt
@@ -89,7 +89,7 @@ class AddServerViewModel(
     }
 
     fun updateHost(host: String) {
-        _form.value = _form.value.copy(host = host)
+        _form.value = _form.value.copy(host = host.filterNot { it.isWhitespace() })
     }
 
     fun updatePort(port: String) {
@@ -207,7 +207,8 @@ class AddServerViewModel(
 
     fun testConnection() {
         val current = _form.value
-        if (current.host.isBlank()) return
+        val host = current.host.filterNot { it.isWhitespace() }
+        if (host.isBlank()) return
         val username = current.username.trim()
         if (username.isBlank()) return
         _testState.value = ConnectionTestState(status = ConnectionTestStatus.Running)
@@ -219,7 +220,7 @@ class AddServerViewModel(
                     val nativeSsh = NativeSshService(hostKeyPolicy = policy)
                     check(nativeSsh.isAvailable()) { "Native SSH unavailable" }
                     nativeSsh.connect(
-                        host = current.host.trim(),
+                        host = host,
                         port = port,
                         username = username,
                         authMethod = current.authMethod,
@@ -244,8 +245,9 @@ class AddServerViewModel(
 
     fun save(onComplete: () -> Unit) {
         val current = _form.value
+        val host = current.host.filterNot { it.isWhitespace() }
         val port = current.port.toIntOrNull() ?: 22
-        if (!current.canSave()) return
+        if (!current.canSave() || host.isBlank()) return
         val username = current.username.trim()
         if (username.isBlank()) return
 
@@ -253,7 +255,7 @@ class AddServerViewModel(
             val profile = HostProfile(
                 id = current.id ?: 0L,
                 name = current.name.trim(),
-                host = current.host.trim(),
+                host = host,
                 port = port,
                 username = username,
                 password = current.password,


### PR DESCRIPTION
### Problem

On ColorOS (Oppo) the system keyboard inserts a space after the first `.` in the **Host** field, so an
IP address cannot be typed:

- tapping `1` `0` `0` `.` `7` `2` produces `100. 72`
- `solom-vps.tail36346.ts.net` produces `solom-vps. tail36346.ts.net`

Both reproduced by tapping the real on-screen keys on an Oppo Pad Mini and read back with
`adb shell uiautomator dump`, so it is the field's actual value, not a rendering artifact. The
resulting host never resolves and nothing in the UI explains why.

### Cause

`ChuTextField` already sets `autoCorrectEnabled = false`, but that maps only to
`TYPE_TEXT_FLAG_AUTO_CORRECT`. "Insert a space after sentence punctuation" is a separate IME behaviour
that flag does not cover. What IMEs do honour is a semantic input type.

### Change

- **Host** → `KeyboardType.Uri` (`TYPE_TEXT_VARIATION_URI`), **Username** → `KeyboardType.Ascii`.
- The **Port** field passed its own `KeyboardOptions`, which silently dropped the `ChuTextField`
  defaults (`capitalization = None`, `autoCorrectEnabled = false`) — restored there too.
- Defence in depth: strip whitespace from the host in `updateHost` and at both the `save()` and
  `testConnection()` boundaries. `trim()` cannot remove an *interior* space, and a profile loaded for
  editing never passes through `updateHost` at all.

Related to #38, which disabled autocorrect/suggestions for the terminal IME mirror; this is the same
class of problem on the host/username form fields.

### Verified on device

Tapping the identical key sequence that produced `100. 72` now yields `100.72`, and the full
`100.72.23.13` and `solom-vps.tail36346.ts.net` both type cleanly.

Based on `5b059b0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved server setup fields with more appropriate keyboards for host, port, and username entry.
  - Host addresses are now automatically cleaned of spaces for more reliable connections and saving.
  - Prevented connection tests and profile saving when the host address is blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->