### PR TITLE
fix: require an explicit choice on the host key dialog

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuDialog.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/components/ChuDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.unit.dp
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
@@ -25,13 +26,17 @@ fun ChuDialog(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     dismissLabel: String = "Cancel",
+    properties: DialogProperties = DialogProperties(),
     content: @Composable () -> Unit,
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
     val shape = RectangleShape
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = properties,
+    ) {
         Column(
             modifier = modifier
                 .fillMaxWidth()

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.FileProvider
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -660,6 +661,10 @@ fun TerminalScreen(
             confirmLabel = "Accept",
             dismissLabel = "Reject",
             onConfirm = { vm.onHostKeyDecision(true) },
+            properties = DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+            ),
         ) {
             val previous = prompt?.previousFingerprint
             val message = buildString {


### PR DESCRIPTION
### Problem

Tapping the backdrop beside the "Verify host key" dialog dismissed it — and because the call site wires
`onDismiss` to `onHostKeyDecision(false)`, that mis-tap was treated as a deliberate **rejection** and
tore the connection down. Pressing Back did the same. I hit this by accident while testing something
else, which is rather the point: a stray tap is indistinguishable from choosing `[ Reject ]`.

### Cause

`ChuDialog` passes no `DialogProperties` to Compose's `Dialog`, so `dismissOnClickOutside` and
`dismissOnBackPress` are both on by default.

### Change

Let callers supply `DialogProperties`, defaulting to today's behaviour so every other dialog in the app
is unchanged, and have the host-key dialog opt out of both dismissal paths. Rejecting is still the safe
default — it just has to come from the `[ Reject ]` button now.

### Verified on device

With the dialog open: tapping well outside it leaves it on screen, and Back leaves it on screen
(confirmed via `uiautomator dump`). `[ Reject ]` still rejects, `[ Accept ]` still accepts.

Based on `5b059b0`.
