### PR TITLE
feat: add host filtering to the server list

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/ServerList/ServerListScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/ServerList/ServerListScreen.kt
@@ -55,6 +55,7 @@ import com.jossephus.chuchu.ui.components.ChuButton
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
 import com.jossephus.chuchu.ui.components.ChuCard
 import com.jossephus.chuchu.ui.components.ChuText
+import com.jossephus.chuchu.ui.components.ChuTextField
 import com.jossephus.chuchu.ui.components.TuiBadge
 import com.jossephus.chuchu.ui.theme.ChuColors
 import com.jossephus.chuchu.ui.theme.ChuTypography
@@ -83,6 +84,7 @@ fun ServerListScreen(
     var selectedHostId by remember { mutableStateOf<Long?>(null) }
     var pendingConnectHostId by remember { mutableStateOf<Long?>(null) }
     var pendingLocalShell by remember { mutableStateOf(false) }
+    var isSearchVisible by remember { mutableStateOf(false) }
     val notificationPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) {
@@ -142,13 +144,40 @@ fun ServerListScreen(
                     ChuText("chuchu", style = typography.headline)
                 }
 
-                ChuButton(
-                    onClick = onOpenSettings,
-                    variant = ChuButtonVariant.Outlined,
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
-                ) {
-                    ChuText("settings", style = typography.label, color = colors.textSecondary)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (!isSearchVisible && hosts.isNotEmpty()) {
+                        ChuButton(
+                            onClick = { isSearchVisible = true },
+                            variant = ChuButtonVariant.Outlined,
+                            bracketed = true,
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                        ) {
+                            ChuText("filter", style = typography.label, color = colors.textSecondary)
+                        }
+                    }
+                    ChuButton(
+                        onClick = onOpenSettings,
+                        variant = ChuButtonVariant.Outlined,
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        ChuText("settings", style = typography.label, color = colors.textSecondary)
+                    }
                 }
+            }
+
+            if (isSearchVisible) {
+                ChuTextField(
+                    value = searchQuery,
+                    onValueChange = { value ->
+                        onSearchChange(value)
+                        if (value.isBlank()) isSearchVisible = false
+                    },
+                    label = "",
+                    placeholder = "filter hosts",
+                    singleLine = true,
+                    showLabel = false,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
 
             SectionHeader("HOSTS")
@@ -163,7 +192,17 @@ fun ServerListScreen(
                     }
                 }
                 if (hosts.isEmpty()) {
-                    item(key = "empty") { EmptyState() }
+                    item(key = "empty") {
+                        if (searchQuery.isBlank()) {
+                            EmptyState()
+                        } else {
+                            ChuText(
+                                "no hosts match",
+                                style = typography.body,
+                                color = colors.textMuted,
+                            )
+                        }
+                    }
                 } else {
                     items(hosts, key = { it.id }) { host ->
                         val isConnected = host.id in connectedHostIds


### PR DESCRIPTION
### Problem

`ServerListScreen` takes `searchQuery` and `onSearchChange` and references **neither** in its body,
while `ServerListViewModel` implements the whole filter (`hosts.combine(searchQuery)`) and
`ApplicationNavController` wires both parameters through. So the filter runs on an input nothing can
ever change: no search field is drawn, and host search is unreachable.

### Change

Draw it, behind a `[ filter ]` control in the header rather than as an always-present field.

That detail matters: an always-visible `ChuTextField` takes **initial window focus**, so the server list
came up with the soft keyboard raised on every launch and on every Back out of a terminal —
measurably worse than the feature is useful on a list that usually holds a handful of hosts. (I built it
that way first and caught it on device: `dumpsys input_method` reported `mInputShown=true` with the
search field focused. Passing `autoFocus = false` does not prevent initial focus.) Revealing the field
on demand means it can focus itself when it appears, which is what you want then, and clearing the
query hides it again.

When a query filters everything out, a muted `no hosts match` line is shown instead of the first-run
empty state.

### Verified on device

![the host filter control and a filtered list](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr94-host-filter.png)

- cold start → no keyboard, no focused `EditText`
- terminal → Back → server list → no keyboard
- `[ filter ]` → typing `hk` filters to the matching host; clearing restores the full list
- zero-hosts first-run empty state unchanged

Based on `5b059b0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a filter control for searching configured hosts.
  * The filter appears when hosts are available and can be cleared to hide it.
  * Settings remains accessible alongside the new filter option.

* **Bug Fixes**
  * Empty host lists now clearly distinguish between no configured hosts and no matching search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->