### PR TITLE
fix: move the terminal cursor when the keyboard asks it to

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
@@ -226,11 +226,13 @@ class TerminalInputView(context: Context) : EditText(context) {
         val connectionId: Int = System.identityHashCode(this)
 
         private val maxImeBufferChars = 1024
+        private val maxImeCursorMoveSteps = 32
 
         private var batchEditDepth = 0
         private var outerBatchBeforeText: String? = null
         private var outerBatchHadDirectEmission = false
         private var directMutationDepth = 0
+        private var imeCaretAnchor: Int? = null
 
         override fun getEditable(): Editable = view.editableText
 
@@ -249,6 +251,7 @@ class TerminalInputView(context: Context) : EditText(context) {
         }
 
         private fun clearImeBuffer(restart: Boolean) {
+            imeCaretAnchor = null
             val editable = getEditable()
             BaseInputConnection.removeComposingSpans(editable)
             if (editable.isNotEmpty()) editable.clear()
@@ -316,6 +319,7 @@ class TerminalInputView(context: Context) : EditText(context) {
             }
 
             emitDiff(source, before, after)
+            imeCaretAnchor = null
 
             if (after.contains('\n') || after.contains('\r') || after.length > maxImeBufferChars) {
                 clearImeBuffer(restart = true)
@@ -354,6 +358,7 @@ class TerminalInputView(context: Context) : EditText(context) {
         // Clear the mirror and composing spans without emitting bytes, keeping
         // it empty between commits so a later delete can't over-emit backspaces.
         private fun clearMirrorSilently() {
+            imeCaretAnchor = null
             val editable = getEditable()
             BaseInputConnection.removeComposingSpans(editable)
             if (editable.isNotEmpty()) editable.clear()
@@ -384,6 +389,7 @@ class TerminalInputView(context: Context) : EditText(context) {
 
         override fun finishComposingText(): Boolean {
             logConn("finishComposingText")
+            imeCaretAnchor = null
             val ok = super.finishComposingText()
             // Composing region is committed; drop the mirror copy so a later
             // backspace can't mass-delete it.
@@ -398,7 +404,48 @@ class TerminalInputView(context: Context) : EditText(context) {
 
         override fun setSelection(start: Int, end: Int): Boolean {
             logConn("setSelection start=$start end=$end")
+            if (
+                start != end ||
+                BaseInputConnection.getComposingSpanStart(getEditable()) != -1 ||
+                directMutationDepth > 0
+            ) {
+                imeCaretAnchor = null
+                return super.setSelection(start, end)
+            }
+
+            val anchor = imeCaretAnchor
+            imeCaretAnchor = start
+            if (anchor != null) {
+                val delta = start.toLong() - anchor.toLong()
+                val steps = kotlin.math.abs(delta)
+                if (steps <= maxImeCursorMoveSteps) {
+                    emitImeCursorMove(
+                        if (delta < 0) KeyEvent.KEYCODE_DPAD_LEFT else KeyEvent.KEYCODE_DPAD_RIGHT,
+                        steps.toInt(),
+                    )
+                }
+            }
             return super.setSelection(start, end)
+        }
+
+        private fun emitImeCursorMove(keyCode: Int, steps: Int) {
+            val mapped = KeyMapper.map(keyCode, 0, 0) ?: return
+            repeat(steps) {
+                view.onTerminalKey?.invoke(
+                    mapped.key,
+                    mapped.codepoint,
+                    mapped.mods,
+                    GhosttyKeyAction.Press,
+                    mapped.charCode,
+                )
+                view.onTerminalKey?.invoke(
+                    mapped.key,
+                    mapped.codepoint,
+                    mapped.mods,
+                    GhosttyKeyAction.Release,
+                    mapped.charCode,
+                )
+            }
         }
 
         override fun getExtractedText(request: ExtractedTextRequest?, flags: Int): ExtractedText {
@@ -418,6 +465,7 @@ class TerminalInputView(context: Context) : EditText(context) {
         }
 
         override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+            imeCaretAnchor = null
             val before = getEditable().toString()
             val ok = super.deleteSurroundingText(beforeLength, afterLength)
             val after = getEditable().toString()

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
@@ -94,11 +94,13 @@ class TerminalInputView(context: Context) : EditText(context) {
 
     private fun emitTerminalText(source: String, text: String) {
         logInput("emit source=$source text=${describeText(text)}")
+        activeInputConnection?.clearImeCaretAnchor()
         onTerminalText?.invoke(text)
     }
 
     private fun emitBackspaceText(source: String) {
         logInput("emit source=$source text=<BS>")
+        activeInputConnection?.clearImeCaretAnchor()
         onTerminalText?.invoke("\u007f")
     }
 
@@ -238,6 +240,10 @@ class TerminalInputView(context: Context) : EditText(context) {
 
         private fun logConn(message: String) {
             view.logInput("conn=$connectionId $message")
+        }
+
+        fun clearImeCaretAnchor() {
+            imeCaretAnchor = null
         }
 
         fun armSuppression() {

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
@@ -420,15 +420,22 @@ class TerminalInputView(context: Context) : EditText(context) {
             }
 
             val anchor = imeCaretAnchor
-            imeCaretAnchor = start
-            if (anchor != null) {
+            if (anchor == null) {
+                imeCaretAnchor = start
+            } else {
                 val delta = start.toLong() - anchor.toLong()
                 val steps = kotlin.math.abs(delta)
                 if (steps <= maxImeCursorMoveSteps) {
+                    imeCaretAnchor = start
                     emitImeCursorMove(
                         if (delta < 0) KeyEvent.KEYCODE_DPAD_LEFT else KeyEvent.KEYCODE_DPAD_RIGHT,
                         steps.toInt(),
                     )
+                } else {
+                    // Past the cap the two models have diverged. Emit nothing and
+                    // drop the anchor, so the next selection re-anchors instead of
+                    // diffing against a position the terminal never reached.
+                    imeCaretAnchor = null
                 }
             }
             return super.setSelection(start, end)


### PR DESCRIPTION
Fixes the cursor-movement half of #60.

## What happens

Sliding along the space bar to move the cursor does nothing in the terminal. @Aijokey's video shows it working in Termux and not here.

## Why

The gesture *does* reach us. With the input logging in `TerminalInputView` turned on, dragging right-to-left across the space bar at a bash prompt produces:

```
setSelection start=7 end=7
setSelection start=5 end=5
setSelection start=3 end=3
setSelection start=1 end=1
setSelection start=0 end=0
```

But `TerminalInputConnection.setSelection` was just:

```kotlin
override fun setSelection(start: Int, end: Int): Boolean {
    return super.setSelection(start, end)
}
```

which moves a caret inside the IME mirror — deliberately kept **empty** — and sends nothing to the terminal. So the remote cursor never moves.

## The change

Translate the caret movement the IME asks for into Left/Right key presses.

The IME's positions are relative to **its own** model, not to our mirror — note it opens the drag at `7` while the mirror is empty — so the first `setSelection` of a gesture only establishes an anchor and emits nothing; subsequent ones emit the delta. The anchor is dropped whenever text changes (commit, delete, composing, mirror clear), so a later gesture can't diff against a stale position.

Details worth knowing:

- Only plain caret moves are translated. A range selection, an active composing region, or being inside our own text mutation resets the anchor and emits nothing — movement that accompanies a text change is already carried by that change.
- Keys go through `KeyMapper` + `onTerminalKey` rather than raw escape bytes, so ghostty encodes them and **application cursor key mode is honoured**.
- A single call is capped at 32 steps. A larger jump means our model and the IME's have diverged, and firing a hundred arrow keys at a remote shell is worse than doing nothing.

## Verified on device

Oppo Pad Mini, Gboard, bash prompt:

- typed `echo ABCDEFGH`, dragged left across the space bar, then typed `X` → line became **`echo AXBCDEFGH`** with the cursor on `B`. Before the fix the cursor stayed pinned at the end and `X` appended. Pressing Enter echoed `AXBCDEFGH`, so the remote line really was edited mid-string.
- dragging right produces increasing positions (`5→7→9→11→13→15`) and moves the cursor back the other way.

## Not fixed here: the backspace-key drag

#60 also mentions the delete-key drag. That one needs a different fix and I've left it out deliberately. During that gesture Gboard issues only `beginBatchEdit` / `endBatchEdit` / `finishComposingText` and **never calls `deleteSurroundingText`** — it sees an empty buffer and concludes there's nothing to delete. Making it work means giving the IME real text context from the terminal line, which is a much larger change (and would likely also affect suggestions and autocorrect). Happy to look at that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor movement handling when editing terminal input with an IME.
  * Added more reliable synchronization between text selection and terminal navigation.
  * Reset cursor tracking appropriately after text changes, composition completion, and deletions.
  * Improved handling of large cursor movements by re-establishing position tracking when needed.
  * Prevented unnecessary cursor movement when an initial text selection is established.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->