### PR TITLE
fix: title the edit screen correctly and stop save from moving

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/AddServer/AddServerScreen.kt
@@ -71,7 +71,7 @@ fun AddServerScreen(
     ) {
         Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
             ChuText("$ ", style = typography.headline, color = colors.textMuted)
-            ChuText("add server", style = typography.headline)
+            ChuText(if (form.id != null) "edit server" else "add server", style = typography.headline)
         }
 
         SectionHeader("CONNECTION")
@@ -273,19 +273,20 @@ fun AddServerScreen(
             modifier = Modifier.fillMaxWidth(),
         ) {
             val label = when (testState.status) {
+                ConnectionTestStatus.Idle -> "test connection"
                 ConnectionTestStatus.Running -> "testing…"
-                else -> "test connection"
+                ConnectionTestStatus.Success -> "connected"
+                ConnectionTestStatus.Error -> "test failed"
             }
             ChuText(label, style = typography.label)
         }
-        if (testState.message != null) {
+        if (testState.status == ConnectionTestStatus.Error && testState.message != null) {
             ChuText(
                 testState.message ?: "",
                 style = typography.bodySmall,
-                color = if (testState.status == ConnectionTestStatus.Error) colors.error else colors.success,
+                color = colors.error,
             )
         }
-
         ChuButton(
             onClick = { vm.save(onBack) },
             enabled = form.canSave(),


### PR DESCRIPTION
Two small things on the add/edit host screen.

## 1. Editing a host was titled "add server"

`[ edit ]` opened a screen headed `$ add server` with every field already filled in. The screen has the form, and `AddServerForm.id` is null when adding and set when editing — `AddServerViewModel.save` already relies on exactly that distinction — so it can just say which one it's doing.

## 2. `[ save ]` moved out from under your finger

The connection test result was drawn **between** `[ test connection ]` and `[ save ]`, so finishing a test pushed save down by about a row — at precisely the moment the flow ("tap test, wait, tap save") has the user reaching for it. A failed test produces a longer, wrapping message and a bigger jump.

My first attempt moved the message below `[ save ]`. On device that turned out worse: `[ save ]` sits at the very bottom of the screen (centre y=1665 on a 1680px display), so the message ended up **entirely off-screen** and a test appeared to do nothing at all unless you scrolled. Trading "save moves" for "no feedback" isn't a fix.

What's here instead: the outcome goes in the test button itself, which already switched its own label for `testing…` —

- `Idle` → `test connection`
- `Running` → `testing…`
- `Success` → `connected`
- `Error` → `test failed`

— and the detailed message stays in its original place but renders **only on failure**.

So the common case (test succeeds, user taps save next) adds no element at all: save never moves, and the result is visible immediately in the button that was just tapped. On failure the message does still push save down, but there the user isn't reaching for save — they're going back to fix a field, and the detail needs to stay on screen.

## Verified on device

- `[ edit ]` on an existing host → header reads **`edit server`**; adding a new one still reads `add server`
- ran a real connection test → button changed to **`connected`** and `[ save ]` stayed at y=1665, unmoved (measured before and after via `uiautomator`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx
