### PR TITLE
fix: draw wide glyphs on the grid instead of by font advance

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -688,12 +688,14 @@ fun TerminalCanvas(
                     sb.setLength(0)
                     if (firstGlyph == null) sb.appendCodePoint(cp) else sb.append(firstGlyph)
                     val startCol = i - rowStart
-                    var j = i + 1
+                    val firstIsWide = i + 1 < rowEnd && snapshot.isSpacerContinuation(i + 1)
+                    var j = if (firstIsWide) i + 2 else i + 1
 
                     while (j < rowEnd) {
                         val c = snapshot.codepoints[j]
                         if (c == 0) break
                         if (c == 32 && !snapshot.isSpacerContinuation(j)) break
+                        if (j + 1 < rowEnd && snapshot.isSpacerContinuation(j + 1)) break
 
                         val jFlags = snapshot.flags[j].toInt()
                         val jSelected = hasSel && j in selStart..selEnd


### PR DESCRIPTION
## What happens

CJK text is drawn narrower than the cells it occupies, so everything after it on the line is dragged left. Any aligned output containing CJK is corrupted — tables, TUI layouts, box-drawn panels, `ls` in columns.

Four lines, each exactly **14 terminal cells** followed by `|`, so all four bars must land in one column:

```
AAAAAAAAAAAAAA|     14 ascii
日本語テキスト|       7 CJK   = 14 cells
😀😀😀😀😀😀😀|       7 emoji = 14 cells
──────────────|     14 box drawing
```

On device, ascii / emoji / box drawing align. The CJK line's `|` sat about **2.5 columns to the left**, taking the rest of the line with it.

Measured against a `....+....1....+....2` ruler by locating each trailing `|`'s pixel column and dividing by the cell width:

- ascii — expected column 12, measured **12.1**
- box drawing — expected 13, measured **13.0**
- emoji — expected 15, measured **15.4**
- **CJK — expected 15, measured 12.4**

The grid itself is right: ghostty allocates 2 cells per wide character (that's why the measured width is ~11.4 cells rather than 7). It's the drawing that compresses them, to roughly 1.6 cells each.

## Cause

In `TerminalCanvas.kt`, cells are batched into runs and each run is drawn with a single call:

```kotlin
nCanvas.drawText(sb.toString(), startCol * cellWidth, baseline, paint)
```

Only the run's **start** is placed on the grid — every glyph after it advances by the *font's* advance width, which the code implicitly assumes equals `cellWidth`. That holds for the primary monospace face (so ascii and box drawing are fine) and the emoji face happens to advance ~2 cells, so emoji look right by luck. It does not hold for the CJK fallback face.

The run already skips the spacer cell that follows a wide character, so a wide glyph contributes one character to the string while consuming two grid columns — and nothing pushes the next glyph back onto the correct column.

## The change

Give each wide glyph its own run, so it is drawn at exactly `col * cellWidth`. Single-width cells keep batching as before, which is what keeps this loop cheap — it runs for every frame.

A cell is wide when the next one is its spacer continuation, which `isSpacerContinuation` already tells us.

I deliberately did **not** scale glyphs to fill two cells. The defect is position, not size; where the fallback face draws narrower than two cells you now get a small gap between CJK glyphs, which is cosmetic and much better than the whole line being wrong. Making them fill the cell pair is a separate, larger change.

## Verified on device

![CJK alignment before and after](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr107-wide-glyph.png)

Same four lines after the fix: all four `|` land in one column, and the trailing annotations line up too. The CJK glyphs are now visibly spaced onto their 2-cell grid.

Also re-checked that ascii, box drawing and emoji are unchanged, and that vim and htop still render correctly (both are full of box drawing and colour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx