### PR TITLE
feat: add terminal autocorrect setting

### DIFF
--- a/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/data/repository/SettingsRepository.kt
@@ -59,6 +59,9 @@ class SettingsRepository(context: Context) {
     private val _hideScreenContents = MutableStateFlow(prefs.getBoolean(KEY_HIDE_SCREEN_CONTENTS, false))
     val hideScreenContents: StateFlow<Boolean> = _hideScreenContents.asStateFlow()
 
+    private val _disableAutocorrect = MutableStateFlow(prefs.getBoolean(KEY_DISABLE_AUTOCORRECT, false))
+    val disableAutocorrect: StateFlow<Boolean> = _disableAutocorrect.asStateFlow()
+
     private val _terminalTabMode = MutableStateFlow(
         parseTabMode(prefs.getString(KEY_TAB_MODE, TerminalTabMode.Classic.name)),
     )
@@ -147,6 +150,11 @@ class SettingsRepository(context: Context) {
         _hideScreenContents.value = enabled
     }
 
+    fun setDisableAutocorrect(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_DISABLE_AUTOCORRECT, enabled).apply()
+        _disableAutocorrect.value = enabled
+    }
+
     fun setThemeMode(mode: ThemeMode) {
         prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
         _themeMode.value = mode
@@ -211,6 +219,7 @@ class SettingsRepository(context: Context) {
         private const val KEY_LOCAL_SHELL_ENABLED = "local_shell_enabled"
         private const val KEY_KEEP_SCREEN_AWAKE = "keep_screen_awake"
         private const val KEY_HIDE_SCREEN_CONTENTS = "hide_screen_contents"
+        private const val KEY_DISABLE_AUTOCORRECT = "disable_autocorrect"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_LIGHT_THEME = "light_theme_name"
         private const val KEY_TERMINAL_FONT_SIZE = "terminal_font_size_sp"

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/ApplicationNavController.kt
@@ -136,6 +136,7 @@ fun ApplicationNavController() {
             val localShellEnabled by settingsRepo.localShellEnabled.collectAsStateWithLifecycle()
             val keepScreenAwake by settingsRepo.keepScreenAwake.collectAsStateWithLifecycle()
             val hideScreenContents by settingsRepo.hideScreenContents.collectAsStateWithLifecycle()
+            val disableAutocorrect by settingsRepo.disableAutocorrect.collectAsStateWithLifecycle()
             val themeMode by settingsRepo.themeMode.collectAsStateWithLifecycle()
             val terminalFontSize by settingsRepo.terminalFontSize.collectAsStateWithLifecycle()
             val lightThemeName by settingsRepo.lightThemeName.collectAsStateWithLifecycle()
@@ -147,6 +148,7 @@ fun ApplicationNavController() {
                 localShellEnabled = localShellEnabled,
                 keepScreenAwake = keepScreenAwake,
                 hideScreenContents = hideScreenContents,
+                disableAutocorrect = disableAutocorrect,
                 currentAccessoryLayoutIds = accessoryLayoutIds,
                 accessoryBarSingleRow = accessoryBarSingleRow,
                 currentTerminalCustomKeyGroups = customKeyGroups,
@@ -167,6 +169,7 @@ fun ApplicationNavController() {
                 onLocalShellEnabledChanged = settingsRepo::setLocalShellEnabled,
                 onKeepScreenAwakeChanged = settingsRepo::setKeepScreenAwake,
                 onHideScreenContentsChanged = settingsRepo::setHideScreenContents,
+                onDisableAutocorrectChanged = settingsRepo::setDisableAutocorrect,
                 onAccessoryLayoutChanged = settingsRepo::setAccessoryLayoutIds,
                 onAccessoryBarSingleRowChanged = settingsRepo::setAccessoryBarSingleRow,
                 currentTerminalFontSize = terminalFontSize,

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ fun SettingsScreen(
     localShellEnabled: Boolean,
     keepScreenAwake: Boolean,
     hideScreenContents: Boolean,
+    disableAutocorrect: Boolean,
     currentAccessoryLayoutIds: List<String>,
     accessoryBarSingleRow: Boolean,
     currentTerminalCustomKeyGroups: List<TerminalCustomKeyGroup>,
@@ -71,6 +72,7 @@ fun SettingsScreen(
     onLocalShellEnabledChanged: (Boolean) -> Unit,
     onKeepScreenAwakeChanged: (Boolean) -> Unit,
     onHideScreenContentsChanged: (Boolean) -> Unit,
+    onDisableAutocorrectChanged: (Boolean) -> Unit,
     onAccessoryLayoutChanged: (List<String>) -> Unit,
     onAccessoryBarSingleRowChanged: (Boolean) -> Unit,
     currentTerminalFontSize: Float = 14f,
@@ -198,6 +200,8 @@ fun SettingsScreen(
                             onKeepScreenAwakeChanged = onKeepScreenAwakeChanged,
                             hideScreenContents = hideScreenContents,
                             onHideScreenContentsChanged = onHideScreenContentsChanged,
+                            disableAutocorrect = disableAutocorrect,
+                            onDisableAutocorrectChanged = onDisableAutocorrectChanged,
                         )
                     SettingsCategory.Keys -> KeysContent(vm = keysViewModel)
                 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Settings/TerminalAccessorySettings.kt
@@ -97,6 +97,8 @@ internal fun TerminalSettings(
     onKeepScreenAwakeChanged: (Boolean) -> Unit = {},
     hideScreenContents: Boolean = false,
     onHideScreenContentsChanged: (Boolean) -> Unit = {},
+    disableAutocorrect: Boolean = false,
+    onDisableAutocorrectChanged: (Boolean) -> Unit = {},
 ) {
     val colors = ChuColors.current
     val typography = ChuTypography.current
@@ -543,6 +545,48 @@ internal fun TerminalSettings(
                     onCheckedChange = onHideScreenContentsChanged,
                 )
             }
+        }
+
+        DisableAutocorrectSetting(
+            checked = disableAutocorrect,
+            onCheckedChange = onDisableAutocorrectChanged,
+        )
+    }
+}
+
+@Composable
+private fun DisableAutocorrectSetting(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val colors = ChuColors.current
+    val typography = ChuTypography.current
+
+    ChuCard(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = 48.dp)
+                    .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                ChuText("disable autocorrect", style = typography.label)
+                ChuText(
+                    "for keyboards that ignore the standard hint; may disable glide typing",
+                    style = typography.bodySmall,
+                    color = colors.textMuted,
+                )
+            }
+            ChuSwitch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/screens/Terminal/TerminalScreen.kt
@@ -338,6 +338,7 @@ fun TerminalScreen(
         settingsRepo.terminalCustomKeyGroups.collectAsStateWithLifecycle()
     val settingsFontSize by settingsRepo.terminalFontSize.collectAsStateWithLifecycle()
     val keepScreenAwake by settingsRepo.keepScreenAwake.collectAsStateWithLifecycle()
+    val disableAutocorrect by settingsRepo.disableAutocorrect.collectAsStateWithLifecycle()
     val keepAwakeView = LocalView.current
     DisposableEffect(keepScreenAwake, keepAwakeView) {
         val window = (keepAwakeView.context as? Activity)?.window
@@ -1538,6 +1539,7 @@ fun TerminalScreen(
                                         if (inputViewRef.value == null) {
                                             inputViewRef.value = view
                                         }
+                                        view.disableAutocorrect = disableAutocorrect
                                     },
                                 )
 

--- a/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
+++ b/android/app/src/main/java/com/jossephus/chuchu/ui/terminal/TerminalInputView.kt
@@ -3,6 +3,7 @@ package com.jossephus.chuchu.ui.terminal
 import android.content.Context
 import android.os.SystemClock
 import android.text.Editable
+import android.text.InputType
 import android.text.Selection
 import android.util.Log
 import android.view.KeyEvent
@@ -13,6 +14,15 @@ import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+
+fun terminalImeInputType(disableAutocorrect: Boolean): Int {
+    // TYPE_NULL matches Termux's default and prevents keyboards from treating terminal input as prose.
+    if (disableAutocorrect) return InputType.TYPE_NULL
+
+    return InputType.TYPE_CLASS_TEXT or
+        InputType.TYPE_TEXT_FLAG_MULTI_LINE or
+        InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+}
 
 class TerminalInputView(context: Context) : EditText(context) {
 
@@ -48,6 +58,14 @@ class TerminalInputView(context: Context) : EditText(context) {
 
     /** Cached InputMethodManager for IME restarts. */
     private var inputMethodManager: InputMethodManager? = null
+
+    var disableAutocorrect = false
+        set(value) {
+            if (field == value) return
+            field = value
+            inputType = terminalImeInputType(value)
+            inputMethodManager?.restartInput(this)
+        }
 
     private fun logInput(message: String) {
         if (!DEBUG_INPUT_LOGS) return
@@ -145,9 +163,7 @@ class TerminalInputView(context: Context) : EditText(context) {
         imeOptions =
             EditorInfo.IME_FLAG_NO_EXTRACT_UI or
                 EditorInfo.IME_ACTION_NONE
-        inputType = android.text.InputType.TYPE_CLASS_TEXT or
-            android.text.InputType.TYPE_TEXT_FLAG_MULTI_LINE or
-            android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+        inputType = terminalImeInputType(disableAutocorrect)
     }
 
     override fun onCheckIsTextEditor(): Boolean = true
@@ -207,9 +223,7 @@ class TerminalInputView(context: Context) : EditText(context) {
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or
             EditorInfo.IME_FLAG_NO_FULLSCREEN or
             EditorInfo.IME_ACTION_NONE
-        outAttrs.inputType = android.text.InputType.TYPE_CLASS_TEXT or
-            android.text.InputType.TYPE_TEXT_FLAG_MULTI_LINE or
-            android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+        outAttrs.inputType = terminalImeInputType(disableAutocorrect)
         outAttrs.initialSelStart = selectionStart
         outAttrs.initialSelEnd = selectionEnd
 

--- a/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/TerminalImeInputTypeTest.kt
+++ b/android/app/src/test/java/com/jossephus/chuchu/ui/terminal/TerminalImeInputTypeTest.kt
@@ -1,0 +1,17 @@
+package com.jossephus.chuchu.ui.terminal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TerminalImeInputTypeTest {
+
+    @Test
+    fun `resolves normal terminal input type when autocorrect is enabled`() {
+        assertEquals(0xA0001, terminalImeInputType(disableAutocorrect = false))
+    }
+
+    @Test
+    fun `uses null input type when autocorrect is disabled`() {
+        assertEquals(0x0, terminalImeInputType(disableAutocorrect = true))
+    }
+}


### PR DESCRIPTION
## What happens

Android keyboards can treat terminal commands as prose even though Chuchu already requests no suggestions. That can capitalize the first character or rewrite tokens such as paths, flags, and command names before they reach a live shell.

## The change

Add an opt-in `disable autocorrect` toggle to the Terminal settings section. When enabled, the terminal reports `TYPE_NULL`, matching Termux's default input behavior, and restarts the active input connection immediately. Turning it off restores the existing text, multiline, and no-suggestions flags. The preference is global, defaults off, persists across launches, and does not alter the terminal's IME mirror, suppression window, or diff-emission logic.

The setting warns that glide typing may be unavailable. Its input-type resolver is shared by the view and every new input connection, with a plain JUnit test pinning `0xA0001` while disabled and `0x0` while enabled.

## Verified on device

Pixel 10 with Microsoft SwiftKey:

- the keyboard opens lowercase and does not autocorrect terminal input
- Enter, backspace, and accessory keys behave normally
- emoji and voice input remain available
- glide typing is unavailable, matching the settings warning

## Testing

- `:app:testDebugUnitTest` — 108 tests passed
- `:app:assembleDebug` — successful arm64 debug APK build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to disable autocorrect for terminal input.
  * The preference is saved and retained between sessions.
  * Terminal input updates immediately when the setting changes.

* **Tests**
  * Added coverage for terminal input behavior with autocorrect enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->