### PR TITLE
feat: keep theme picker dropdown open on selection

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/ThemeSelectorSection.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/ThemeSelectorSection.kt
@@ -16,10 +16,13 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -157,6 +160,22 @@ private fun SingleThemePicker(
         if (query.isEmpty()) themeByName.keys.toList() else themeByName.keys.filter { it.contains(query, ignoreCase = true) }
     }
     var showPreview by rememberSaveable { mutableStateOf(false) }
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(expanded) {
+        if (expanded && themeQuery.isBlank()) {
+            val index = filteredThemes.indexOf(currentTheme)
+            if (index >= 0) {
+                listState.scrollToItem(index)
+            }
+        }
+    }
+
+    LaunchedEffect(themeQuery) {
+        if (themeQuery.isNotBlank()) {
+            listState.scrollToItem(0)
+        }
+    }
 
     val previewTheme = remember(currentTheme, themeByName) { themeByName[currentTheme] }
 
@@ -189,8 +208,9 @@ private fun SingleThemePicker(
                 onQueryChange = { themeQuery = it },
                 filteredThemes = filteredThemes,
                 currentTheme = currentTheme,
-                onThemeSelected = { onThemeSelected(it); expanded = false },
+                onThemeSelected = onThemeSelected,
                 themeByName = themeByName,
+                listState = listState,
             )
         }
     }
@@ -230,6 +250,7 @@ private fun ThemePickerDropdown(
     currentTheme: String,
     onThemeSelected: (String) -> Unit,
     themeByName: Map<String, GhosttyTheme?>,
+    listState: LazyListState = rememberLazyListState(),
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ChuTextField(
@@ -242,6 +263,7 @@ private fun ThemePickerDropdown(
         )
 
         LazyColumn(
+            state = listState,
             verticalArrangement = Arrangement.spacedBy(2.dp),
             modifier = Modifier.fillMaxWidth().heightIn(max = 480.dp),
         ) {


### PR DESCRIPTION
Closes #114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Theme selection menus now automatically scroll to the currently selected theme when opened.
  - Searching for themes resets the list to the top for easier navigation.
  - The dropdown remains open after selecting a theme, allowing users to make additional selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->