### PR TITLE
fix: let the multiplexer session list use the space it has

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/MultiplexerSessionPanel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/MultiplexerSessionPanel.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -63,7 +62,7 @@ fun MultiplexerSessionPanel(
             )
         }
         if (visibleSessions.isNotEmpty()) {
-            LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 150.dp)) {
+            LazyColumn(modifier = Modifier.fillMaxWidth().weight(1f, fill = false)) {
                 items(visibleSessions) { session ->
                     MultiplexerSessionRow(
                         session = session,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabManager.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabManager.kt
@@ -436,6 +436,7 @@ fun TerminalTabManager(
                         onNew = onMultiplexerNew,
                         onAttach = onMultiplexerAttach,
                         onDismiss = onDismiss,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
                 }
             }


### PR DESCRIPTION
### Problem

The multiplexer session list in the tab manager is capped at `heightIn(max = 150.dp)`. On a tablet that
shows roughly **two of eight** sessions, with rows sliced through the middle at both the top and bottom
edge, while most of the overlay below the panel sits empty.

### Change

Replace the fixed cap with `weight(1f, fill = false)` on the list and on the panel itself, so it wraps
its content when there are only a couple of sessions and grows into the available space when there are
many. The header and the `[ refresh ] [ new ]` actions stay visible either way.

### Verified on device

![the multiplexer session list using the available height](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr91-panel-height.png)

Oppo Pad Mini with 11 tmux sessions on the host: all 11 rows visible in one pass, no clipping, actions
still reachable. With one or two sessions the panel still wraps rather than stretching.

Based on `5b059b0`.