### PR TITLE
fix: keep SFTP transfers alive across slow network windows

### DIFF
--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -77,7 +77,7 @@ fn setLibssh2Error(session: *NativeSshSession, prefix: []const u8, rc: c_int) vo
         _ = c.libssh2_session_last_error(ssh_session, @ptrCast(&errmsg_ptr), &errmsg_len, 0);
     }
     if (errmsg_ptr != null and errmsg_len > 0) {
-        setError(session, "{s}: {s}", .{ prefix, errmsg_ptr[0..@intCast(errmsg_len)] });
+        setError(session, "{s}: {s} (rc={})", .{ prefix, errmsg_ptr[0..@intCast(errmsg_len)], rc });
     } else {
         setError(session, "{s}: rc={}", .{ prefix, rc });
     }
@@ -1364,10 +1364,24 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpOpenWr
     defer allocator.free(path_z);
 
     if (session.upload_handle) |stale| {
-        while (true) {
+        const started_ms = nowMs();
+        var idle_since_ms = started_ms;
+        var eagain_count: u64 = 0;
+        close_stale: while (true) {
             const rc = c.libssh2_sftp_close_handle(stale);
             if (rc != c.LIBSSH2_ERROR_EAGAIN) break;
-            if (!waitSocket(session, io_wait_timeout_ms)) break;
+            eagain_count +%= 1;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => {},
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    logError(
+                        "SFTP close timed out after {}ms (idle {}ms, EAGAIN={})",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    break :close_stale;
+                },
+            }
         }
         session.upload_handle = null;
     }
@@ -1389,19 +1403,31 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpWriteC
     const data_ptr = env.*.*.GetByteArrayElements.?(env, data, null) orelse return -1;
     defer env.*.*.ReleaseByteArrayElements.?(env, data, data_ptr, c.JNI_ABORT);
     const ptr: [*]const u8 = @ptrCast(data_ptr);
-    const sftp_write_idle_limit_ms: i64 = 30_000;
     var written: usize = 0;
-    var idle_since_ms: i64 = std.time.milliTimestamp();
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u64 = 0;
     while (written < @as(usize, @intCast(data_len))) {
         const remaining: usize = @as(usize, @intCast(data_len)) - written;
         const chunk_size: usize = @min(remaining, 32768);
         const rc = c.libssh2_sftp_write(sftp_handle, ptr + written, chunk_size);
         if (rc == c.LIBSSH2_ERROR_EAGAIN or rc == 0) {
-            if (waitSocket(session, io_wait_timeout_ms)) {
-                idle_since_ms = std.time.milliTimestamp();
-            } else if (std.time.milliTimestamp() - idle_since_ms > sftp_write_idle_limit_ms) {
-                setError(session, "SFTP write stalled (no socket activity for {d}ms)", .{sftp_write_idle_limit_ms});
-                return -1;
+            eagain_count +%= 1;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => {},
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    setError(
+                        session,
+                        "SFTP write timed out after {d}ms (idle {d}ms, EAGAIN={d})",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    logError(
+                        "SFTP write timeout elapsed={}ms idle={}ms eagain={}",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    return -1;
+                },
             }
             continue;
         }
@@ -1410,7 +1436,7 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpWriteC
             return -1;
         }
         written += @intCast(rc);
-        idle_since_ms = std.time.milliTimestamp();
+        idle_since_ms = nowMs();
     }
 
     return @intCast(written);
@@ -1422,19 +1448,31 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpCloseW
     const session = sessionFromHandle(handle) orelse return c.JNI_FALSE;
     const sftp_handle = session.upload_handle orelse return c.JNI_FALSE;
     session.upload_handle = null;
-    const close_idle_limit_ms: i64 = 10_000;
-    var idle_since_ms: i64 = std.time.milliTimestamp();
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u64 = 0;
     while (true) {
         const rc = c.libssh2_sftp_close_handle(sftp_handle);
         if (rc == 0) return c.JNI_TRUE;
         if (rc == c.LIBSSH2_ERROR_EAGAIN) {
-            if (waitSocket(session, io_wait_timeout_ms)) {
-                idle_since_ms = std.time.milliTimestamp();
-                continue;
+            eagain_count +%= 1;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => {},
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    setError(
+                        session,
+                        "SFTP close timed out after {d}ms (idle {d}ms, EAGAIN={d})",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    logError(
+                        "SFTP close timeout elapsed={}ms idle={}ms eagain={}",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    return c.JNI_FALSE;
+                },
             }
-            if (std.time.milliTimestamp() - idle_since_ms < close_idle_limit_ms) continue;
-            setError(session, "SFTP close stalled (no socket activity for {d}ms)", .{close_idle_limit_ms});
-            return c.JNI_FALSE;
+            continue;
         }
         setLibssh2Error(session, "SFTP close failed", @intCast(rc));
         return c.JNI_FALSE;
@@ -1451,11 +1489,15 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpReadFi
     defer allocator.free(path_z);
     const file = sftpOpenFile(session, sftp, path_z, c.LIBSSH2_FXF_READ, 0) orelse return null;
     defer {
+        var idle_since_ms = nowMs();
         while (true) {
             const rc = c.libssh2_sftp_close_handle(file);
             if (rc == 0) break;
             if (rc == c.LIBSSH2_ERROR_EAGAIN) {
-                if (waitSocket(session, io_wait_timeout_ms)) continue;
+                switch (awaitSftpProgress(session, &idle_since_ms)) {
+                    .retry => continue,
+                    .no_socket, .stalled => {},
+                }
             }
             logInfo("SFTP close handle failed rc={}", .{rc});
             break;
@@ -1466,15 +1508,37 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpReadFi
     defer out.deinit(allocator);
     const limit: usize = if (max_bytes <= 0) 4096 else @intCast(max_bytes);
     var buf: [32768]u8 = undefined;
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u64 = 0;
     while (out.items.len < limit) {
         const want = @min(buf.len, limit - out.items.len);
         const rc = c.libssh2_sftp_read(file, &buf, want);
         if (rc > 0) {
             out.appendSlice(allocator, buf[0..@intCast(rc)]) catch return null;
+            idle_since_ms = nowMs();
             continue;
         }
         if (rc == 0) break;
-        if (rc == c.LIBSSH2_ERROR_EAGAIN and waitSocket(session, io_wait_timeout_ms)) continue;
+        if (rc == c.LIBSSH2_ERROR_EAGAIN) {
+            eagain_count +%= 1;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => continue,
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    setError(
+                        session,
+                        "SFTP read timed out after {d}ms (idle {d}ms, EAGAIN={d})",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    logError(
+                        "SFTP read timeout elapsed={}ms idle={}ms eagain={}",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    return null;
+                },
+            }
+        }
         setLibssh2Error(session, "SFTP read failed", @intCast(rc));
         return null;
     }
@@ -1489,10 +1553,31 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpDelete
     defer allocator.free(path_bytes);
     const path_z = dupSentinel(path_bytes) orelse return c.JNI_FALSE;
     defer allocator.free(path_z);
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u64 = 0;
     while (true) {
         const rc = c.libssh2_sftp_unlink_ex(sftp, path_z.ptr, @intCast(path_z.len));
         if (rc == 0) return c.JNI_TRUE;
-        if (rc == c.LIBSSH2_ERROR_EAGAIN and waitSocket(session, io_wait_timeout_ms)) continue;
+        if (rc == c.LIBSSH2_ERROR_EAGAIN) {
+            eagain_count +%= 1;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => continue,
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    setError(
+                        session,
+                        "SFTP delete file timed out after {d}ms (idle {d}ms, EAGAIN={d})",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    logError(
+                        "SFTP delete file timeout elapsed={}ms idle={}ms eagain={}",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    return c.JNI_FALSE;
+                },
+            }
+        }
         setLibssh2Error(session, "SFTP delete file failed", @intCast(rc));
         return c.JNI_FALSE;
     }
@@ -1506,16 +1591,40 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpDelete
     defer allocator.free(path_bytes);
     const path_z = dupSentinel(path_bytes) orelse return c.JNI_FALSE;
     defer allocator.free(path_z);
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u64 = 0;
     while (true) {
         const rc = c.libssh2_sftp_rmdir_ex(sftp, path_z.ptr, @intCast(path_z.len));
         if (rc == 0) return c.JNI_TRUE;
-        if (rc == c.LIBSSH2_ERROR_EAGAIN and waitSocket(session, io_wait_timeout_ms)) continue;
+        if (rc == c.LIBSSH2_ERROR_EAGAIN) {
+            eagain_count +%= 1;
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => continue,
+                .no_socket, .stalled => {
+                    const now = nowMs();
+                    setError(
+                        session,
+                        "SFTP delete directory timed out after {d}ms (idle {d}ms, EAGAIN={d})",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    logError(
+                        "SFTP delete directory timeout elapsed={}ms idle={}ms eagain={}",
+                        .{ now - started_ms, now - idle_since_ms, eagain_count },
+                    );
+                    return c.JNI_FALSE;
+                },
+            }
+        }
         setLibssh2Error(session, "SFTP delete directory failed", @intCast(rc));
         return c.JNI_FALSE;
     }
 }
 
 fn sftpOpenFile(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, path_z: [:0]u8, flags: c_ulong, mode: c_long) ?*c.LIBSSH2_SFTP_HANDLE {
+    const started_ms = nowMs();
+    var idle_since_ms = started_ms;
+    var eagain_count: u64 = 0;
     while (true) {
         const file = c.libssh2_sftp_open(sftp, path_z.ptr, flags, mode);
         if (file != null) return file;
@@ -1524,9 +1633,22 @@ fn sftpOpenFile(session: *NativeSshSession, sftp: *c.LIBSSH2_SFTP, path_z: [:0]u
             setLibssh2Error(session, "SFTP open failed", rc);
             return null;
         }
-        if (!waitSocket(session, io_wait_timeout_ms)) {
-            setError(session, "SFTP open timed out", .{});
-            return null;
+        eagain_count +%= 1;
+        switch (awaitSftpProgress(session, &idle_since_ms)) {
+            .retry => {},
+            .no_socket, .stalled => {
+                const now = nowMs();
+                setError(
+                    session,
+                    "SFTP open timed out after {d}ms (idle {d}ms, EAGAIN={d})",
+                    .{ now - started_ms, now - idle_since_ms, eagain_count },
+                );
+                logError(
+                    "SFTP open timeout elapsed={}ms idle={}ms eagain={}",
+                    .{ now - started_ms, now - idle_since_ms, eagain_count },
+                );
+                return null;
+            },
         }
     }
 }

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -144,9 +144,11 @@ fn clearHostKeyCopy(session: *NativeSshSession) void {
     session.hostkey_type = 0;
 }
 
-fn waitSocket(session: *NativeSshSession, timeout_ms: c_int) bool {
-    const ssh_session = session.session orelse return false;
-    if (session.socket_fd < 0) return false;
+const SocketWait = enum { ready, timeout, failed };
+
+fn pollSocket(session: *NativeSshSession, timeout_ms: c_int) SocketWait {
+    const ssh_session = session.session orelse return .failed;
+    if (session.socket_fd < 0) return .failed;
 
     const directions = c.libssh2_session_block_directions(ssh_session);
     var events: c_short = 0;
@@ -166,7 +168,17 @@ fn waitSocket(session: *NativeSshSession, timeout_ms: c_int) bool {
         .revents = 0,
     }};
     const poll_rc = c.poll(&poll_fds, 1, timeout_ms);
-    return poll_rc > 0;
+    if (poll_rc < 0) return .failed;
+    if (poll_rc == 0) return .timeout;
+
+    const revents = poll_fds[0].revents;
+    if ((revents & (c.POLLIN | c.POLLOUT)) != 0) return .ready;
+    if ((revents & (c.POLLERR | c.POLLHUP | c.POLLNVAL)) != 0) return .failed;
+    return .ready;
+}
+
+fn waitSocket(session: *NativeSshSession, timeout_ms: c_int) bool {
+    return pollSocket(session, timeout_ms) == .ready;
 }
 
 fn trySetChannelEnv(session: *NativeSshSession, channel: *c.LIBSSH2_CHANNEL, name: []const u8, value: []const u8) void {
@@ -256,10 +268,13 @@ const SftpProgress = enum {
 /// caller should retry. `idle_since_ms` is reset whenever the socket signals
 /// activity so the idle budget only measures genuinely silent periods.
 fn awaitSftpProgress(session: *NativeSshSession, idle_since_ms: *i64) SftpProgress {
-    if (session.session == null or session.socket_fd < 0) return .no_socket;
-    if (waitSocket(session, io_wait_timeout_ms)) {
-        idle_since_ms.* = nowMs();
-        return .retry;
+    switch (pollSocket(session, io_wait_timeout_ms)) {
+        .ready => {
+            idle_since_ms.* = nowMs();
+            return .retry;
+        },
+        .failed => return .no_socket,
+        .timeout => {},
     }
     if (nowMs() - idle_since_ms.* > sftp_idle_limit_ms) return .stalled;
     return .retry;


### PR DESCRIPTION
Fixes #81.

## What happens

`nativeSftpReadFile` (and every other SFTP data-path call) treats a single 120 ms socket poll as the whole retry budget:

```zig
if (rc == c.LIBSSH2_ERROR_EAGAIN and waitSocket(session, io_wait_timeout_ms)) continue;
setLibssh2Error(session, "SFTP read failed", @intCast(rc));
return null;
```

`io_wait_timeout_ms` is 120. If the socket is not ready inside that window the `and` short-circuits and the **entire transfer is failed**, even though `EAGAIN` only means "nothing to do right now".

A 900 KB file read in 32 KB chunks is ~28 iterations, so ~28 independent chances to land on one slow window. Over Tailscale — especially relayed — a >120 ms gap is routine, which is why the failure looks random and why retrying eventually works.

#20 already solved exactly this for directory listing by adding `awaitSftpProgress`, which keeps an idle deadline, resets it on every socket wakeup, and only gives up after `sftp_idle_limit_ms` (15 s) of *no activity at all*. That helper was only ever wired into `sftpOpenDir`/readdir/shutdown. Download, upload, open and delete were left on the bare poll — which is why browsing is reliable while downloads are not.

## Why retrying often fails a second time

Abandoning the call mid-request also corrupts libssh2's state. In `sftp_packet_requirev`:

```c
if(sftp->requirev_start == 0)
    sftp->requirev_start = time(NULL);
...
else if(rc == LIBSSH2_ERROR_EAGAIN) {
    return rc;                     /* requirev_start stays set */
}
...
long left = session->packet_read_timeout - (time(NULL) - sftp->requirev_start);
if(left <= 0) { sftp->requirev_start = 0; return LIBSSH2_ERROR_TIMEOUT; }
```

`requirev_start` is a wall-clock deadline that survives `EAGAIN` returns, and the budget is `packet_read_timeout` (`LIBSSH2_DEFAULT_READ_TIMEOUT`, 60 s — chuchu never calls `libssh2_session_set_timeout`). So when we walk away from an in-flight request and the user retries more than 60 s later, the next call finds an already-expired deadline and fails **instantly**, without touching the network.

That is observable: on a device I measured retries failing in **0.5 s** and **0.9 s** with `SFTP open failed: Timeout waiting for status message` — far too fast to be a real 60 s timeout.

## The change

Route the SFTP data path through the same `awaitSftpProgress` helper the listing path already uses — read, write, open, close and delete. The idle deadline is reset whenever bytes actually move, so the 15 s budget measures *consecutive* idleness, not elapsed transfer time: a large download over a slow link keeps going, while a genuinely dead peer still fails.

Also include the return code in `setLibssh2Error`. It currently drops `rc` whenever libssh2 has any last-error string, and that string is sticky and frequently unrelated to the call that just failed — which is why this issue arrived as a bare `sftp_read() internal error` with no code.

## Measured on device

Oppo Pad Mini over Tailscale, downloading a 900 KB file, same host and same session in both cases:

- **before:** 4 successes in 11 attempts
- **after:** 12 successes in 12 attempts

Downloaded bytes verified with sha256 against the source (the data was always correct when a download completed — this is purely an availability bug). Uploads, deletes and listing re-tested, no regression.

Built with `zig build -Doptimize=ReleaseSmall -Dtarget=aarch64-linux-android.24 jni`; `:app:compileDebugKotlin` and `:app:testDebugUnitTest` pass.

## Second commit: socket error/hangup is now terminal

Added after review. `waitSocket` ended in `return poll_rc > 0` without looking at `revents`, and `poll()` reports `POLLERR`/`POLLHUP`/`POLLNVAL` whether or not they were requested — returning immediately when one is set. A dead socket therefore looked like activity, so `awaitSftpProgress` reset its idle deadline every pass and the 15 s budget could never expire: a tight loop at full CPU that never times out. That defeats the guarantee this PR exists to provide, so it belongs here.

The poll result is now classified rather than collapsed to a bool, checking readability **first** so a `POLLHUP` that still has buffered data is drained normally instead of being treated as failure. `awaitSftpProgress` maps a failed socket to `.no_socket` immediately rather than waiting out the idle budget. `waitSocket` keeps its signature, so its other call sites are unchanged in shape.

Re-verified on device after this commit: 900 KB download 5/5, then again 3/3 after the test below. Killing the server-side sshd mid-download now surfaces `Download failed: SFTP init failed: Unable to request SFTP subsystem (rc=-21)` in **0.5 s** — prompt and specific, with no hang and no spin — and the next download succeeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx
