### PR TITLE
fix: do not silently truncate SFTP downloads

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/ssh/NativeSshService.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/ssh/NativeSshService.kt
@@ -10,6 +10,7 @@ class NativeSshService(
     private val hostKeyPolicy: HostKeyPolicy,
 ) : Closeable {
     private companion object {
+        // Absolute in-memory ceiling; callers request 16/32 MiB, so this is the effective download limit.
         private const val MAX_SFTP_READ_BYTES = 4 * 1024 * 1024
     }
 

--- a/zig-src/src/bridge/chuchu_ssh.zig
+++ b/zig-src/src/bridge/chuchu_ssh.zig
@@ -1478,6 +1478,30 @@ export fn Java_com_jossephus_chuchu_service_ssh_NativeSshBridge_nativeSftpReadFi
         setLibssh2Error(session, "SFTP read failed", @intCast(rc));
         return null;
     }
+
+    if (out.items.len == limit) {
+        var probe: [1]u8 = undefined;
+        var idle_since_ms = nowMs();
+        while (true) {
+            const rc = c.libssh2_sftp_read(file, &probe, probe.len);
+            if (rc > 0) {
+                setError(session, "SFTP read aborted: {s} is larger than the {d} byte download limit", .{ path_z, limit });
+                return null;
+            }
+            if (rc == 0) break;
+            if (rc != c.LIBSSH2_ERROR_EAGAIN) {
+                setLibssh2Error(session, "SFTP read failed", @intCast(rc));
+                return null;
+            }
+            switch (awaitSftpProgress(session, &idle_since_ms)) {
+                .retry => {},
+                .no_socket, .stalled => {
+                    setError(session, "SFTP read probe timed out for {s}", .{path_z});
+                    return null;
+                },
+            }
+        }
+    }
     return jniNewByteArrayOrNull(env, out.items);
 }
 


### PR DESCRIPTION
## What happens

Downloading a file larger than 4 MiB produces a **truncated, corrupt file** on the device — and the app reports success with a `Downloaded <name>` toast. Nothing tells the user anything went wrong.

Measured on an Oppo Pad Mini against a known source:

```
source  sftp-test-6m.bin   6291456 bytes   f72ce1759bdae777...
device  sftp-test-6m.bin   4194304 bytes   5ee40ec0f5e68dd6...
```

Exactly 4 MiB. A 900 KB file from the same directory round-trips byte for byte, so the transfer itself is fine — the read is being cut off at a fixed boundary and the short result is reported as a complete one.

## Why

Three layers each assume someone else is checking:

1. `TerminalScreen.kt` asks for a generous limit — `16 * 1024 * 1024` for download, `32 * 1024 * 1024` for open.
2. `NativeSshService.sftpReadFile` silently overrules both:
   ```kotlin
   private const val MAX_SFTP_READ_BYTES = 4 * 1024 * 1024
   val boundedMaxBytes = minOf(maxBytes, MAX_SFTP_READ_BYTES)
   ```
   The caller is never told its request was reduced.
3. `nativeSftpReadFile` stops when the buffer reaches the limit and returns it through the *same path* as a genuine end-of-file:
   ```zig
   while (out.items.len < limit) { ... if (rc == 0) break; ... }
   return jniNewByteArrayOrNull(env, out.items);
   ```
   "Ran out of budget" and "reached EOF" are indistinguishable to the caller.

So a truncated read is indistinguishable from a complete one, and the UI writes it out and reports success.

## The change

Once the buffer is full, probe for one more byte. If any data is there the file is larger than the limit, so fail with a message naming both the path and the limit instead of returning a short read. If the probe hits EOF the file was exactly the limit and the download is genuinely complete, so that case still succeeds. The probe handles `EAGAIN` through the existing `awaitSftpProgress` idle-budget helper rather than a bare poll.

`MAX_SFTP_READ_BYTES` is left at its current value — that is a memory-policy decision, and this PR is only about not lying about the result. It is worth deciding separately though: the whole file is buffered in RAM, the callers clearly did not intend a 4 MiB cap (they ask for 16 and 32 MiB), and a file browser that cannot fetch anything over 4 MiB is a real limitation. Streaming straight to the SAF destination would lift it properly, but that needs the destination chosen *before* the read, so it is a bigger change than this.

## Verified on device

After the fix, the same 6.0 MB file gives:

```
Download failed: SFTP read aborted: /home/salem/.AAA-sftp/sftp-test-6m.bin
is larger than the 4194304 byte download limit
```

and **no file is written**, instead of a corrupt one. The 900 KB file still downloads (3/3) and still matches the source sha256.

Built with `zig build -Doptimize=ReleaseSmall -Dtarget=aarch64-linux-android.24 jni`; `:app:compileDebugKotlin` passes.

Note for whoever merges: this and #97 both add a local in `nativeSftpReadFile`. Applied together they need one variable renamed (`idle_since_ms` in the probe loop) — each branch compiles on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SFTP downloads now detect when files exceed the configured download limit.
  * Oversized files return an explicit error instead of being silently truncated.
  * Improved handling of temporary transfer stalls and probe failures, providing clearer failure behavior during downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->