### PR TITLE
fix: resolve the Mosh host before starting the client

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/mosh/MoshEndpointResolver.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/mosh/MoshEndpointResolver.kt
@@ -1,0 +1,28 @@
+package com.jossephus.chuchu.service.mosh
+
+import java.net.InetAddress
+import java.net.UnknownHostException
+
+/** Resolves profile host names to the numeric literal required by the Mosh UDP client. */
+object MoshEndpointResolver {
+
+    fun resolve(host: String): String = resolve(host, InetAddress::getAllByName)
+
+    internal fun resolve(
+        host: String,
+        lookup: (String) -> Array<InetAddress>,
+    ): String {
+        val address =
+            try {
+                lookup(host).firstOrNull() ?: throw UnknownHostException(host)
+            } catch (error: UnknownHostException) {
+                throw IllegalStateException(
+                    "Could not resolve Mosh host '$host' to an IP address",
+                    error,
+                )
+            }
+
+        // The port is a separate config field, so IPv6 must remain an unbracketed literal.
+        return address.hostAddress.substringBefore('%')
+    }
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -6,6 +6,7 @@ import com.jossephus.chuchu.model.AuthMethod
 import com.jossephus.chuchu.model.MultiplexerType
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.mosh.MoshBootstrapParser
+import com.jossephus.chuchu.service.mosh.MoshEndpointResolver
 import com.jossephus.chuchu.service.mosh.MoshEventType
 import com.jossephus.chuchu.service.mosh.MoshReconnectPolicy
 import com.jossephus.chuchu.service.mosh.MoshState
@@ -873,6 +874,17 @@ class TerminalSessionEngine(
             privateKeyPem = params.privateKeyPem,
             keyPassphrase = params.keyPassphrase,
         )
+        val endpointHost =
+            try {
+                withContext(Dispatchers.IO) { MoshEndpointResolver.resolve(params.host) }
+            } catch (error: IllegalStateException) {
+                nativeSsh.close()
+                throw error
+            }
+        Log.d(
+            "TerminalSession",
+            "MOSH: Resolved endpoint host=$endpointHost from profile host=${params.host}",
+        )
         // Use exec channel to bypass shell init noise and MOTD.
         // Falls back to shell if the remote server doesn't support exec.
         val moshCommand = MoshReconnectPolicy.bootstrapCommand()
@@ -899,7 +911,7 @@ class TerminalSessionEngine(
                 if (chunk != null && chunk.isNotEmpty()) {
                     val text = String(chunk, Charsets.UTF_8)
                     outputBuffer.append(text)
-                    val result = MoshBootstrapParser.parse(params.host, outputBuffer.toString())
+                    val result = MoshBootstrapParser.parse(endpointHost, outputBuffer.toString())
                     if (result is MoshBootstrapParser.ParseResult.Success) {
                         Log.d(
                             "TerminalSession",

--- a/android/app/src/test/java/com/jossephus/chuchu/service/mosh/MoshEndpointResolverTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/mosh/MoshEndpointResolverTest.kt
@@ -1,0 +1,50 @@
+package com.jossephus.chuchu.service.mosh
+
+import java.net.InetAddress
+import java.net.UnknownHostException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MoshEndpointResolverTest {
+    @Test
+    fun preservesNumericIpv4Literal() {
+        assertEquals("100.72.23.13", MoshEndpointResolver.resolve("100.72.23.13"))
+    }
+
+    @Test
+    fun resolvesDnsNameToIpv4Literal() {
+        val address = InetAddress.getByName("100.72.23.13")
+
+        val result =
+            MoshEndpointResolver.resolve("solom-vps.tail36346.ts.net") { arrayOf(address) }
+
+        assertEquals("100.72.23.13", result)
+    }
+
+    @Test
+    fun preservesIpv6AsAnUnbracketedConfigLiteral() {
+        val address = InetAddress.getByName("2001:db8::13")
+
+        val result = MoshEndpointResolver.resolve("vps.example") { arrayOf(address) }
+
+        assertEquals(address.hostAddress, result)
+        assertTrue(!result.startsWith("["))
+        assertTrue(!result.endsWith("]"))
+    }
+
+    @Test
+    fun namesHostWhenResolutionFails() {
+        val error =
+            try {
+                MoshEndpointResolver.resolve("missing.example") {
+                    throw UnknownHostException("missing.example")
+                }
+                throw AssertionError("Expected resolution to fail")
+            } catch (error: IllegalStateException) {
+                error
+            }
+
+        assertTrue(error.message.orEmpty().contains("missing.example"))
+    }
+}


### PR DESCRIPTION
### Problem

The Mosh transport only works when the profile's host is a numeric IP. Against the **same machine**:

- host `100.72.23.13` → connects; `mosh-server new -s -c 256` is running on the host and `who` reports
  `salem pts/22 (100.65.103.2 via mosh [3001829])`
- host `solom-vps.tail36346.ts.net` → `IllegalStateException: Failed to start mosh client`, in **~1 ms**,
  leaving a Retry button that can never succeed

The SSH transport connects to that same name fine, and the Mosh **bootstrap succeeds** too — the remote
`mosh-server` really does start and print its `MOSH CONNECT <port> <key>` line. Only the UDP client
start rejects it, instantly, which points at the bundled client not resolving names.

Because the failure happens *after* the bootstrap, every attempt also leaves a started `mosh-server`
behind on the remote host until it times out.

Likely unnoticed so far because profiles are usually configured with an IP.

### Cause

`MoshBootstrapParser.parse(host, output)` is handed `params.host` — the raw profile string — and puts it
verbatim into `MoshEndpoint.host`, which the engine serialises straight into the client config.

### Change

Resolve the endpoint host to a numeric literal before starting the client, off the main thread. IPv6
stays an unbracketed literal (the port is a separate config field) and a zone suffix is dropped. An
unresolvable host now reports *which* host failed instead of a generic start failure. Resolving before
the bootstrap also means a bad hostname no longer leaves an orphaned `mosh-server` running remotely.

Unit tests cover numeric-IPv4 passthrough, DNS → literal, unbracketed IPv6, and the error naming the host.

### Verified on device

The exact profile that previously failed instantly now connects:

```
MOSH: Resolved endpoint host=100.72.23.13 from profile host=solom-vps.tail36346.ts.net
MOSH: mosh client started, resizing 80 x 24
MOSH: STATE_CHANGED: running
```

and the session is live server-side. A numeric-IP profile still connects exactly as before.

Based on `5b059b0`.
