### PR TITLE
feat: open the file browser at the session's current directory

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -465,6 +465,18 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
 
     private fun resolveInitialFilePathAndRefresh(tabId: String) {
         if (!tabExists(tabId)) return
+        val pwd =
+            sessionRepository.tabs.value
+                .firstOrNull { it.id == tabId }
+                ?.sessionState
+                ?.value
+                ?.pwd
+                ?.takeIf { it.isNotBlank() }
+        if (pwd != null) {
+            updateFileBrowserState(tabId) { it.copy(currentPath = pwd, resolvedHomePath = pwd) }
+            refreshFileBrowser(tabId)
+            return
+        }
         val cachedHome = fileHomeByTab[tabId]
         if (cachedHome != null) {
             updateFileBrowserState(tabId) { it.copy(currentPath = cachedHome) }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -454,6 +454,14 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
 
     private fun tabExists(tabId: String): Boolean = sessionRepository.tabs.value.any { it.id == tabId }
 
+    private fun currentSessionPwd(tabId: String): String? =
+        sessionRepository.tabs.value
+            .firstOrNull { it.id == tabId }
+            ?.sessionState
+            ?.value
+            ?.pwd
+            ?.takeIf { it.isNotBlank() }
+
     private suspend fun resolveRealpath(tabId: String, path: String): String? =
         try {
             sessionRepository.sftpRealpath(tabId, path).takeIf { it.isNotBlank() }
@@ -465,13 +473,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
 
     private fun resolveInitialFilePathAndRefresh(tabId: String) {
         if (!tabExists(tabId)) return
-        val pwd =
-            sessionRepository.tabs.value
-                .firstOrNull { it.id == tabId }
-                ?.sessionState
-                ?.value
-                ?.pwd
-                ?.takeIf { it.isNotBlank() }
+        val pwd = currentSessionPwd(tabId)
         if (pwd != null) {
             updateFileBrowserState(tabId) { it.copy(currentPath = pwd, resolvedHomePath = pwd) }
             refreshFileBrowser(tabId)
@@ -490,8 +492,9 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
                 val fallback = tabState?.engine?.state?.value?.pwd?.takeIf { it.isNotBlank() } ?: "/"
                 val resolved = resolveRealpath(tabId, ".") ?: resolveRealpath(tabId, "~")
                 if (!isActive || !tabExists(tabId)) return@launch
-                val initial = resolved ?: fallback
-                fileHomeByTab[tabId] = initial
+                val home = resolved ?: fallback
+                val initial = currentSessionPwd(tabId) ?: home
+                fileHomeByTab[tabId] = home
                 updateFileBrowserState(tabId) {
                     it.copy(currentPath = initial, resolvedHomePath = initial)
                 }

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -45,6 +45,7 @@ const CELL_FLAG_SPACER: u8 = 1 << 7;
 const IMAGE_HEADER_BYTES = 52;
 const MAX_KITTY_IMAGES = 64;
 const MAX_OSC52_CLIPBOARD_BYTES = 1024 * 1024;
+const MAX_OSC7_PWD_BYTES = 4096;
 // Kitty Unicode graphics placeholder (U+10EEEE). These cells only mark where an
 // image is composited; we blank them so the raw glyph never shows through a gap
 // the image doesn't fully cover.
@@ -159,6 +160,9 @@ const ChuchuStreamHandler = struct {
         if (action == .clipboard_contents) {
             self.clipboardContents(value.kind, value.data);
         }
+        if (action == .report_pwd) {
+            self.reportPwd(value.url);
+        }
         self.inner.vt(action, value);
     }
 
@@ -166,9 +170,58 @@ const ChuchuStreamHandler = struct {
         if (std.mem.eql(u8, data, "?")) return;
         storeClipboardData(self.owner, data);
     }
+
+    fn reportPwd(self: *ChuchuStreamHandler, url: []const u8) void {
+        var decoded: [MAX_OSC7_PWD_BYTES]u8 = undefined;
+        const pwd = decodeOsc7FilePath(url, &decoded) orelse return;
+        // Chuchu terminals are remote, so their reported path is useful even when the URL host is not local.
+        self.owner.terminal.setPwd(pwd) catch return;
+    }
 };
 
 const ChuchuTerminalStream = ghostty.Stream(*ChuchuStreamHandler);
+
+fn decodeOsc7FilePath(url: []const u8, decoded: *[MAX_OSC7_PWD_BYTES]u8) ?[]const u8 {
+    const prefix = "file://";
+    if (!std.mem.startsWith(u8, url, prefix) or url.len > MAX_OSC7_PWD_BYTES) return null;
+
+    const host_and_path = url[prefix.len..];
+    const path_start = std.mem.indexOfScalar(u8, host_and_path, '/') orelse return null;
+    const encoded_path = host_and_path[path_start..];
+    if (encoded_path.len == 0) return null;
+
+    var encoded_index: usize = 0;
+    var decoded_len: usize = 0;
+    while (encoded_index < encoded_path.len) {
+        const byte = encoded_path[encoded_index];
+        if (byte == '%' and encoded_index + 2 < encoded_path.len) {
+            if (hexValue(encoded_path[encoded_index + 1])) |high| {
+                if (hexValue(encoded_path[encoded_index + 2])) |low| {
+                    decoded[decoded_len] = high * 16 + low;
+                    decoded_len += 1;
+                    encoded_index += 3;
+                    continue;
+                }
+            }
+        }
+        decoded[decoded_len] = byte;
+        decoded_len += 1;
+        encoded_index += 1;
+    }
+
+    const path = decoded[0..decoded_len];
+    if (!std.mem.startsWith(u8, path, "/")) return null;
+    return path;
+}
+
+fn hexValue(byte: u8) ?u8 {
+    return switch (byte) {
+        '0'...'9' => byte - '0',
+        'a'...'f' => byte - 'a' + 10,
+        'A'...'F' => byte - 'A' + 10,
+        else => null,
+    };
+}
 
 fn chuchuFromHandle(handle: c.jlong) ?*ChuchuTerminal {
     if (handle == 0) return null;


### PR DESCRIPTION
Closes #82.

## What it does

The file browser opens at the directory the shell is actually in, instead of always at home.

## Why it always opened at home

Two things, in `TerminalViewModel.resolveInitialFilePathAndRefresh`:

1. The initial path came from `resolveRealpath(tabId, ".")` — but that resolves `.` over the **SFTP** channel, whose working directory is the login directory, not the interactive shell's. So it was effectively always home.
2. The result was cached in `fileHomeByTab`, so every later open short-circuited straight back to it.

There is already a `pwd` fallback in that function, but it could never be reached.

## The working directory was never actually being populated

This is the part that made it more than a one-line change. The chain looked complete — `Terminal.getPwd()` → snapshot `pwd` + dirty flag → `chuchu_poll_pwd_ptr` → `nativePollPwd` → `TerminalSessionEngine` → `state.pwd` — but nothing ever *set* it.

In the vendored ghostty, `report_pwd` is in the list of OSC actions the bundled terminal handler explicitly ignores (`src/terminal/stream_terminal.zig`):

```zig
.report_pwd,
.show_desktop_notification,
.progress_report,
.clipboard_contents,
.title_push,
.title_pop,
=> {},
```

So `setPwd` was never called and `getPwd()` always returned null. I only found this by turning on OSC 7 in a real shell and watching the browser still open at home.

Note `clipboard_contents` is in that same ignored list, and `ChuchuStreamHandler` already works around it by intercepting the action before delegating to `inner`. This PR does the same for `report_pwd`: parse the `file://host/path` URL, percent-decode it, and call `setPwd`.

The decoder is deliberately strict about remote input — `file://` scheme only, bounded at 4096 bytes, rejects anything that doesn't decode to an absolute path, and passes a `%` through unchanged when it isn't followed by two hex digits. It intentionally does **not** filter on the hostname: ghostty's desktop app ignores OSC 7 from a foreign host because a remote path is meaningless locally, but chuchu's terminal is always remote and that path is exactly what we want.

## Fallback is untouched

`pwd` only exists if the remote shell emits OSC 7, and plenty of default bash setups don't (tmux doesn't reliably forward it either). When it's absent the old path runs exactly as before: cached home, else resolve `.` then `~`.

## Verified on device

![the file browser opening at the session's working directory](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr101-browser-cwd.png)

Oppo Pad Mini, with `PROMPT_COMMAND='printf "\033]7;file://%s%s\a" "$HOSTNAME" "$PWD"'` in the remote shell:

- `cd /var/log` → open the browser → it opens at **`/var/log`** and lists the real contents (before: `/home/salem`)
- Back from there returns to the terminal in one press, rather than walking up `/var` → `/` first

That second point is why `resolvedHomePath` is also set on this path: it is not really "home", it is the path at which Back leaves the browser (`FileBrowserScreen.kt:67` and `:292`). Leaving it null made Back climb the whole tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal sessions now report their current working directory automatically.
  - The file browser opens directly to the terminal’s active directory when available.
  - Supports working-directory updates from compatible terminal applications, including URL-encoded paths.

- **Bug Fixes**
  - Improved initial file browser navigation by prioritizing the terminal’s current location over previously saved or remotely resolved paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->