### PR TITLE
fix: stop the keyboard inserting spaces after dots in the terminal

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
@@ -207,9 +207,12 @@ class TerminalInputView(context: Context) : EditText(context) {
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or
             EditorInfo.IME_FLAG_NO_FULLSCREEN or
             EditorInfo.IME_ACTION_NONE
+        // URI variation stops IMEs applying prose conventions, such as auto-space
+        // after punctuation and suggestions, to shell input.
         outAttrs.inputType = android.text.InputType.TYPE_CLASS_TEXT or
             android.text.InputType.TYPE_TEXT_FLAG_MULTI_LINE or
-            android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS or
+            android.text.InputType.TYPE_TEXT_VARIATION_URI
         outAttrs.initialSelStart = selectionStart
         outAttrs.initialSelEnd = selectionEnd
 


### PR DESCRIPTION
## What happens

Typing `echo a.b test.sh` in the terminal arrives at the remote shell as:

```
echo a. b test. sh
```

The keyboard inserts a space after **every** period. The suggestion strip is active in the terminal too (it was offering `sh` / `she` / `should`), even though `TYPE_TEXT_FLAG_NO_SUGGESTIONS` is already set.

This hits most of what actually gets typed at a prompt — `./deploy.sh`, `1.2.3.4`, `foo.tar.gz`, `nginx.conf`. I found it by accident while typing a path during other testing, then reproduced it deliberately.

It's the terminal-side counterpart of the host/username field bug: the same IME behaviour, on the input path that never got the same treatment.

## Cause

`onCreateInputConnection` describes the terminal as ordinary multi-line prose:

```kotlin
outAttrs.inputType = TYPE_CLASS_TEXT or TYPE_TEXT_FLAG_MULTI_LINE or TYPE_TEXT_FLAG_NO_SUGGESTIONS
```

so the IME applies prose conventions to it. `NO_SUGGESTIONS` on its own does not stop the auto-space — it was already set while the bug was happening.

## The change

Add `TYPE_TEXT_VARIATION_URI`. One line, plus a comment saying why it's there.

## Why not the visible-password variation

`TYPE_TEXT_VARIATION_VISIBLE_PASSWORD` is the more commonly cited trick and it does also fix the auto-space — I tried it on device first. But it **disables voice input**: Gboard renders the microphone key crossed out. Since #67 is an open report about voice dictation in the terminal, that would trade one input bug for closing off another. The URI variation stops the auto-space and the suggestions with the microphone still enabled.

## Verified on device

Oppo Pad Mini, Gboard, typing the same string each time:

- **before:** `echo a. b test. sh`
- **with visible-password:** `echo a.b test.sh` — but microphone crossed out
- **with URI (this PR):** `echo a.b test.sh`, microphone still enabled, no suggestion strip

Side benefit visible on the keyboard: the key next to the globe becomes `/` instead of `,`, which is rather more useful at a shell prompt.

Also checked it composes with #102 (cursor drag) — with both applied, `a.b test.sh` types correctly *and* the space-bar drag still moves the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text input compatibility by identifying entered content as a URI.
  * Enhanced keyboard behavior for multiline terminal input while preserving suggestion suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->