### PR TITLE
feat: add an opt-in setting to hide screen contents

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/MainActivity.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.jossephus.chuchu
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -13,16 +14,28 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
 import com.jossephus.chuchu.data.repository.SettingsRepository
 import com.jossephus.chuchu.ui.ApplicationNavController
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTheme
 import com.jossephus.chuchu.ui.theme.GhosttyThemeRegistry
 import com.jossephus.chuchu.ui.theme.resolveActiveThemeName
+import kotlinx.coroutines.launch
 
 class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val settings = SettingsRepository.getInstance(this)
+        lifecycleScope.launch {
+            settings.hideScreenContents.collect { hideScreenContents ->
+                if (hideScreenContents) {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                } else {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                }
+            }
+        }
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(0x00000000),
             navigationBarStyle = SystemBarStyle.dark(0x00000000),

--- a/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
@@ -56,6 +56,9 @@ class SettingsRepository(context: Context) {
     private val _keepScreenAwake = MutableStateFlow(prefs.getBoolean(KEY_KEEP_SCREEN_AWAKE, false))
     val keepScreenAwake: StateFlow<Boolean> = _keepScreenAwake.asStateFlow()
 
+    private val _hideScreenContents = MutableStateFlow(prefs.getBoolean(KEY_HIDE_SCREEN_CONTENTS, false))
+    val hideScreenContents: StateFlow<Boolean> = _hideScreenContents.asStateFlow()
+
     private val _terminalTabMode = MutableStateFlow(
         parseTabMode(prefs.getString(KEY_TAB_MODE, TerminalTabMode.Classic.name)),
     )
@@ -139,6 +142,11 @@ class SettingsRepository(context: Context) {
         _keepScreenAwake.value = enabled
     }
 
+    fun setHideScreenContents(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_HIDE_SCREEN_CONTENTS, enabled).apply()
+        _hideScreenContents.value = enabled
+    }
+
     fun setThemeMode(mode: ThemeMode) {
         prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
         _themeMode.value = mode
@@ -202,6 +210,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_REQUIRE_AUTH_ON_CONNECT = "require_auth_on_connect"
         private const val KEY_LOCAL_SHELL_ENABLED = "local_shell_enabled"
         private const val KEY_KEEP_SCREEN_AWAKE = "keep_screen_awake"
+        private const val KEY_HIDE_SCREEN_CONTENTS = "hide_screen_contents"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_LIGHT_THEME = "light_theme_name"
         private const val KEY_TERMINAL_FONT_SIZE = "terminal_font_size_sp"

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -128,6 +128,7 @@ fun ApplicationNavController() {
             val tabMode by settingsRepo.terminalTabMode.collectAsStateWithLifecycle()
             val localShellEnabled by settingsRepo.localShellEnabled.collectAsStateWithLifecycle()
             val keepScreenAwake by settingsRepo.keepScreenAwake.collectAsStateWithLifecycle()
+            val hideScreenContents by settingsRepo.hideScreenContents.collectAsStateWithLifecycle()
             val themeMode by settingsRepo.themeMode.collectAsStateWithLifecycle()
             val terminalFontSize by settingsRepo.terminalFontSize.collectAsStateWithLifecycle()
             val lightThemeName by settingsRepo.lightThemeName.collectAsStateWithLifecycle()
@@ -138,6 +139,7 @@ fun ApplicationNavController() {
                 requireAuthOnConnect = requireAuthOnConnect,
                 localShellEnabled = localShellEnabled,
                 keepScreenAwake = keepScreenAwake,
+                hideScreenContents = hideScreenContents,
                 currentAccessoryLayoutIds = accessoryLayoutIds,
                 accessoryBarSingleRow = accessoryBarSingleRow,
                 currentTerminalCustomKeyGroups = customKeyGroups,
@@ -157,6 +159,7 @@ fun ApplicationNavController() {
                 onRequireAuthOnConnectChanged = settingsRepo::setRequireAuthOnConnect,
                 onLocalShellEnabledChanged = settingsRepo::setLocalShellEnabled,
                 onKeepScreenAwakeChanged = settingsRepo::setKeepScreenAwake,
+                onHideScreenContentsChanged = settingsRepo::setHideScreenContents,
                 onAccessoryLayoutChanged = settingsRepo::setAccessoryLayoutIds,
                 onAccessoryBarSingleRowChanged = settingsRepo::setAccessoryBarSingleRow,
                 currentTerminalFontSize = terminalFontSize,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ fun SettingsScreen(
     requireAuthOnConnect: Boolean,
     localShellEnabled: Boolean,
     keepScreenAwake: Boolean,
+    hideScreenContents: Boolean,
     currentAccessoryLayoutIds: List<String>,
     accessoryBarSingleRow: Boolean,
     currentTerminalCustomKeyGroups: List<TerminalCustomKeyGroup>,
@@ -66,6 +67,7 @@ fun SettingsScreen(
     onRequireAuthOnConnectChanged: (Boolean) -> Unit,
     onLocalShellEnabledChanged: (Boolean) -> Unit,
     onKeepScreenAwakeChanged: (Boolean) -> Unit,
+    onHideScreenContentsChanged: (Boolean) -> Unit,
     onAccessoryLayoutChanged: (List<String>) -> Unit,
     onAccessoryBarSingleRowChanged: (Boolean) -> Unit,
     currentTerminalFontSize: Float = 14f,
@@ -191,6 +193,8 @@ fun SettingsScreen(
                         onLocalShellEnabledChanged = onLocalShellEnabledChanged,
                         keepScreenAwake = keepScreenAwake,
                         onKeepScreenAwakeChanged = onKeepScreenAwakeChanged,
+                        hideScreenContents = hideScreenContents,
+                        onHideScreenContentsChanged = onHideScreenContentsChanged,
                     )
                 }
             }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
@@ -95,6 +95,8 @@ internal fun TerminalSettings(
     onLocalShellEnabledChanged: (Boolean) -> Unit = {},
     keepScreenAwake: Boolean = false,
     onKeepScreenAwakeChanged: (Boolean) -> Unit = {},
+    hideScreenContents: Boolean = false,
+    onHideScreenContentsChanged: (Boolean) -> Unit = {},
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
@@ -512,6 +514,33 @@ internal fun TerminalSettings(
                 ChuSwitch(
                     checked = keepScreenAwake,
                     onCheckedChange = onKeepScreenAwakeChanged,
+                )
+            }
+        }
+
+        ChuCard(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 48.dp)
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    ChuText("hide screen contents", style = typography.label)
+                    ChuText(
+                        "blocks screenshots and hides the terminal in the app switcher",
+                        style = typography.bodySmall,
+                        color = colors.textMuted,
+                    )
+                }
+                ChuSwitch(
+                    checked = hideScreenContents,
+                    onCheckedChange = onHideScreenContentsChanged,
                 )
             }
         }


### PR DESCRIPTION
### Problem

`FLAG_SECURE` is set nowhere in the app, so the Android app switcher renders a **live thumbnail of the
terminal** — tmux status bar and text clearly legible — and system screenshots and screen recordings
capture it too. Whatever is on screen when you leave the app (an SSH key you just printed, a token, a
password prompt) is preserved in the recents thumbnail.

### Change

An opt-in setting that applies `WindowManager.LayoutParams.FLAG_SECURE` to the activity window,
observed from the repository so toggling takes effect immediately rather than on next launch.

It **defaults to off** deliberately: forcing it on would break legitimate screenshotting, which this
project relies on for bug reports and PR evidence, so hiding contents is the user's choice.

### Verified on device

With the setting on, the app switcher shows a blank card for the app while another chuchu install
alongside it still shows its terminal. Toggling back off restores the thumbnail live, without a
restart. Setting survives an app restart.

(Note `adb exec-out screencap` still captures the window, since that path is privileged — what the flag
blocks is the recents thumbnail and user-initiated screenshots, which is the exposure here.)

Based on `5b059b0`.
