### PR TITLE
fix: guard the multiplexer duplicate and show it is working

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -1300,6 +1300,13 @@ fun TerminalScreen(
                                             color = colors.error,
                                         )
                                     }
+                                    if (multiplexerState.duplicateLoading) {
+                                        ChuText(
+                                            text = "Preparing new multiplexer session...",
+                                            style = typography.labelSmall,
+                                            color = colors.textMuted,
+                                        )
+                                    }
                                     if (pwdText != null) {
                                         ChuText(
                                             text = pwdText,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -68,6 +69,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     private var pendingMultiplexerAction: PendingMultiplexerAction? = null
     private var multiplexerActionGeneration = 0L
     private var multiplexerSessionListGeneration = 0L
+    private var multiplexerDuplicateInFlight = false
 
     private val _tailscaleActive = MutableStateFlow(tailscaleStatusChecker.isActive())
     val tailscaleActive: StateFlow<Boolean> = _tailscaleActive.asStateFlow()
@@ -174,24 +176,34 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     }
 
     private fun startMultiplexerDuplicate(spec: TabSpec) {
+        if (multiplexerDuplicateInFlight) return
+        multiplexerDuplicateInFlight = true
+        _multiplexerState.value = _multiplexerState.value.copy(duplicateLoading = true)
         val duplicateSpec = spec.copy(
             multiplexer = spec.multiplexer ?: MultiplexerRegistry.defaultType,
             multiplexerSessionName = null,
             multiplexerCreateIfMissing = true,
         )
         viewModelScope.launch(Dispatchers.IO) {
-            val result = runCatching { sessionRepository.resolveMultiplexerSessionName(duplicateSpec) }
-            withContext(Dispatchers.Main) {
-                result.fold(
-                    onSuccess = { name ->
-                        openTab(duplicateSpec.copy(multiplexerSessionName = name))
-                    },
-                    onFailure = { error ->
-                        _multiplexerState.value = _multiplexerState.value.copy(
-                            preflightError = error.message ?: "Could not create multiplexer session",
-                        )
-                    },
-                )
+            try {
+                val result = runCatching { sessionRepository.resolveMultiplexerSessionName(duplicateSpec) }
+                withContext(Dispatchers.Main) {
+                    result.fold(
+                        onSuccess = { name ->
+                            openTab(duplicateSpec.copy(multiplexerSessionName = name))
+                        },
+                        onFailure = { error ->
+                            _multiplexerState.value = _multiplexerState.value.copy(
+                                preflightError = error.message ?: "Could not create multiplexer session",
+                            )
+                        },
+                    )
+                }
+            } finally {
+                withContext(NonCancellable + Dispatchers.Main) {
+                    multiplexerDuplicateInFlight = false
+                    _multiplexerState.value = _multiplexerState.value.copy(duplicateLoading = false)
+                }
             }
         }
     }
@@ -749,6 +761,7 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
 
 data class MultiplexerUiState(
     val preflightError: String? = null,
+    val duplicateLoading: Boolean = false,
     val sessions: List<RemoteMultiplexerSession> = emptyList(),
     val sessionsLoading: Boolean = false,
     val sessionsError: String? = null,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalViewModel.kt
@@ -178,7 +178,11 @@ class TerminalViewModel(application: Application) : AndroidViewModel(application
     private fun startMultiplexerDuplicate(spec: TabSpec) {
         if (multiplexerDuplicateInFlight) return
         multiplexerDuplicateInFlight = true
-        _multiplexerState.value = _multiplexerState.value.copy(duplicateLoading = true)
+        _multiplexerState.value =
+            _multiplexerState.value.copy(
+                duplicateLoading = true,
+                preflightError = null,
+            )
         val duplicateSpec = spec.copy(
             multiplexer = spec.multiplexer ?: MultiplexerRegistry.defaultType,
             multiplexerSessionName = null,


### PR DESCRIPTION
## What happens

Reported by a user:

> "when i press on the plus sign nothing happens so i press again and suddenly i have two new tabs"

On a host using a multiplexer, `+` gives no feedback for several seconds, so people press it again — and get two tabs and two tmux sessions.

## Cause

```kotlin
fun duplicateActiveTab(): TabSession? {
    val current = sessionRepository.activeTab.value ?: return null
    if (current.spec.usesRuntimeMultiplexer) {
        startMultiplexerDuplicate(current.spec)   // returns before any tab exists
        return null
    }
    return openTab(current.spec)                  // non-multiplexer: immediate
}
```

Without a multiplexer, `openTab` creates the tab synchronously and the strip updates at once. With one, `startMultiplexerDuplicate` launches a coroutine that calls `resolveMultiplexerSessionName(...)` — a **full SSH preflight**: fresh connection, auth, and a remote `tmux` command — before `openTab` is finally reached. Meanwhile it sets state **only on failure**, and nothing stops a second press starting a second, independent preflight.

I measured it on device: **5.7 seconds** from tapping `+` to the new tmux session existing. That's a long time to stare at a button that looks dead.

The connect path doesn't suffer from this — `beginMultiplexerAction` already tracks a pending action and a loading flag. `startMultiplexerDuplicate` is a parallel path that never got the same treatment.

## The change

- **In-flight guard** so a second press is ignored while one duplicate is already running. `duplicateTab(tabId)` shares the same path and is covered by the same flag, which is correct.
- **`duplicateLoading`** on `MultiplexerUiState`, surfaced in `TerminalScreen` next to the existing `Reconnecting` indicator, so the button no longer looks dead.

The flag is cleared in a `finally` that runs under `NonCancellable + Dispatchers.Main`, so a cancelled or failed attempt can't leave it stuck — a leaked flag would wedge `+` permanently, which would be worse than the bug being fixed.

The non-multiplexer path stays synchronous and untouched.

## Verified on device

![the in-flight indicator while the preflight runs](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr109-duplicate-progress.png)

Oppo Pad Mini against a tmux host, counting sessions server-side:

- **single tap** → one new session after ~5.7 s, with `Preparing new multiplexer session...` shown throughout
- **two taps 0.6 s apart** → **one** new session (9 → 10). Before this change that produced two sessions and two tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status message while a terminal session is being duplicated.
  * Prevented duplicate requests from starting while another duplication is in progress.
  * Added loading feedback during session duplication.

* **Bug Fixes**
  * Improved failure handling and cleanup so duplication state resets correctly after errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->