### PR TITLE
fix: stop tmux 3.7 mangling the session list separator

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/TmuxMultiplexer.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/multiplexer/TmuxMultiplexer.kt
@@ -11,7 +11,7 @@ object TmuxMultiplexer : Multiplexer {
 
     override fun listSessionsCommand(): String =
         "if ! command -v tmux >/dev/null 2>&1; then printf 'tmux executable not found\\n' >&2; false; " +
-            "else tmux list-sessions -F '#{session_name}\t#{session_attached}' 2>/dev/null; " +
+            "else tmux list-sessions -F '#{session_attached} #{session_name}' 2>/dev/null; " +
             "status=\$?; if [ \"\$status\" -eq 1 ]; then true; else [ \"\$status\" -eq 0 ]; fi; fi"
 
     override fun parseSessions(output: String): List<RemoteMultiplexerSession> =
@@ -20,11 +20,13 @@ object TmuxMultiplexer : Multiplexer {
             .mapNotNull { line ->
                 val trimmed = line.trimEnd('\r')
                 if (trimmed.isBlank()) return@mapNotNull null
-                val parts = trimmed.split('\t')
-                if (parts.isEmpty() || parts[0].isBlank()) return@mapNotNull null
+                val separatorIndex = trimmed.indexOf(' ')
+                if (separatorIndex == -1) return@mapNotNull null
+                val name = trimmed.substring(separatorIndex + 1)
+                if (name.isBlank()) return@mapNotNull null
                 RemoteMultiplexerSession(
-                    name = parts[0],
-                    attached = parts.getOrNull(1) == "1",
+                    name = name,
+                    attached = trimmed.substring(0, separatorIndex).toIntOrNull()?.let { it > 0 } == true,
                 )
             }
             .toList()

--- a/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/TmuxMultiplexerTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/service/multiplexer/TmuxMultiplexerTest.kt
@@ -79,21 +79,32 @@ class TmuxMultiplexerTest {
 
         assertEquals(
             "if ! command -v tmux >/dev/null 2>&1; then printf 'tmux executable not found\\n' >&2; false; " +
-                "else tmux list-sessions -F '#{session_name}\t#{session_attached}' 2>/dev/null; " +
+                "else tmux list-sessions -F '#{session_attached} #{session_name}' 2>/dev/null; " +
                 "status=\$?; if [ \"\$status\" -eq 1 ]; then true; else [ \"\$status\" -eq 0 ]; fi; fi",
             command,
         )
     }
 
     @Test
-    fun parsesSessionList() {
-        val sessions = TmuxMultiplexer.parseSessions("main\t1\nwork\t0\n")
+    fun parsesSessionListWithAttachedClientCountsAndNamesContainingSpaces() {
+        val sessions = TmuxMultiplexer.parseSessions("0 work\n1 main\n2 work space\n")
 
         assertEquals(
             listOf(
-                RemoteMultiplexerSession(name = "main", attached = true),
                 RemoteMultiplexerSession(name = "work", attached = false),
+                RemoteMultiplexerSession(name = "main", attached = true),
+                RemoteMultiplexerSession(name = "work space", attached = true),
             ),
+            sessions,
+        )
+    }
+
+    @Test
+    fun skipsMalformedSessionListLines() {
+        val sessions = TmuxMultiplexer.parseSessions("missing-separator\n1 \n")
+
+        assertEquals(
+            emptyList<RemoteMultiplexerSession>(),
             sessions,
         )
     }


### PR DESCRIPTION
## What happens

On a host running **tmux 3.7b**, every session in the multiplexer list fails to attach:

```
tmux session chuchu-1_0 is no longer available
```

The session is `chuchu-1`. That `_0` is the *attached* flag glued onto the name.

The session list itself looks fine at a glance, which is why this presents as "attach is broken" rather than "listing is broken" — the names are subtly wrong and every downstream operation uses them.

## Cause

`TmuxMultiplexer.listSessionsCommand()` separates its two fields with a literal tab inside the tmux format string (`\t` in a Kotlin literal is a real tab, so tmux receives a tab in `-F`):

```kotlin
"else tmux list-sessions -F '#{session_name}\t#{session_attached}' 2>/dev/null; "
```

**Newer tmux sanitises control characters in format output.** Same command, two hosts, through `cat -A`:

```
tmux 3.7b    chuchu-1_0$      <- tab replaced with "_"
older tmux   chuchu-1^I0$     <- real tab (^I)
```

So on 3.7 `split('\t')` finds nothing to split, the whole line becomes the session name, and `tmux has-session -t '=chuchu-1_0'` correctly reports that no such session exists.

## The change

Ask for the attached count **first**, separated by a space, and split on the first space only:

```
#{session_attached} #{session_name}
```

Identical output on both versions:

```
0 chuchu-1
0 chuchu-2
0 shellfish-1
```

Flag-first is deliberate: **tmux session names may contain spaces**, so the name has to be the trailing field. Splitting on the first space keeps such names intact. I avoided a printable separator like `|` or `:` for the same reason — a name could contain one and the bug returns in a new costume.

Also fixed while in there: `#{session_attached}` is a **count of attached clients**, not a boolean, so `== "1"` reported a session with two clients attached as detached. It now treats any positive count as attached, matching how `ZmxMultiplexer` already handles its `clients` field.

`ZmxMultiplexer` is untouched — its tabs come from `zmx list`'s own output rather than a format string we control, so it is unaffected.

## Verified on device

![tmux session name before and after](https://raw.githubusercontent.com/salemsayed/chuchu/pr-assets/pr111-tmux-names.png)

Against a real tmux 3.7b host, before and after:

- **before** — all three sessions failed with `tmux session chuchu-1_0 is no longer available`
- **after** — the panel lists `chuchu-1`, `chuchu-2`, `shellfish-1`, and attaching succeeds. Confirmed server-side: `tmux list-sessions` reports `1 chuchu-1`, i.e. a client is attached.

Unit tests added for `parseSessions` covering attached counts of 0/1/2, a session name containing spaces, and malformed lines being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497S7hY6iFKVi89wzSg5Mx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux session detection by accurately identifying attached sessions.
  * Session names containing spaces are now handled correctly.
  * Malformed or unnamed session entries are safely ignored.

* **Tests**
  * Added coverage for attached-client counts, spaced session names, and invalid session-list entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->