### PR TITLE
fix: confirm before disconnecting every session on a host

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/ServerList/ServerListScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/ServerList/ServerListScreen.kt
@@ -54,6 +54,7 @@ import com.jossephus.chuchu.service.terminal.TerminalSessionRepository
 import com.jossephus.chuchu.ui.components.ChuButton
 import com.jossephus.chuchu.ui.components.ChuButtonVariant
 import com.jossephus.chuchu.ui.components.ChuCard
+import com.jossephus.chuchu.ui.components.ChuDialog
 import com.jossephus.chuchu.ui.components.ChuText
 import com.jossephus.chuchu.ui.components.TuiBadge
 import com.jossephus.chuchu.ui.theme.ChuColors
@@ -81,6 +82,7 @@ fun ServerListScreen(
     val hasOpenLocalShell = openTabs.any { it.spec.transport == Transport.LocalShell }
 
     var selectedHostId by remember { mutableStateOf<Long?>(null) }
+    var pendingDisconnectHostId by remember { mutableStateOf<Long?>(null) }
     var pendingConnectHostId by remember { mutableStateOf<Long?>(null) }
     var pendingLocalShell by remember { mutableStateOf(false) }
     val notificationPermissionLauncher = rememberLauncherForActivityResult(
@@ -200,13 +202,7 @@ fun ServerListScreen(
                                 }
                             },
                             onDisconnect = {
-                                selectedHostId = null
-                                openTabs
-                                    .asSequence()
-                                    .filter { it.spec.hostId == host.id }
-                                    .map { it.id }
-                                    .toList()
-                                    .forEach(sessionRepo::closeTab)
+                                pendingDisconnectHostId = host.id
                             },
                         )
                     }
@@ -227,6 +223,33 @@ fun ServerListScreen(
             ChuText("+ add server", style = typography.label, color = colors.onAccent)
         }
 
+        val pendingDisconnectHost = hosts.firstOrNull { it.id == pendingDisconnectHostId }
+        if (pendingDisconnectHost != null) {
+            val sessionCount = openTabs.count { it.spec.hostId == pendingDisconnectHost.id }
+            ChuDialog(
+                title = "Disconnect ${pendingDisconnectHost.name}?",
+                confirmLabel = "Disconnect",
+                dismissLabel = "Cancel",
+                onConfirm = {
+                    selectedHostId = null
+                    openTabs
+                        .asSequence()
+                        .filter { it.spec.hostId == pendingDisconnectHost.id }
+                        .map { it.id }
+                        .toList()
+                        .forEach(sessionRepo::closeTab)
+                    pendingDisconnectHostId = null
+                },
+                onDismiss = { pendingDisconnectHostId = null },
+            ) {
+                val sessionLabel = if (sessionCount == 1) "session" else "sessions"
+                ChuText(
+                    "This closes $sessionCount $sessionLabel on this host.",
+                    style = typography.body,
+                    color = colors.warning,
+                )
+            }
+        }
     }
 }
 
@@ -425,7 +448,9 @@ private fun HostCard(
                             onDragEnd = {
                                 if (swipeOffsetX.value <= -disconnectThresholdPx) {
                                     onDisconnect()
-                                    scope.launch { swipeOffsetX.snapTo(0f) }
+                                    scope.launch {
+                                        swipeOffsetX.animateTo(0f, animationSpec = tween(140))
+                                    }
                                 } else {
                                     scope.launch {
                                         swipeOffsetX.animateTo(0f, animationSpec = tween(140))


### PR DESCRIPTION
## What happens

On the server list, a connected host's primary button reads `[ disconnect ]` and sits in **exactly the position `[ connect ]` occupies on every other card**. Tapping it immediately closed every session on that host — no confirmation, no undo:

```kotlin
onDisconnect = {
    selectedHostId = null
    openTabs.asSequence()
        .filter { it.spec.hostId == host.id }
        .map { it.id }.toList()
        .forEach(sessionRepo::closeTab)
}
```

The realistic failure isn't misreading the label — it's muscle memory. You go to open a session on a host you're already using, tap where connect always is, and destroy the several you had. On a non-multiplexer host that shell state is simply gone.

I measured the positions on device to be sure it wasn't just a hunch: on the connected card `[ disconnect ]` sits at x=405, and on the card below it `[ connect ]` sits at x=379 — the same slot, ~26px apart.

## The change

Ask first, from both entry points (the button and the swipe-to-disconnect gesture), using the existing `ChuDialog`. The dialog names the host and says how many sessions are about to close. Dismissing does nothing and lets the swiped card settle back.

The button is deliberately left where it is — moving a destructive action out of the connect slot is a design call for you to make, not something to slip into a safety fix.

## Verified on device

![the disconnect confirmation dialog](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr103-disconnect-confirm.png)

- tapping `[ disconnect ]` on a host with one live session → `Disconnect zz-dogfood?` / `This closes 1 session on this host.`, and the SSH connection is **still up** at that point (checked server-side with `ss`)
- **Cancel** → connection still up
- **Disconnect** → connection gone, confirmed server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before disconnecting a server, showing the host name and number of sessions that will be closed.
  * Confirmed disconnections now close the server’s open sessions and clear related selections.

* **Bug Fixes**
  * Cancelling a disconnection keeps the server connected.
  * Improved the swipe reset animation with a smoother transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->