### PR TITLE
fix: make tab strip labels distinguishable per host

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
@@ -40,6 +40,9 @@ import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
 
+// Approximates the visible title width before the fixed-size tab ellipsizes it.
+private const val TAB_TITLE_COLLISION_PREFIX_LENGTH = 14
+
 /**
  * Human-readable status text for accessibility.
  */
@@ -72,9 +75,21 @@ fun TerminalTabStrip(
     val trailingActionWidth = if (tabs.size > 1) 72.dp else 40.dp
     val tabOffsets = remember { mutableStateMapOf<String, Int>() }
     val rowRootLeft = remember { mutableStateOf(0) }
+    val titles = tabs.map { tab ->
+        val title by remember(tab) {
+            tab.sessionState.map { it.title?.takeIf(String::isNotBlank) }
+        }.collectAsStateWithLifecycle(initialValue = null)
+        title
+    }
+    val titlePrefixCounts = titles
+        .filterNotNull()
+        .groupingBy { it.take(TAB_TITLE_COLLISION_PREFIX_LENGTH) }
+        .eachCount()
 
-    LaunchedEffect(activeTabId) {
-        val target = activeTabId?.let { tabOffsets[it] } ?: return@LaunchedEffect
+    val activeTabOffset = activeTabId?.let { tabOffsets[it] }
+
+    LaunchedEffect(activeTabId, activeTabOffset) {
+        val target = activeTabOffset ?: return@LaunchedEffect
         scrollState.animateScrollTo(target)
     }
 
@@ -95,13 +110,15 @@ fun TerminalTabStrip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            tabs.forEach { tab ->
+            tabs.forEachIndexed { index, tab ->
                 val isActive = tab.id == activeTabId
                 val alias = terminalTabDisplayLabel(tab)
-                val title by remember(tab) {
-                    tab.sessionState.map { it.title?.takeIf(String::isNotBlank) }
-                }.collectAsStateWithLifecycle(initialValue = null)
-                val label = title ?: alias
+                val title = titles[index]
+                val label = when {
+                    title == null -> alias
+                    titlePrefixCounts.getValue(title.take(TAB_TITLE_COLLISION_PREFIX_LENGTH)) == 1 -> title
+                    else -> "$alias · $title"
+                }
 
                 Box(
                     modifier = Modifier


### PR DESCRIPTION
### Problem

Every shell on one host reports the same OSC-2 title, so opening three tabs against one server renders
`user@host: ~` three times, pixel identical — you cannot tell which tab you are switching to. Running
several terminals against one server is rather the point of the app.

There is a second, subtler case: under tmux the titles genuinely *do* differ
(`host ▫ chuchu-3` vs `host ▫ chuchu-4`), but they differ only in a suffix that the tab's
`widthIn(max = 160.dp)` + ellipsis cuts off — so those look identical too.

`TerminalTabManager` already shows both the title and the per-tab alias and is unambiguous, so the
strip was strictly worse than the manager.

### Change

Group tabs by a **bounded prefix** of their title rather than the whole string — that covers both the
exactly-equal case and the differs-only-past-the-ellipsis case — and prefix every member of a colliding
group with that tab's unique alias. The alias goes **first** so it survives the ellipsis rather than
being the part that gets cut. Tabs with a unique title, and tabs with no title at all, are unchanged.

The prefix length is a named constant with a comment noting it approximates the visible width, so it is
obviously a heuristic and easy to tune.

Also keys the auto-scroll effect on the active tab's measured offset: `tabOffsets` is filled in
`onGloballyPositioned`, i.e. after first layout, so the effect previously returned early on first
composition and the strip never scrolled to the active tab.

Follows on from #39, which introduced the OSC title + ellipsis behaviour.

### Verified on device

![two tabs with identical remote titles, still distinguishable](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr90-tab-labels.png)

- three tabs on one host, identical titles → `delta-orbit · salem@u…` / `indigo-anchor · salem…`
- two tmux tabs differing only past the ellipsis → `mango-anchor · ubuntu…` / `nova-willow · ubuntu-…`
- tabs with clearly different titles → plain titles, unprefixed

Based on `5b059b0`.