### PR TITLE
fix: do not silently drop a multiplexer connect, and show progress while it runs

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -686,7 +686,9 @@ fun TerminalScreen(
             Toast.makeText(context, preflightError, Toast.LENGTH_LONG).show()
         }
     }
-    when (sessionState.status) {
+    val displaySessionStatus =
+        if (multiplexerState.preflightLoading) SessionStatus.Connecting else sessionState.status
+    when (displaySessionStatus) {
         SessionStatus.Disconnected,
         SessionStatus.Error -> {
             if (tabMode == TerminalTabMode.Strip) {
@@ -768,7 +770,9 @@ fun TerminalScreen(
         }
 
         SessionStatus.Connecting -> {
-            val hostLabel = if (tabMode == TerminalTabMode.Strip) {
+            val hostLabel = if (multiplexerState.preflightLoading) {
+                "${multiplexerState.preflightHostLabel ?: "server"}..."
+            } else if (tabMode == TerminalTabMode.Strip) {
                 activeTab?.spec?.tabLabel?.let { "$it..." } ?: "..."
             } else {
                 activeTabForHost?.spec?.host?.let { "$it..." } ?: "..."

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -205,7 +206,6 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     }
 
     private fun beginMultiplexerAction(action: PendingMultiplexerAction) {
-        val actionGeneration = ++multiplexerActionGeneration
         val preparedAction = when (action) {
             is PendingMultiplexerAction.Open -> action.copy(
                 spec = action.spec.copy(multiplexer = action.spec.multiplexer ?: MultiplexerRegistry.defaultType),
@@ -214,6 +214,14 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 spec = action.spec.copy(multiplexer = action.spec.multiplexer ?: MultiplexerRegistry.defaultType),
             )
         }
+        if (
+            pendingMultiplexerAction == preparedAction &&
+                _multiplexerState.value.preflightLoading
+        ) {
+            // Keep the original generation alive while its host-key prompt is awaiting a decision.
+            return
+        }
+        val actionGeneration = ++multiplexerActionGeneration
         pendingMultiplexerAction = preparedAction
         val spec = preparedAction.spec
         val label = spec.multiplexer?.label ?: MultiplexerRegistry.defaultType.label
@@ -232,28 +240,47 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
             )
             return
         }
-        _multiplexerState.value = MultiplexerUiState(reconnectRecovery = reconnectRecovery)
+        _multiplexerState.value = MultiplexerUiState(
+            preflightLoading = true,
+            preflightHostLabel = spec.tabLabel,
+            reconnectRecovery = reconnectRecovery,
+        )
         viewModelScope.launch(Dispatchers.IO) {
-            val result = runCatching {
-                sessionRepository.resolveMultiplexerSessionName(
-                    spec = spec,
-                    reuseDetachedChuchuSession =
-                        preparedAction is PendingMultiplexerAction.Open &&
-                            spec.multiplexerSessionName.isNullOrBlank(),
-                )
-            }
+            val result =
+                try {
+                    Result.success(
+                        sessionRepository.resolveMultiplexerSessionName(
+                            spec = spec,
+                            reuseDetachedChuchuSession =
+                                preparedAction is PendingMultiplexerAction.Open &&
+                                    spec.multiplexerSessionName.isNullOrBlank(),
+                        ),
+                    )
+                } catch (_: CancellationException) {
+                    withContext(NonCancellable + Dispatchers.Main) {
+                        reportMultiplexerActionStopped(actionGeneration, preparedAction)
+                    }
+                    return@launch
+                } catch (error: Exception) {
+                    Result.failure(error)
+                }
             withContext(Dispatchers.Main) {
-                if (!isCurrentMultiplexerAction(actionGeneration, preparedAction)) return@withContext
-                result.fold(
-                    onSuccess = { sessionName ->
-                        completeMultiplexerAction(actionGeneration, preparedAction, sessionName)
-                    },
-                    onFailure = { error ->
-                        _multiplexerState.value = _multiplexerState.value.copy(
-                            preflightError = error.message ?: "Could not prepare multiplexer session",
-                        )
-                    },
-                )
+                if (isCurrentMultiplexerAction(actionGeneration, preparedAction)) {
+                    result.fold(
+                        onSuccess = { sessionName ->
+                            completeMultiplexerAction(actionGeneration, preparedAction, sessionName)
+                        },
+                        onFailure = { error ->
+                            _multiplexerState.value = _multiplexerState.value.copy(
+                                preflightLoading = false,
+                                preflightHostLabel = null,
+                                preflightError = error.message ?: "Could not prepare multiplexer session",
+                            )
+                        },
+                    )
+                } else {
+                    reportMultiplexerActionStopped(actionGeneration, preparedAction)
+                }
             }
         }
     }
@@ -266,23 +293,48 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         action: PendingMultiplexerAction,
         sessionName: String,
     ) {
-        if (!isCurrentMultiplexerAction(actionGeneration, action)) return
-        val nextSpec = action.spec.copy(
-            multiplexer = action.spec.multiplexer ?: MultiplexerRegistry.defaultType,
-            multiplexerSessionName = sessionName,
-            multiplexerCreateIfMissing = action.spec.multiplexerCreateIfMissing,
-        )
-        pendingMultiplexerAction = null
-        _multiplexerState.value = MultiplexerUiState()
-        when (action) {
-            is PendingMultiplexerAction.Open -> openTab(nextSpec)
-            is PendingMultiplexerAction.Reconnect -> {
-                if (!reconnectTabWithSpec(action.tabId, nextSpec)) {
-                    _multiplexerState.value = MultiplexerUiState(
-                        preflightError = "Terminal session is no longer available",
-                        reconnectRecovery = true,
-                    )
+        if (isCurrentMultiplexerAction(actionGeneration, action)) {
+            val nextSpec = action.spec.copy(
+                multiplexer = action.spec.multiplexer ?: MultiplexerRegistry.defaultType,
+                multiplexerSessionName = sessionName,
+                multiplexerCreateIfMissing = action.spec.multiplexerCreateIfMissing,
+            )
+            pendingMultiplexerAction = null
+            _multiplexerState.value = MultiplexerUiState()
+            when (action) {
+                is PendingMultiplexerAction.Open -> openTab(nextSpec)
+                is PendingMultiplexerAction.Reconnect -> {
+                    if (!reconnectTabWithSpec(action.tabId, nextSpec)) {
+                        _multiplexerState.value = MultiplexerUiState(
+                            preflightError = "Terminal session is no longer available",
+                            reconnectRecovery = true,
+                        )
+                    }
                 }
+            }
+        } else {
+            reportMultiplexerActionStopped(actionGeneration, action)
+        }
+    }
+
+    private fun reportMultiplexerActionStopped(
+        actionGeneration: Long,
+        action: PendingMultiplexerAction,
+    ) {
+        when {
+            isCurrentMultiplexerAction(actionGeneration, action) -> {
+                _multiplexerState.value = _multiplexerState.value.copy(
+                    preflightLoading = false,
+                    preflightHostLabel = null,
+                    preflightError = "Connection preparation was cancelled",
+                )
+            }
+
+            pendingMultiplexerAction == null -> {
+                _multiplexerState.value = MultiplexerUiState(
+                    preflightError = "Connection preparation was superseded",
+                    reconnectRecovery = action is PendingMultiplexerAction.Reconnect,
+                )
             }
         }
     }
@@ -771,6 +823,8 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
 
 data class MultiplexerUiState(
     val preflightError: String? = null,
+    val preflightLoading: Boolean = false,
+    val preflightHostLabel: String? = null,
     val sessions: List<RemoteMultiplexerSession> = emptyList(),
     val sessionsLoading: Boolean = false,
     val sessionsError: String? = null,


### PR DESCRIPTION
### Problem

Two things go wrong when connecting to a host with a multiplexer configured:

1. Tapping `[ connect ]` shows **nothing at all** for several seconds — still the server list, no
   spinner, no status — and then lands on the terminal showing an **unrelated, already-open tab**.
2. If the host key is not yet trusted, accepting it could leave the whole action **silently dropped**:
   no tab, no session, and no error message of any kind.

### Cause

`TerminalViewModel.beginMultiplexerAction` bumped `multiplexerActionGeneration` on **every** call, so a
repeated start — e.g. from a recomposition while the host-key dialog was on screen — invalidated the
in-flight action. The completed pre-flight was then discarded by `isCurrentMultiplexerAction` with no
state change at all. Silence, by construction. `completeMultiplexerAction` had the same silent
early-return.

### Change

- Make a repeated start for an identical action **idempotent** while its pre-flight is still running, so
  the generation stays valid across the prompt.
- Replace every silent `return` on this route with a reported outcome (cancelled / superseded).
- Surface a pre-flight loading state so connecting shows `Connecting to <host>…` immediately, instead of
  leaving the user looking at an unrelated tab.

### Verified on device

![progress shown while the multiplexer connect runs](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr87-connect-progress.png)

Connecting to a tmux host now shows `Connecting to 100.72.23.13…` right away, and failures on this route
are reported (toast + recovery options `retry multiplexer` / `connect without multiplexer`) rather than
vanishing.

Independent of, and complementary to, the sibling PR that stops the SSH handshake being held open across
the host-key prompt — that one fixes the underlying teardown, this one fixes the dropped action and the
missing feedback. They touch disjoint files and can land in either order.

Based on `5b059b0`.