### PR TITLE
feat: handle different cursor styles

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/service/terminal/TerminalSnapshot.kt
@@ -27,6 +27,7 @@ data class TerminalSnapshot(
     val cursorX: Int,
     val cursorY: Int,
     val cursorVisible: Boolean,
+    val cursorStyle: Int = CURSOR_STYLE_BLOCK,
     val defaultBgArgb: Int,
     val defaultFgArgb: Int,
     val codepoints: IntArray,
@@ -61,6 +62,7 @@ data class TerminalSnapshot(
         return cols == other.cols && rows == other.rows &&
             cursorX == other.cursorX && cursorY == other.cursorY &&
             cursorVisible == other.cursorVisible &&
+            cursorStyle == other.cursorStyle &&
             defaultBgArgb == other.defaultBgArgb &&
             defaultFgArgb == other.defaultFgArgb &&
             codepoints.contentEquals(other.codepoints) &&
@@ -79,6 +81,7 @@ data class TerminalSnapshot(
         result = 31 * result + cursorX
         result = 31 * result + cursorY
         result = 31 * result + cursorVisible.hashCode()
+        result = 31 * result + cursorStyle
         result = 31 * result + defaultBgArgb
         result = 31 * result + defaultFgArgb
         result = 31 * result + codepoints.contentHashCode()
@@ -103,7 +106,11 @@ data class TerminalSnapshot(
         const val CELL_FLAG_INVERSE: Int = 0x08
         const val CELL_FLAG_BLINK: Int = 0x10
         const val CELL_FLAG_FAINT: Int = 0x20
-        private const val HEADER_I32_COUNT = 14
+        const val CURSOR_STYLE_BLOCK: Int = 0
+        const val CURSOR_STYLE_BAR: Int = 1
+        const val CURSOR_STYLE_UNDERLINE: Int = 2
+        const val CURSOR_STYLE_BLOCK_HOLLOW: Int = 3
+        private const val HEADER_I32_COUNT = 15
         private const val CELL_SIZE_BYTES = 11
         private const val IMAGE_HEADER_BYTES = 52
 
@@ -143,6 +150,7 @@ data class TerminalSnapshot(
             val extrasOffset = wrapped.int
             val viewportScrollY = wrapped.int
             val appHandlesSelectionDrag = wrapped.int == 1
+            val cursorStyle = wrapped.int
 
             val cellCount = cols * rows
             val expectedSize = (HEADER_I32_COUNT * 4) + (cellCount * CELL_SIZE_BYTES)
@@ -221,6 +229,7 @@ data class TerminalSnapshot(
                 cursorX = cursorX,
                 cursorY = cursorY,
                 cursorVisible = cursorVisible,
+                cursorStyle = cursorStyle,
                 defaultBgArgb = packArgb(defaultBgR, defaultBgG, defaultBgB),
                 defaultFgArgb = packArgb(defaultFgR, defaultFgG, defaultFgB),
                 codepoints = codepoints,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalCanvas.kt
@@ -781,16 +781,56 @@ fun TerminalCanvas(
                 val cursorLeft = snapshot.cursorX * cellWidth
                 val cursorTop = snapshot.cursorY * cellHeight
                 cursorPaint.color = cursorColorArgb
-                nCanvas.drawRect(
-                    cursorLeft,
-                    cursorTop,
-                    cursorLeft + cellWidth,
-                    cursorTop + cellHeight,
-                    cursorPaint,
-                )
+                when (snapshot.cursorStyle) {
+                    TerminalSnapshot.CURSOR_STYLE_BAR -> {
+                        val barWidth = (cellWidth * CURSOR_BAR_FRACTION).coerceAtLeast(1f)
+                        nCanvas.drawRect(
+                            cursorLeft,
+                            cursorTop,
+                            cursorLeft + barWidth,
+                            cursorTop + cellHeight,
+                            cursorPaint,
+                        )
+                    }
+                    TerminalSnapshot.CURSOR_STYLE_UNDERLINE -> {
+                        val underlineHeight = (cellHeight * CURSOR_UNDERLINE_FRACTION).coerceAtLeast(1f)
+                        nCanvas.drawRect(
+                            cursorLeft,
+                            cursorTop + cellHeight - underlineHeight,
+                            cursorLeft + cellWidth,
+                            cursorTop + cellHeight,
+                            cursorPaint,
+                        )
+                    }
+                    TerminalSnapshot.CURSOR_STYLE_BLOCK_HOLLOW -> {
+                        val stroke = (cellWidth * CURSOR_BAR_FRACTION).coerceAtLeast(1f)
+                        cursorPaint.style = Paint.Style.STROKE
+                        cursorPaint.strokeWidth = stroke
+                        val inset = stroke / 2f
+                        nCanvas.drawRect(
+                            cursorLeft + inset,
+                            cursorTop + inset,
+                            cursorLeft + cellWidth - inset,
+                            cursorTop + cellHeight - inset,
+                            cursorPaint,
+                        )
+                        cursorPaint.style = Paint.Style.FILL
+                    }
+                    else -> {
+                        nCanvas.drawRect(
+                            cursorLeft,
+                            cursorTop,
+                            cursorLeft + cellWidth,
+                            cursorTop + cellHeight,
+                            cursorPaint,
+                        )
+                    }
+                }
 
                 val cursorIndex = snapshot.cursorY * cols + snapshot.cursorX
-                if (cursorTextColorArgb != null && cursorIndex in snapshot.codepoints.indices) {
+                if (snapshot.cursorStyle == TerminalSnapshot.CURSOR_STYLE_BLOCK &&
+                    cursorTextColorArgb != null && cursorIndex in snapshot.codepoints.indices
+                ) {
                     val codepoint = snapshot.codepoints[cursorIndex]
                     if (codepoint != 0 && codepoint != 32) {
                         val extras = snapshot.graphemeExtras[cursorIndex]
@@ -917,6 +957,9 @@ internal fun TerminalSnapshot.glyphAt(cellIndex: Int): String {
 }
 
 private const val FAINT_TEXT_ALPHA: Int = 96
+
+private const val CURSOR_BAR_FRACTION: Float = 0.15f
+private const val CURSOR_UNDERLINE_FRACTION: Float = 0.15f
 
 private const val TEXT_STYLE_MASK: Int =
     TerminalSnapshot.CELL_FLAG_BOLD or

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/EmojiSnapshotRegressionTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/EmojiSnapshotRegressionTest.kt
@@ -15,7 +15,7 @@ class EmojiSnapshotRegressionTest {
         val cols = 4
         val rows = 1
         val cellCount = cols * rows
-        val headerBytes = 14 * 4
+        val headerBytes = 15 * 4
         val gridBytes = cellCount * 11
         val extrasOffset = headerBytes + gridBytes
 
@@ -40,6 +40,7 @@ class EmojiSnapshotRegressionTest {
         raw.putInt(extrasOffset)
         raw.putInt(0) // viewport_scroll_y
         raw.putInt(0) // app_handles_selection_drag
+        raw.putInt(TerminalSnapshot.CURSOR_STYLE_BLOCK) // cursor_style
 
         fun putCell(codepoint: Int, flags: Int) {
             raw.putInt(codepoint)
@@ -77,7 +78,7 @@ class EmojiSnapshotRegressionTest {
     fun parsesAppSelectionDragFlagFromSnapshotHeader() {
         val cols = 1
         val rows = 1
-        val headerBytes = 14 * 4
+        val headerBytes = 15 * 4
         val gridBytes = cols * rows * 11
         val raw = ByteBuffer.allocate(headerBytes + gridBytes).order(ByteOrder.LITTLE_ENDIAN)
 
@@ -95,6 +96,7 @@ class EmojiSnapshotRegressionTest {
         raw.putInt(0)
         raw.putInt(0)
         raw.putInt(1)
+        raw.putInt(TerminalSnapshot.CURSOR_STYLE_BAR) // cursor_style
 
         raw.putInt('a'.code)
         raw.put(255.toByte())
@@ -109,6 +111,7 @@ class EmojiSnapshotRegressionTest {
         val snapshot = TerminalSnapshot.fromByteBuffer(raw)
 
         assertTrue(snapshot.appHandlesSelectionDrag)
+        assertEquals(TerminalSnapshot.CURSOR_STYLE_BAR, snapshot.cursorStyle)
     }
 
     @Test
@@ -174,7 +177,7 @@ class EmojiSnapshotRegressionTest {
         val cols = 3
         val rows = 1
         val cellCount = cols * rows
-        val headerBytes = 14 * 4
+        val headerBytes = 15 * 4
         val gridBytes = cellCount * 11
         val extrasOffset = headerBytes + gridBytes
 
@@ -203,6 +206,7 @@ class EmojiSnapshotRegressionTest {
         raw.putInt(extrasOffset)
         raw.putInt(0) // viewport_scroll_y
         raw.putInt(0) // app_handles_selection_drag
+        raw.putInt(TerminalSnapshot.CURSOR_STYLE_BLOCK) // cursor_style
 
         fun putCell(codepoint: Int, flags: Int) {
             raw.putInt(codepoint)

--- a/zig-src/src/bridge/chuchu_snapshot.zig
+++ b/zig-src/src/bridge/chuchu_snapshot.zig
@@ -33,7 +33,9 @@ const verbose_snapshot_perf_logs = false;
 //      long-press drag gestures to the app instead of starting a client-side
 //      grid selection. This is what lets tmux/zellij perform their own
 //      pane-scoped selection.)
-const SNAPSHOT_HEADER_I32_COUNT = 14;
+//  14  cursor_style (the visual shape the app requested via DECSCUSR:
+//      0 = block, 1 = bar, 2 = underline, 3 = block_hollow)
+const SNAPSHOT_HEADER_I32_COUNT = 15;
 const SNAPSHOT_CELL_SIZE_BYTES = 11;
 // Flag bit set on a cell whose codepoint has additional grapheme codepoints
 // in the extras section.
@@ -907,6 +909,13 @@ export fn chuchu_build_text_snapshot(handle: c.jlong, out_size: [*c]usize) callc
     // its own long-press selection behavior.
     const app_handles_selection_drag: i32 = if (appHandlesSelectionDrag(terminal.terminal.flags.mouse_event)) 1 else 0;
     writeIntLe(i32, buffer[0..base_total_size], 52, app_handles_selection_drag);
+    const cursor_style: i32 = switch (terminal.render_state.cursor.visual_style) {
+        .block => 0,
+        .bar => 1,
+        .underline => 2,
+        .block_hollow => 3,
+    };
+    writeIntLe(i32, buffer[0..base_total_size], 56, cursor_style);
 
     terminal.snapshot_extras_scratch.clearRetainingCapacity();
     var extras_records: usize = 0;


### PR DESCRIPTION
Closes #113 

https://github.com/user-attachments/assets/06a36fd2-5fb4-4385-bb10-219c68126823


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



## Summary by CodeRabbit

- **New Features**
  - Terminal cursors now support multiple visual styles: block, vertical bar, underline, and hollow block.
  - Cursor appearance is preserved across terminal updates for consistent rendering.
  - Block cursors continue to display the character beneath them using the cursor text color, while alternative styles use their respective shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->