### PR TITLE
fix: run the post-connect command on multiplexer hosts too

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -1147,8 +1147,8 @@ class TerminalSessionEngine(
     }
 
     private suspend fun sendStartupCommand(params: ConnectionParams) {
-        val multiplexerCommand = params.multiplexerStartupCommand()?.trim().orEmpty()
-        if (multiplexerCommand.isNotEmpty() && params.transport != Transport.Mosh) return
+        // Multiplexer startup is dispatched through openExecPty before this runs. Later writes on
+        // that PTY follow the exec request, so the command is consumed by the attached session.
         sendPostConnectCommand(params.postConnectCommand)
     }
 


### PR DESCRIPTION
### Problem

`auto-run on connect` (added in #18, requested in #16) is silently discarded on **every** host that has
session persistence set to tmux or zmx.

Verified on device with a control — same profile, same command, only the persistence setting differs:

- persistence **tmux** + `auto-run on connect = echo AUTORUN-FIRED` → connect creates the session, pane
  shows a bare prompt. The command never ran.
- persistence **off**, same command → runs, prints `AUTORUN-FIRED`.

The add/edit screen shows "SESSION PERSISTENCE" and "auto-run on connect" together with nothing to
suggest they are mutually exclusive.

### Cause

```kotlin
private suspend fun sendStartupCommand(params: ConnectionParams) {
    val multiplexerCommand = params.multiplexerStartupCommand()?.trim().orEmpty()
    if (multiplexerCommand.isNotEmpty() && params.transport != Transport.Mosh) return   // drops it
    sendPostConnectCommand(params.postConnectCommand)
}
```

Note Mosh is explicitly excluded from the early return, so Mosh + a multiplexer *does* run it —
inconsistent on top of being silent.

### Change

Drop the early return so the post-connect command runs **inside** the multiplexer session, which is what
someone who filled in both fields is asking for. The multiplexer startup is dispatched through the exec
PTY before this runs, and later writes on that PTY follow the exec request, so the command lands in the
attached session.

### Verified on device

tmux host with `auto-run on connect = echo AUTORUN-FIRED`:

- freshly **created** session (`chuchu-1`) → `AUTORUN-FIRED` printed inside tmux
- **reattached** session (`chuchu-3`) → `AUTORUN-FIRED` printed inside tmux

The create path is the riskier timing case and it was clean across trials. Persistence-off route
unchanged.

Based on `5b059b0`.
