### PR TITLE
fix: print host key fingerprints without base64 padding

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/ssh/HostKeyStore.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/ssh/HostKeyStore.kt
@@ -44,7 +44,7 @@ class HostKeyStore(
 
     private fun fingerprintSha256(keyBytes: ByteArray): String {
         val digest = MessageDigest.getInstance("SHA-256").digest(keyBytes)
-        val encoded = Base64.encodeToString(digest, Base64.NO_WRAP)
+        val encoded = Base64.encodeToString(digest, Base64.NO_WRAP or Base64.NO_PADDING)
         return "SHA256:$encoded"
     }
 }


### PR DESCRIPTION
## What happens

`HostKeyStore.fingerprintSha256` encodes with `Base64.NO_WRAP`, which keeps padding, so chuchu shows a trailing `=` that OpenSSH does not:

```
chuchu       SHA256:m2Ahfnz/BA5KqnyY1kV/+T6gU3AhMagxS8CvojNojac=
ssh-keygen   SHA256:m2Ahfnz/BA5KqnyY1kV/+T6gU3AhMagxS8CvojNojac
```

A SHA-256 digest is 32 bytes, which base64 always encodes as 43 characters plus one `=`, so this differed for **every** key, not some.

It's a small thing with an outsized effect on the one screen where it appears. The host key dialog asks the user to compare a fingerprint against one they got from the server and make a trust decision. A character that never matches teaches people that a mismatch is normal and can be ignored — the exact instinct host key verification depends on.

## The change

```diff
-val encoded = Base64.encodeToString(digest, Base64.NO_WRAP)
+val encoded = Base64.encodeToString(digest, Base64.NO_WRAP or Base64.NO_PADDING)
```

## Why it's safe

`fingerprintSha256` has three call sites in total — its definition, and `previousFingerprint` / `fingerprint` in `TerminalSessionEngine`, both computed fresh from key bytes. The fingerprint **string is never persisted and never compared against a stored string**; trust decisions compare raw key bytes through `HostKeyStore`. Both sides of any comparison come from the same function, so no stored host key is invalidated and no trust outcome changes. Presentation only.

## Verified on device

![the host key fingerprint without base64 padding](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr104-fingerprint.png)

Cleared the stored host keys, reconnected to trigger the prompt, and read the dialog:

```
Host: 100.72.23.13:22
Algorithm: ECDSA
New: SHA256:m2Ahfnz/BA5KqnyY1kV/+T6gU3AhMagxS8CvojNojac
```

and `ssh-keyscan`/`ssh-keygen -lf` against the same host:

```
256 SHA256:m2Ahfnz/BA5KqnyY1kV/+T6gU3AhMagxS8CvojNojac 100.72.23.13 (ECDSA)
```

Character for character identical, 43 characters, no padding. Accepting the key still stores and trusts it as before.

No test: `HostKeyStore` uses `android.util.Base64`, which isn't available in plain JVM unit tests, and this didn't seem worth adding Robolectric for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SSH host key fingerprints to use the standard unpadded SHA-256 format, improving compatibility with fingerprint displays and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->