### PR TITLE
fix: let the tab manager be opened with a single tab

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
@@ -69,7 +69,7 @@ fun TerminalTabStrip(
     val colors = ChuColors.current
     val typography = ChuTypography.current
     val scrollState = rememberScrollState()
-    val trailingActionWidth = if (tabs.size > 1) 72.dp else 40.dp
+    val trailingActionWidth = if (tabs.isNotEmpty()) 72.dp else 40.dp
     val tabOffsets = remember { mutableStateMapOf<String, Int>() }
     val rowRootLeft = remember { mutableStateOf(0) }
 
@@ -146,7 +146,7 @@ fun TerminalTabStrip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            if (tabs.size > 1) {
+            if (tabs.isNotEmpty()) {
                 ChuButton(
                     onClick = onOpenManager,
                     modifier = Modifier.defaultMinSize(minHeight = 32.dp, minWidth = 32.dp),


### PR DESCRIPTION
## What happens

With a single tab open there is **no way to reach the tab manager**. The button that opens it is gated on a second tab existing:

```kotlin
if (tabs.size > 1) {
    ChuButton(onClick = onOpenManager, … contentDescription = "all tabs") {
        ChuText(if (tabs.size > 99) "≡" else "${tabs.size}", …)
    }
}
```

That's worse than a missing shortcut, because the manager is also the only home of the **multiplexer session list** — the `multiplexer sessions` section with its `[attach]` buttons. So with one tab open on a tmux host you cannot list the sessions running there, and cannot attach to any of them.

A user hit this and worked it out the hard way: duplicate a tab so the counter appears, *then* open the manager. Which is a strange thing to have to discover.

## The change

Show the button whenever there is a tab to manage. The count simply reads `1` with one tab.

`trailingActionWidth` was gated on the same condition — it reserves horizontal space for these controls, so it needed the same treatment or the button would render into space sized for a narrower control and clip the tab labels.

Nothing else changes: same styling, same ghost variant, same `≡` fallback past 99 tabs, same `+` behaviour.

## Verified on device

Connected a single tmux host and the strip now shows `1` next to `+`, opening the manager and its multiplexer session list directly — previously it showed only `+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The terminal tab manager action now appears whenever at least one terminal tab is open, making tab management consistently accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->