### PR TITLE
feat: make OSC 52 clipboard writes opt-in instead of unreachable

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
@@ -59,6 +59,10 @@ class SettingsRepository(context: Context) {
     private val _hideScreenContents = MutableStateFlow(prefs.getBoolean(KEY_HIDE_SCREEN_CONTENTS, false))
     val hideScreenContents: StateFlow<Boolean> = _hideScreenContents.asStateFlow()
 
+    private val _remoteClipboardWriteEnabled =
+        MutableStateFlow(prefs.getBoolean(KEY_REMOTE_CLIPBOARD_WRITE_ENABLED, false))
+    val remoteClipboardWriteEnabled: StateFlow<Boolean> = _remoteClipboardWriteEnabled.asStateFlow()
+
     private val _terminalTabMode = MutableStateFlow(
         parseTabMode(prefs.getString(KEY_TAB_MODE, TerminalTabMode.Classic.name)),
     )
@@ -147,6 +151,11 @@ class SettingsRepository(context: Context) {
         _hideScreenContents.value = enabled
     }
 
+    fun setRemoteClipboardWriteEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_REMOTE_CLIPBOARD_WRITE_ENABLED, enabled).apply()
+        _remoteClipboardWriteEnabled.value = enabled
+    }
+
     fun setThemeMode(mode: ThemeMode) {
         prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
         _themeMode.value = mode
@@ -211,6 +220,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_LOCAL_SHELL_ENABLED = "local_shell_enabled"
         private const val KEY_KEEP_SCREEN_AWAKE = "keep_screen_awake"
         private const val KEY_HIDE_SCREEN_CONTENTS = "hide_screen_contents"
+        private const val KEY_REMOTE_CLIPBOARD_WRITE_ENABLED = "remote_clipboard_write_enabled"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_LIGHT_THEME = "light_theme_name"
         private const val KEY_TERMINAL_FONT_SIZE = "terminal_font_size_sp"

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -3,6 +3,7 @@ package com.jossephus.chuchu.service.terminal
 import android.app.Application
 import android.content.ClipData
 import android.content.ClipboardManager
+import com.jossephus.chuchu.data.repository.SettingsRepository
 import com.jossephus.chuchu.model.MultiplexerType
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.multiplexer.MultiplexerRegistry
@@ -30,11 +31,6 @@ import kotlinx.coroutines.sync.withLock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TerminalSessionRepository private constructor(application: Application) {
-    private enum class Osc52ClipboardPolicy {
-        Deny,
-        AllowActiveForegroundSession,
-    }
-
     private val appContext = application.applicationContext
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -42,7 +38,7 @@ class TerminalSessionRepository private constructor(application: Application) {
         HostKeyStore(appContext.getSharedPreferences(HostKeyStore.PREFS_NAME, Application.MODE_PRIVATE))
     private val tailscaleStatusChecker = TailscaleStatusChecker(appContext)
     private val clipboard = appContext.getSystemService(ClipboardManager::class.java)
-    private val osc52ClipboardPolicy = Osc52ClipboardPolicy.Deny
+    private val settingsRepository = SettingsRepository.getInstance(appContext)
 
     private fun publishTerminalClipboard(tabId: String, text: String) {
         if (!canPublishTerminalClipboard(tabId)) return
@@ -50,7 +46,7 @@ class TerminalSessionRepository private constructor(application: Application) {
     }
 
     private fun canPublishTerminalClipboard(tabId: String): Boolean {
-        if (osc52ClipboardPolicy != Osc52ClipboardPolicy.AllowActiveForegroundSession) return false
+        if (!settingsRepository.remoteClipboardWriteEnabled.value) return false
         return attachedClients > 0 && _activeTabId.value == tabId
     }
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -129,6 +129,8 @@ fun ApplicationNavController() {
             val localShellEnabled by settingsRepo.localShellEnabled.collectAsStateWithLifecycle()
             val keepScreenAwake by settingsRepo.keepScreenAwake.collectAsStateWithLifecycle()
             val hideScreenContents by settingsRepo.hideScreenContents.collectAsStateWithLifecycle()
+            val remoteClipboardWriteEnabled by
+                settingsRepo.remoteClipboardWriteEnabled.collectAsStateWithLifecycle()
             val themeMode by settingsRepo.themeMode.collectAsStateWithLifecycle()
             val terminalFontSize by settingsRepo.terminalFontSize.collectAsStateWithLifecycle()
             val lightThemeName by settingsRepo.lightThemeName.collectAsStateWithLifecycle()
@@ -140,6 +142,7 @@ fun ApplicationNavController() {
                 localShellEnabled = localShellEnabled,
                 keepScreenAwake = keepScreenAwake,
                 hideScreenContents = hideScreenContents,
+                remoteClipboardWriteEnabled = remoteClipboardWriteEnabled,
                 currentAccessoryLayoutIds = accessoryLayoutIds,
                 accessoryBarSingleRow = accessoryBarSingleRow,
                 currentTerminalCustomKeyGroups = customKeyGroups,
@@ -160,6 +163,7 @@ fun ApplicationNavController() {
                 onLocalShellEnabledChanged = settingsRepo::setLocalShellEnabled,
                 onKeepScreenAwakeChanged = settingsRepo::setKeepScreenAwake,
                 onHideScreenContentsChanged = settingsRepo::setHideScreenContents,
+                onRemoteClipboardWriteEnabledChanged = settingsRepo::setRemoteClipboardWriteEnabled,
                 onAccessoryLayoutChanged = settingsRepo::setAccessoryLayoutIds,
                 onAccessoryBarSingleRowChanged = settingsRepo::setAccessoryBarSingleRow,
                 currentTerminalFontSize = terminalFontSize,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -48,6 +48,7 @@ fun SettingsScreen(
     localShellEnabled: Boolean,
     keepScreenAwake: Boolean,
     hideScreenContents: Boolean,
+    remoteClipboardWriteEnabled: Boolean,
     currentAccessoryLayoutIds: List<String>,
     accessoryBarSingleRow: Boolean,
     currentTerminalCustomKeyGroups: List<TerminalCustomKeyGroup>,
@@ -68,6 +69,7 @@ fun SettingsScreen(
     onLocalShellEnabledChanged: (Boolean) -> Unit,
     onKeepScreenAwakeChanged: (Boolean) -> Unit,
     onHideScreenContentsChanged: (Boolean) -> Unit,
+    onRemoteClipboardWriteEnabledChanged: (Boolean) -> Unit,
     onAccessoryLayoutChanged: (List<String>) -> Unit,
     onAccessoryBarSingleRowChanged: (Boolean) -> Unit,
     currentTerminalFontSize: Float = 14f,
@@ -195,6 +197,8 @@ fun SettingsScreen(
                         onKeepScreenAwakeChanged = onKeepScreenAwakeChanged,
                         hideScreenContents = hideScreenContents,
                         onHideScreenContentsChanged = onHideScreenContentsChanged,
+                        remoteClipboardWriteEnabled = remoteClipboardWriteEnabled,
+                        onRemoteClipboardWriteEnabledChanged = onRemoteClipboardWriteEnabledChanged,
                     )
                 }
             }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
@@ -97,6 +97,8 @@ internal fun TerminalSettings(
     onKeepScreenAwakeChanged: (Boolean) -> Unit = {},
     hideScreenContents: Boolean = false,
     onHideScreenContentsChanged: (Boolean) -> Unit = {},
+    remoteClipboardWriteEnabled: Boolean = false,
+    onRemoteClipboardWriteEnabledChanged: (Boolean) -> Unit = {},
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
@@ -487,6 +489,33 @@ internal fun TerminalSettings(
                 ChuSwitch(
                     checked = localShellEnabled,
                     onCheckedChange = onLocalShellEnabledChanged,
+                )
+            }
+        }
+
+        ChuCard(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 48.dp)
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    ChuText("allow remote clipboard writes", style = typography.label)
+                    ChuText(
+                        "lets the remote host set this device's clipboard (OSC 52). only the visible tab can write.",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+                ChuSwitch(
+                    checked = remoteClipboardWriteEnabled,
+                    onCheckedChange = onRemoteClipboardWriteEnabledChanged,
                 )
             }
         }


### PR DESCRIPTION
### Context

#53 landed OSC 52 support with the policy deliberately gated off:

```kotlin
private enum class Osc52ClipboardPolicy { Deny, AllowActiveForegroundSession }
private val osc52ClipboardPolicy = Osc52ClipboardPolicy.Deny
```

Deny-by-default is the right call — a remote host silently rewriting the device clipboard is a real
risk. But the constant is a hardcoded `private val`, so `AllowActiveForegroundSession` is unreachable
and nothing anywhere can change it. The result today is that "copy on the server, paste on the phone"
never works, with no error and nothing in logcat: the zig layer decodes the sequence
(`chuchu_snapshot.zig`), `TerminalSessionEngine.publishClipboard` calls through, and the repository
discards it.

Verified on device by sending OSC 52 from the server both normally and via tmux passthrough (to rule
tmux out) — the Android clipboard never changed.

### Change

Turn that placeholder into a real setting, keeping the safe default:

- new boolean in `SettingsRepository` following the existing pattern (`localShellEnabled`,
  `keepScreenAwake`), **default false**
- `canPublishTerminalClipboard` reads the setting instead of the hardcoded enum, and **keeps the
  existing guard** — only the currently visible tab of an attached session may write
- a terminal setting to turn it on, with a short note about what it allows

This is intended as the follow-up #53 left room for rather than a change of policy.

### Verified on device

![the OSC 52 clipboard setting, default off](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr92-osc52-setting.png)

Fresh install → setting off → OSC 52 writes dropped exactly as today. Toggled on → a payload sent from
the server landed in the Android clipboard and pasted back into the shell. Setting survives an app
restart.

Based on `5b059b0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to allow or block remote hosts from writing to the device clipboard.
  * The setting is disabled by default and persists across app sessions.
  * Remote clipboard writes are limited to the currently visible terminal tab.
  * Added a toggle under terminal settings to manage this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->