### PR TITLE
feat: let "+" open a session on any host

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -71,12 +73,15 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.core.content.FileProvider
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jossephus.chuchu.data.repository.SettingsRepository
 import com.jossephus.chuchu.model.AuthMethod
+import com.jossephus.chuchu.model.HostProfile
 import com.jossephus.chuchu.model.Transport
 import com.jossephus.chuchu.service.terminal.SessionStatus
 import com.jossephus.chuchu.service.terminal.TabSpec
@@ -150,6 +155,85 @@ private fun TerminalViewModel.dispatchTextWithModifierState(
             onHardwareKey(ghosttyKey, codepoint, mods, GhosttyKeyAction.Release)
         } else {
             onTextInput(modifierState.applyToText(char.toString()))
+        }
+    }
+}
+
+@Composable
+private fun NewTabHostPicker(
+    currentHostName: String,
+    otherHosts: List<HostProfile>,
+    onCurrentHost: () -> Unit,
+    onHostSelected: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+    val density = LocalDensity.current
+
+    Popup(
+        alignment = Alignment.TopEnd,
+        offset = with(density) { IntOffset(0, 36.dp.roundToPx()) },
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Column(
+            modifier =
+                Modifier.width(320.dp)
+                    .background(colors.background)
+                    .border(1.dp, colors.border)
+                    .padding(4.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            ChuButton(
+                onClick = onCurrentHost,
+                modifier = Modifier.fillMaxWidth(),
+                variant = ChuButtonVariant.Ghost,
+                bracketed = true,
+                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+            ) {
+                ChuText(
+                    "new session on $currentHostName",
+                    style = typography.label,
+                    color = colors.textPrimary,
+                )
+            }
+
+            if (otherHosts.isNotEmpty()) {
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .height(1.dp)
+                            .background(colors.border),
+                )
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().weight(1f, fill = false),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    items(otherHosts, key = { it.id }) { host ->
+                        ChuButton(
+                            onClick = { onHostSelected(host.id) },
+                            modifier = Modifier.fillMaxWidth(),
+                            variant = ChuButtonVariant.Ghost,
+                            bracketed = true,
+                            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+                        ) {
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                                ChuText(
+                                    host.name,
+                                    style = typography.label,
+                                    color = colors.textPrimary,
+                                )
+                                ChuText(
+                                    "${host.username}@${host.host}:${host.port}",
+                                    style = typography.labelSmall,
+                                    color = colors.textMuted,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -297,6 +381,7 @@ fun TerminalScreen(
     openLocalShell: Boolean = false,
 ) {
     val sessionState by vm.sessionState.collectAsStateWithLifecycle()
+    val hosts by vm.hosts.collectAsStateWithLifecycle()
     val tabs by vm.tabs.collectAsStateWithLifecycle()
     val activeTabId by vm.activeTabId.collectAsStateWithLifecycle()
     val activeTab by vm.activeTab.collectAsStateWithLifecycle()
@@ -364,6 +449,7 @@ fun TerminalScreen(
     var passphraseFromPicker by remember { mutableStateOf(false) }
     var showTabSheet by remember { mutableStateOf(false) }
     var showGlobalTabManager by remember { mutableStateOf(false) }
+    var showNewTabPicker by remember { mutableStateOf(false) }
     var hasSeenTabsForHost by remember(hostId, openLocalShell) { mutableStateOf(false) }
     var focusedTabIndex by remember { mutableStateOf(0) }
     var localShellFilesMessage by remember { mutableStateOf<String?>(null) }
@@ -532,6 +618,36 @@ fun TerminalScreen(
 
         }
     }
+    val pickerCurrentHostId = activeTab?.spec?.hostId ?: hostId
+    val pickerCurrentHostName =
+        currentHostName ?: hosts.firstOrNull { it.id == pickerCurrentHostId }?.name ?: "current host"
+    val pickerOtherHosts =
+        remember(hosts, pickerCurrentHostId) { hosts.filter { it.id != pickerCurrentHostId } }
+    val openNewSessionForHost: (Long) -> Unit = { pickerHostId ->
+        pickerScope.launch(Dispatchers.IO) {
+            val prepared = vm.prepareTabOpenForHost(pickerHostId) ?: return@launch
+            withContext(Dispatchers.Main) {
+                openPreparedTab(prepared.spec, prepared.requiresVerification, false)
+            }
+        }
+    }
+    val newTabPicker: @Composable () -> Unit = {
+        if (showNewTabPicker) {
+            NewTabHostPicker(
+                currentHostName = pickerCurrentHostName,
+                otherHosts = pickerOtherHosts,
+                onCurrentHost = {
+                    showNewTabPicker = false
+                    openAnotherSessionForCurrentHost()
+                },
+                onHostSelected = { pickerHostId ->
+                    showNewTabPicker = false
+                    openNewSessionForHost(pickerHostId)
+                },
+                onDismiss = { showNewTabPicker = false },
+            )
+        }
+    }
 
     LaunchedEffect(hostId, openLocalShell) {
         showPassphrasePrompt = false
@@ -695,8 +811,9 @@ fun TerminalScreen(
                         tabs = tabs,
                         activeTabId = activeTabId,
                         onTabSelected = { id -> vm.selectTab(id) },
-                        onAddTab = openAnotherSessionForCurrentHost,
+                        onAddTab = { showNewTabPicker = true },
                         onOpenManager = { showGlobalTabManager = true },
+                        newTabPicker = newTabPicker,
                     )
                     Box(
                         modifier = Modifier.weight(1f).fillMaxWidth(),
@@ -779,8 +896,9 @@ fun TerminalScreen(
                         tabs = tabs,
                         activeTabId = activeTabId,
                         onTabSelected = { id -> vm.selectTab(id) },
-                        onAddTab = openAnotherSessionForCurrentHost,
+                        onAddTab = { showNewTabPicker = true },
                         onOpenManager = { showGlobalTabManager = true },
+                        newTabPicker = newTabPicker,
                     )
                     Box(
                         modifier = Modifier.weight(1f).fillMaxWidth(),
@@ -1096,10 +1214,11 @@ fun TerminalScreen(
                                 onTabSelected = { id ->
                                     vm.selectTab(id)
                                 },
-                                onAddTab = openAnotherSessionForCurrentHost,
+                                onAddTab = { showNewTabPicker = true },
                                 onOpenManager = {
                                     showGlobalTabManager = true
                                 },
+                                newTabPicker = newTabPicker,
                             )
                         }
 
@@ -1776,8 +1895,9 @@ fun TerminalScreen(
                             tabs = tabs,
                             activeTabId = activeTabId,
                             onTabSelected = { id -> vm.selectTab(id) },
-                            onAddTab = openAnotherSessionForCurrentHost,
+                            onAddTab = { showNewTabPicker = true },
                             onOpenManager = { showGlobalTabManager = true },
+                            newTabPicker = newTabPicker,
                         )
                         Box(
                             modifier = Modifier.weight(1f).fillMaxWidth(),

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalTabStrip.kt
@@ -64,6 +64,7 @@ fun TerminalTabStrip(
     onTabSelected: (String) -> Unit,
     onAddTab: () -> Unit,
     onOpenManager: () -> Unit,
+    newTabPicker: @Composable () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val colors = ChuColors.current
@@ -162,14 +163,17 @@ fun TerminalTabStrip(
                 }
             }
 
-            ChuButton(
-                onClick = onAddTab,
-                modifier = Modifier.defaultMinSize(minHeight = 32.dp, minWidth = 32.dp),
-                variant = ChuButtonVariant.Ghost,
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp),
-                contentDescription = "new connection",
-            ) {
-                ChuText("+", style = typography.label, color = colors.accent)
+            Box {
+                ChuButton(
+                    onClick = onAddTab,
+                    modifier = Modifier.defaultMinSize(minHeight = 32.dp, minWidth = 32.dp),
+                    variant = ChuButtonVariant.Ghost,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp),
+                    contentDescription = "new connection",
+                ) {
+                    ChuText("+", style = typography.label, color = colors.accent)
+                }
+                newTabPicker()
             }
         }
     }


### PR DESCRIPTION
## Why

`+` in the tab strip is wired to `openAnotherSessionForCurrentHost`, which calls `duplicateActiveTab()`. So it always opens another session on the host you are already on, and there is **no way to reach a different host from the terminal at all** — you have to navigate back to the server list. Meanwhile the button's own `contentDescription` is `"new connection"`, which promises rather more than it delivers.

A user hit this and described it as "i can't choose another host unless i duplicate first".

## What it does now

Tapping `+` opens a picker anchored under the button:

```
[ new session on zz-dogfood ]     <- current host, unchanged behaviour
  CachyOS      salemsayed@100.117.68.47:22
  Hetzner      salem@46.224.146.124:22
  Homeserver   salem@192.168.1.237:22
  …
```

- The **first row is the old behaviour** — it calls the same `openAnotherSessionForCurrentHost` lambda, so the common case costs one extra tap and still routes through the multiplexer duplicate path when the host uses one.
- Below it, the other saved hosts, each with `username@host:port` so similar names stay distinguishable. The active host is excluded, since the first row covers it.
- Dismissing does nothing.

## How

Almost all of this already existed:

- `TerminalViewModel` already exposes `val hosts: StateFlow<List<HostProfile>>`, so no new query or repository.
- Opening a chosen host reuses `prepareTabOpenForHost(hostId)` + `openPreparedTab(...)` — the same path the screen already had for the `activeTab == null` case, which was effectively unreachable. That means key passphrase prompts, biometric verification when the host or global setting requires it, and multiplexer opens all behave exactly as they do from the server list, with no new code.

The strip takes the picker as a composable slot rendered in a `Box` around the `+`, which is what anchors it to the button. Built with `Popup` + `Chu*` components, following the sort-dropdown pattern in `FileBrowserScreen` — no material3 (this project has no such dependency).

The list scrolls via `weight(1f, fill = false)` rather than a fixed `dp` cap, deliberately: a hard-coded `heightIn(max = 150.dp)` is what limited the multiplexer session panel to two visible rows of nine on a tablet.

All four `TerminalTabStrip` call sites are wired to the picker so `+` means the same thing in every layout. **The tab manager's `[ + new ]` is intentionally left as duplicate** — happy to make it consistent if you'd prefer.

## Verified on device

![the new-tab host picker](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr110-host-picker.png)

Oppo Pad Mini, connected to a tmux host:

- `+` opens the picker with `new session on zz-dogfood` first and the five other saved hosts below, current host excluded
- Choosing **Hetzner** (a different profile, reaching the same box over its public address rather than Tailscale) opened a second tab and connected — confirmed server-side: a new login appeared from the tablet's public IP at the moment of the tap, distinct from the existing Tailscale session
- The first row still duplicates the current host as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx