### PR TITLE
fix: wait for the session before starting an SFTP transfer

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSessionRepository.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TerminalSessionRepository private constructor(application: Application) {
@@ -332,6 +334,14 @@ class TerminalSessionRepository private constructor(application: Application) {
 
     private fun sftpEngineForTab(tabId: String): TerminalSessionEngine? =
         _tabs.value.firstOrNull { it.id == tabId && it.spec.transport != Transport.LocalShell }?.engine
+
+    suspend fun awaitTabConnected(tabId: String, timeoutMs: Long = 20_000) {
+        val tab = _tabs.value.firstOrNull { it.id == tabId && it.spec.transport != Transport.LocalShell } ?: return
+        if (tab.sessionState.value.status == SessionStatus.Connected) return
+        withTimeoutOrNull(timeoutMs) {
+            tab.sessionState.first { it.status == SessionStatus.Connected }
+        } ?: throw IllegalStateException("Timed out waiting for the session to reconnect")
+    }
 
     fun resize(
         cols: Int,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -573,6 +573,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
         val tabId = activeTabId.value ?: return
         val current = _fileBrowserStateByTab.value[tabId] ?: return
         val targetPath = current.currentPath.trimEnd('/') + "/" + fileName
+        sessionRepository.awaitTabConnected(tabId)
         sessionRepository.sftpOpenWrite(tabId, targetPath)
     }
 
@@ -617,6 +618,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     }
 
     suspend fun readFile(tabId: String, entry: FileBrowserEntry, maxBytes: Int): ByteArray {
+        sessionRepository.awaitTabConnected(tabId)
         return sessionRepository.sftpReadFile(tabId, entry.path, maxBytes)
     }
 


### PR DESCRIPTION
## What happens

Tap `[ ↑ ]` in the file browser, pick a file, and the upload fails:

```
Uploaded 0, 1 failed: SFTP init failed: Unable to startup channel (rc=-21)
```

Nothing reaches the server. In normal use it fails every time — I hit it 3/3 before working out why.

## Why

Measured on an Oppo Pad Mini with the server on the other end of the session:

1. The upload button launches a SAF picker (`GetMultipleContents`), which necessarily backgrounds the app while the user browses.
2. **About 6 s after the app is backgrounded the SSH TCP connection is gone.** Confirmed from both ends — `ss` on the server *and* on the tablet show zero connections.
3. On return the app reconnects; the new connection is established around **t+3 s**.
4. The picker's result callback fires at **t≈0** and calls `vm.beginUpload(...)` → `sftpOpenWrite` → `nativeSftpInit` immediately, against a session that has no transport yet. libssh2 cannot open the channel and returns `LIBSSH2_ERROR_CHANNEL_FAILURE` (-21).

The write always races a reconnect it never waits for, and always loses.

**Proof of mechanism:** driving the picker fast enough to select a file inside that ~6 s window — so the connection never drops — makes the upload succeed, with the uploaded file matching the source sha256 byte for byte. The SFTP write path is fine; only the sequencing is wrong.

Downloads mostly escape this because they read *before* opening their picker, but a download started right after returning to the app hits the same race, so it takes the same wait.

## The change

Add a bounded `awaitTabConnected(tabId)` on the repository and call it before opening the remote file for upload and before a download read. It returns immediately when the session is already connected (the normal path costs nothing), and throws after a 20 s timeout so a genuinely dead host still fails rather than hanging. Both call sites already catch exceptions, so the existing toast reports it.

Chunk writes and the close are untouched — once the handle is open the session is up, and waiting per 64 KB chunk would be pointless.

## Verified on device

Same scenario that failed before — open the picker, wait past the drop (connection confirmed gone), then pick the file:

- **before:** 0 successes in 3 attempts
- **after:** 2 for 2, `Uploaded 1 file(s)`, uploaded bytes matching the source sha256

`:app:compileDebugKotlin` and `:app:testDebugUnitTest` pass. No native changes.

## Separately worth a look — and I was wrong about the cause

I originally wrote here that every OS-side indicator said the OS was not the one cutting the connection. That was wrong, and I have since traced it. For anyone hitting this, the real mechanism is ColorOS's app freezer:

```
I/OplusHansManager: uid=10045, pkg=com.jossephus.chuchu.dogfood F enter(), M stay=3
I/OplusHansManager: freeze uid: 10045 ... scene: |StrictMode-1|LcdOn
D/MediaFocusControlExtImpl: onUidFrozenChanged success + uid = 10045, frozen = true
E/OplusNetd: DestroyAllSocket 1 sockets for uids{ 10045 } skip={0} in 4777us
```

About 5 s after the app leaves the foreground, ColorOS freezes the uid and `OplusNetd` **explicitly destroys all of its sockets** — screen still on. The `specialUse` foreground service does not exempt it; in the same log Tailscale is skipped with `cannot transition from R to M, importance=vpn`.

The checks that misled me are simply blind to this: `/proc/<pid>/cgroup` still reports `freezer:/` and `cpuset:/foreground` while frozen this way, and `dumpsys netpolicy` reports `effective=NONE` because netd is destroying the sockets directly rather than applying a policy rule.

Confirmed causally in both directions — adding the app to the battery whitelist (`dumpsys deviceidle whitelist +<pkg>`) makes Hans stop at `M enter()` instead of `F enter()`, no `destroyAllSocketForUid`, and the connection then survives indefinitely in the background.

So this is not a chuchu bug, and this PR does not try to fix it. It is worth knowing about though, because it affects every ColorOS/OxygenOS/realme UI user: sessions die a few seconds after switching apps unless the user exempts chuchu from battery optimisation. Prompting for `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` would address it properly — happy to send that separately if you want it.

The race this PR fixes is real regardless: any reconnect in flight when a transfer starts hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx
