### PR TITLE
fix: show when a Mosh session has lost contact

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicy.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicy.kt
@@ -1,6 +1,8 @@
 package com.jossephus.chuchu.service.terminal
 
 import com.jossephus.chuchu.model.Transport
+import com.jossephus.chuchu.service.mosh.MoshRuntimeState
+import com.jossephus.chuchu.service.mosh.MoshState
 
 internal enum class ReadLoopExitAction {
     Disconnect,
@@ -14,3 +16,70 @@ internal fun readLoopExitAction(transport: Transport?): ReadLoopExitAction =
         Transport.Mosh -> ReadLoopExitAction.RequireManualReconnect
         else -> ReadLoopExitAction.AutomaticReconnect
     }
+
+internal fun sessionStatusForMoshState(state: Int): SessionStatus? =
+    when (state) {
+        MoshState.Idle.code,
+        MoshState.Disconnecting.code -> SessionStatus.Disconnected
+        MoshState.Connecting.code -> SessionStatus.Connecting
+        MoshState.Connected.code -> SessionStatus.Connected
+        MoshState.Reconnecting.code -> SessionStatus.Reconnecting
+        MoshState.Failed.code -> SessionStatus.Error
+        else -> null
+    }
+
+internal class MoshConnectionStalenessTracker {
+    private companion object {
+        // Mosh starts warning about lost contact after roughly three seconds; matching that keeps the
+        // terminal responsive without waiting for its intentionally long failure timeout.
+        const val STALE_CONNECTION_THRESHOLD_MS = 3_000L
+    }
+
+    private var lastStateNumReceived: Long? = null
+    private var lastStateNumSent: Long? = null
+    private var lastReceivedAdvanceAtMs: Long? = null
+    private var sentSinceLastReceiveAdvance = false
+
+    fun reset() {
+        lastStateNumReceived = null
+        lastStateNumSent = null
+        lastReceivedAdvanceAtMs = null
+        sentSinceLastReceiveAdvance = false
+    }
+
+    fun observe(runtime: MoshRuntimeState, nowMs: Long): SessionStatus? {
+        val previousReceived = lastStateNumReceived
+        val previousSent = lastStateNumSent
+        if (previousReceived == null || runtime.lastStateNumReceived < previousReceived) {
+            lastStateNumReceived = runtime.lastStateNumReceived
+            lastStateNumSent = runtime.lastStateNumSent
+            lastReceivedAdvanceAtMs = nowMs
+            sentSinceLastReceiveAdvance = false
+            return null
+        }
+
+        val receivedAdvanced = runtime.lastStateNumReceived > previousReceived
+        val sentAdvanced = previousSent != null && runtime.lastStateNumSent > previousSent
+        lastStateNumReceived = runtime.lastStateNumReceived
+        lastStateNumSent = runtime.lastStateNumSent
+
+        if (receivedAdvanced) {
+            lastReceivedAdvanceAtMs = nowMs
+            sentSinceLastReceiveAdvance = false
+            return SessionStatus.Connected
+        }
+        if (sentAdvanced) {
+            sentSinceLastReceiveAdvance = true
+        }
+
+        val staleForMs = nowMs - (lastReceivedAdvanceAtMs ?: nowMs)
+        return if (
+            staleForMs >= STALE_CONNECTION_THRESHOLD_MS &&
+                (runtime.pendingOutbound > 0 || sentSinceLastReceiveAdvance)
+        ) {
+            SessionStatus.Reconnecting
+        } else {
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionEngine.kt
@@ -8,6 +8,7 @@ import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.mosh.MoshBootstrapParser
 import com.jossephus.chuchu.service.mosh.MoshEventType
 import com.jossephus.chuchu.service.mosh.MoshReconnectPolicy
+import com.jossephus.chuchu.service.mosh.MoshRuntimeState
 import com.jossephus.chuchu.service.mosh.MoshState
 import com.jossephus.chuchu.service.mosh.NativeMoshService
 import com.jossephus.chuchu.service.multiplexer.MultiplexerAvailability
@@ -108,6 +109,7 @@ class TerminalSessionEngine(
     @Volatile private var disposed = false
 
     private val bridge = GhosttyBridge()
+    private val moshConnectionStaleness = MoshConnectionStalenessTracker()
     private val nativeSsh = NativeSshService(hostKeyPolicy = ::verifyHostKey)
     private val moshService = NativeMoshService()
 
@@ -785,6 +787,7 @@ class TerminalSessionEngine(
                     MoshEventType.EchoAck.code -> Unit
                     MoshEventType.StateChanged.code -> {
                         Log.d("TerminalSession", "MOSH: STATE_CHANGED: ${String(event.payload)}")
+                        moshService.pollState()?.let { updateMoshRuntimeStatus(it) }
                     }
                     MoshEventType.Diagnostic.code -> {
                         Log.d("TerminalSession", "MOSH: DIAG: ${String(event.payload)}")
@@ -803,6 +806,7 @@ class TerminalSessionEngine(
             // Check session health
             val runtime = moshService.pollState()
             if (runtime != null) {
+                updateMoshRuntimeStatus(runtime)
                 if (runtime.state == MoshState.Failed.code) {
                     failureCode = runtime.lastFailureCode
                     Log.e("TerminalSession", "MOSH: session FAILED code=$failureCode")
@@ -816,6 +820,24 @@ class TerminalSessionEngine(
         }
         Log.d("TerminalSession", "MOSH: read loop exited after $loopCount iterations")
         return failureCode
+    }
+
+    private fun updateMoshSessionStatus(moshState: Int) {
+        val status = sessionStatusForMoshState(moshState) ?: return
+        updateSessionStatus(status)
+    }
+
+    private fun updateMoshRuntimeStatus(runtime: MoshRuntimeState) {
+        updateMoshSessionStatus(runtime.state)
+        moshConnectionStaleness.observe(runtime, System.currentTimeMillis())?.let { status ->
+            updateSessionStatus(status)
+        }
+    }
+
+    private fun updateSessionStatus(status: SessionStatus) {
+        if (_state.value.status != status) {
+            _state.value = _state.value.copy(status = status)
+        }
     }
 
     private suspend fun establishConnection(params: ConnectionParams, username: String) {
@@ -862,6 +884,7 @@ class TerminalSessionEngine(
 
     private suspend fun establishMoshConnection(params: ConnectionParams, username: String) {
         Log.d("TerminalSession", "MOSH: Phase 1 — SSH bootstrap start")
+        moshConnectionStaleness.reset()
         check(nativeSsh.isAvailable()) { "Native SSH unavailable for mosh bootstrap" }
         nativeSsh.connect(
             host = params.host,

--- a/android/app/src/test/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicyTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/terminal/ConnectionRecoveryPolicyTest.kt
@@ -1,7 +1,10 @@
 package com.jossephus.chuchu.service.terminal
 
 import com.jossephus.chuchu.model.Transport
+import com.jossephus.chuchu.service.mosh.MoshRuntimeState
+import com.jossephus.chuchu.service.mosh.MoshState
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ConnectionRecoveryPolicyTest {
@@ -32,4 +35,87 @@ class ConnectionRecoveryPolicyTest {
             readLoopExitAction(Transport.LocalShell),
         )
     }
+
+    @Test
+    fun moshStatesUseTheExistingSessionStatusIndicator() {
+        assertEquals(
+            SessionStatus.Disconnected,
+            sessionStatusForMoshState(MoshState.Idle.code),
+        )
+        assertEquals(
+            SessionStatus.Connecting,
+            sessionStatusForMoshState(MoshState.Connecting.code),
+        )
+        assertEquals(
+            SessionStatus.Connected,
+            sessionStatusForMoshState(MoshState.Connected.code),
+        )
+        assertEquals(
+            SessionStatus.Reconnecting,
+            sessionStatusForMoshState(MoshState.Reconnecting.code),
+        )
+        assertEquals(
+            SessionStatus.Disconnected,
+            sessionStatusForMoshState(MoshState.Disconnecting.code),
+        )
+        assertEquals(
+            SessionStatus.Error,
+            sessionStatusForMoshState(MoshState.Failed.code),
+        )
+    }
+
+    @Test
+    fun moshStalenessReturnsConnectedWhenTheServerAcknowledgesNewState() {
+        val tracker = MoshConnectionStalenessTracker()
+        tracker.observe(moshRuntimeState(sent = 1, received = 1), nowMs = 0)
+
+        assertEquals(
+            SessionStatus.Connected,
+            tracker.observe(moshRuntimeState(sent = 2, received = 2), nowMs = 1_000),
+        )
+    }
+
+    @Test
+    fun moshStalenessReturnsReconnectingWhenOutboundStateStopsBeingAcknowledged() {
+        val tracker = MoshConnectionStalenessTracker()
+        tracker.observe(moshRuntimeState(sent = 1, received = 1), nowMs = 0)
+        tracker.observe(moshRuntimeState(sent = 2, received = 1, pendingOutbound = 1), nowMs = 1)
+
+        assertEquals(
+            SessionStatus.Reconnecting,
+            tracker.observe(
+                moshRuntimeState(sent = 2, received = 1, pendingOutbound = 1),
+                nowMs = 3_001,
+            ),
+        )
+        assertEquals(
+            SessionStatus.Connected,
+            tracker.observe(moshRuntimeState(sent = 2, received = 2), nowMs = 3_002),
+        )
+    }
+
+    @Test
+    fun moshStalenessLeavesAnIdleSessionUnchanged() {
+        val tracker = MoshConnectionStalenessTracker()
+        tracker.observe(moshRuntimeState(sent = 1, received = 1), nowMs = 0)
+
+        assertNull(
+            tracker.observe(moshRuntimeState(sent = 1, received = 1), nowMs = 3_001),
+        )
+    }
+
+    private fun moshRuntimeState(
+        sent: Long,
+        received: Long,
+        pendingOutbound: Int = 0,
+    ): MoshRuntimeState =
+        MoshRuntimeState(
+            state = MoshState.Connected.code,
+            lastFailureCode = 0,
+            lastStateNumSent = sent,
+            lastStateNumReceived = received,
+            pendingOutbound = pendingOutbound,
+            pendingHostOps = 0,
+            currentRtoMs = 0,
+        )
 }


### PR DESCRIPTION
### Problem

A Mosh session gives no indication when it has lost contact with the server.

Measured on device by freezing the remote `mosh-server` with `SIGSTOP`, typing, and resuming: the
session recovered perfectly and the buffered input executed — Mosh doing exactly what it exists for —
but **nothing was shown for the whole outage**. Then killing the `mosh-server` outright (confirmed gone
from `ps` and `who`): **60+ seconds later the tab was still visually identical to a healthy session**,
and typed input did not even echo.

SSH shows `Reconnecting` in the same situation, so the transport built for lossy links was the one
without feedback. This is also a plausible source of the perception in #66 ("display freezes ... while
input and connection stay alive").

### Why the obvious fix isn't enough

Mapping `MoshState` onto `SessionStatus` alone does nothing here: the client network timeout is ~31 days
by design (#75, deliberately ordered so the client never gives up before the server expires), so the
runtime does not leave the connected state when contact is lost. No state change is emitted at all — I
saw none during either the freeze or the kill.

### Change

Derive staleness from the counters `pollState()` already returns, so no native change is needed. When
the received state number stops advancing for a few seconds **while something is outstanding**, report
the existing `SessionStatus.Reconnecting`; when it advances again, report `Connected`.

- Requiring outstanding work is what keeps an idle session from flapping into "Reconnecting".
- Counters are re-baselined if they regress.
- The `MoshReconnectPolicy` constants are untouched — this only *reports* what is happening, it does not
  change when the session gives up.
- The existing renderer omits the attempt counter when it is zero, so Mosh shows a plain `Reconnecting`
  and reuses the indicator SSH already has rather than introducing a second one.

### Verified on device

![the Mosh session reporting lost contact](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr96-mosh-status.png)

With the remote `mosh-server` killed:

- idle, no input → no indicator (the anti-flap guard holding, and consistent with upstream mosh, which
  warns when it has unacknowledged state)
- after typing → `Reconnecting` appears within a few seconds, in the same place SSH shows it

A healthy session shows no spurious indicator.

Based on `5b059b0`.